### PR TITLE
Add decimal-precision arithmetic operators and ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,232 @@
+# Architecture
+
+This document describes the internal architecture of **Associative-Dependent Logic (ADL)**, a minimal probabilistic logic framework built on [LiNo (Links Notation)](https://github.com/linksplatform/protocols-lino).
+
+## Project Structure
+
+```
+.
+├── ARCHITECTURE.md          # This file
+├── README.md                # Project overview, syntax, and examples
+├── LICENSE                  # Unlicense (public domain)
+├── js/                      # JavaScript implementation
+│   ├── package.json
+│   ├── src/
+│   │   └── adl-links.mjs   # Core implementation (~370 lines)
+│   ├── test/
+│   │   └── adl-links.test.mjs  # 93 tests
+│   ├── demo.lino
+│   ├── flipped-axioms.lino
+│   └── examples/
+│       ├── liar-paradox.lino
+│       ├── liar-paradox-balanced.lino
+│       └── ternary-kleene.lino
+└── rust/                    # Rust implementation
+    ├── Cargo.toml
+    ├── Cargo.lock
+    ├── src/
+    │   ├── lib.rs           # Core implementation + 93 tests (~2000 lines)
+    │   └── main.rs          # CLI entry point (~25 lines)
+    ├── demo.lino
+    ├── flipped-axioms.lino
+    └── examples/
+        ├── liar-paradox.lino
+        ├── liar-paradox-balanced.lino
+        └── ternary-kleene.lino
+```
+
+Both implementations are equivalent: they pass the same 93 tests and produce identical results for all inputs.
+
+## Processing Pipeline
+
+The evaluation pipeline has four stages:
+
+```
+LiNo text → Parse → AST → Evaluate → Results
+```
+
+### Stage 1: LiNo Parsing
+
+**Input:** Raw text in LiNo (Links Notation) format.
+
+**Output:** A list of link strings, where each link is a top-level parenthesized expression.
+
+- **JavaScript:** Uses the official [`@linksplatform/protocols-lino`](https://www.npmjs.com/package/@linksplatform/protocols-lino) parser.
+- **Rust:** Uses a built-in minimal parser (`parse_lino`) with no external dependencies.
+
+Lines starting with `#` are treated as comments and skipped.
+
+### Stage 2: Tokenization and AST Construction
+
+Each link string goes through two sub-steps:
+
+1. **Tokenize** (`tokenize_one` / `tokenizeOne`): Splits a link string into tokens (parentheses and words). Also strips inline comments (everything after `#`) and balances parentheses after stripping.
+
+2. **Parse** (`parse_one` / `parseOne`): Converts the token list into an AST (Abstract Syntax Tree). The AST is a recursive structure:
+   - **Leaf nodes:** Strings (symbols, numbers, operators).
+   - **List nodes:** Ordered sequences of child nodes, corresponding to parenthesized groups.
+
+There is no operator precedence; all grouping is explicit via parentheses. For example, `(0.1 + 0.2)` is parsed as a 3-element list `["0.1", "+", "0.2"]`, and `((0.1 + 0.2) = 0.3)` is parsed as `[["0.1", "+", "0.2"], "=", "0.3"]`.
+
+### Stage 3: Evaluation
+
+Each AST node is evaluated recursively by `eval_node` / `evalNode`. The evaluation depends on the node structure:
+
+| Pattern | Meaning | Example |
+|---------|---------|---------|
+| `"0.5"` (numeric leaf) | Numeric literal, clamped to logic range | `0.5` |
+| `"x"` (symbol leaf) | Symbol prior probability (default: midpoint) | `x` |
+| `(head: rhs...)` | Definition form | `(a: a is a)` |
+| `((expr) has probability p)` | Probability assignment | `((a = a) has probability 1)` |
+| `(range: lo hi)` | Range configuration | `(range: -1 1)` |
+| `(valence: N)` | Valence configuration | `(valence: 3)` |
+| `(? expr)` | Query — returns evaluated truth value | `(? (a = a))` |
+| `(A + B)`, `(A - B)`, `(A * B)`, `(A / B)` | Arithmetic (decimal-precision) | `(0.1 + 0.2)` |
+| `(A and B)`, `(A or B)` | Logical conjunction/disjunction | `(a and b)` |
+| `(A = B)`, `(A != B)` | Equality/inequality | `(a = b)` |
+| `(not X)` | Prefix negation | `(not 0.5)` |
+| `(op X Y ...)` | Prefix operator application | `(and X Y Z)` |
+
+### Stage 4: Output
+
+Only query expressions `(? ...)` produce output. Their evaluated truth values are collected and returned as an array of numbers.
+
+## Environment (`Env`)
+
+The environment holds all mutable state during evaluation:
+
+- **`terms`**: Set of declared term names (e.g., `a` from `(a: a is a)`).
+- **`assign`**: Map from expression keys to assigned truth values.
+- **`symbol_prob`**: Map from symbol names to prior probabilities.
+- **`lo`, `hi`**: Truth value range bounds. Default: `[0, 1]`.
+- **`valence`**: Number of discrete truth levels. Default: `0` (continuous).
+- **`ops`**: Map from operator names to operator implementations.
+
+### Clamping and Quantization
+
+All logical results are **clamped** to the range `[lo, hi]` and optionally **quantized** to the nearest discrete level (if `valence >= 2`).
+
+**Quantization algorithm:**
+```
+step = (hi - lo) / (valence - 1)
+level = round((x - lo) / step)
+result = lo + clamp(level, 0, valence-1) * step
+```
+
+This maps continuous values to the nearest of N evenly-spaced levels in the range.
+
+## Decimal-Precision Arithmetic
+
+### The Problem
+
+IEEE-754 floating-point arithmetic produces unexpected results for some decimal operations:
+```
+0.1 + 0.2 = 0.30000000000000004  (not 0.3)
+0.3 - 0.1 = 0.19999999999999998  (not 0.2)
+```
+
+### The Solution
+
+All arithmetic operations (`+`, `-`, `*`, `/`) use a **decimal-precision rounding** function that rounds results to 12 significant decimal places. This eliminates floating-point artefacts while preserving meaningful precision:
+
+```
+decRound(x) = round(x * 10^12) / 10^12
+```
+
+**JavaScript implementation:**
+```javascript
+const DECIMAL_PRECISION = 12;
+function decRound(x) {
+  if (!Number.isFinite(x)) return x;
+  return +(Math.round(x + 'e' + DECIMAL_PRECISION) + 'e-' + DECIMAL_PRECISION);
+}
+```
+
+**Rust implementation:**
+```rust
+const DECIMAL_PRECISION: i32 = 12;
+pub fn dec_round(x: f64) -> f64 {
+    if !x.is_finite() { return x; }
+    let factor = 10f64.powi(DECIMAL_PRECISION);
+    (x * factor).round() / factor
+}
+```
+
+### Arithmetic Context
+
+Arithmetic operators evaluate their operands in an **arithmetic context** where numeric literals are **not** clamped to the logic range. This allows expressions like `(2 + 3)` to correctly compute `5`, even though the logic range is `[0, 1]`. Clamping only occurs when the result is used in a logical context (queries, `and`, `or`, etc.).
+
+### Numeric Equality
+
+The `=` operator uses a three-tier comparison:
+
+1. **Explicit assignment:** If a probability has been explicitly assigned to the expression (e.g., `((a = b) has probability 0.5)`), use that value.
+2. **Structural equality:** If the left and right AST subtrees are structurally identical, return `hi` (true).
+3. **Numeric comparison:** Evaluate both sides and compare with decimal-precision rounding: `decRound(left) == decRound(right)`.
+
+This ensures that `((0.1 + 0.2) = 0.3)` evaluates to `1` (true).
+
+## Operators
+
+### Default Operators
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `not` | Unary | `hi - (x - lo)` | Negation: mirrors around midpoint |
+| `and` | N-ary | `avg` | Conjunction (aggregator-based) |
+| `or` | N-ary | `max` | Disjunction (aggregator-based) |
+| `=` | Binary | Structural/numeric | Equality |
+| `!=` | Binary | `not(=(...))` | Inequality |
+| `+` | Binary | `decRound(a + b)` | Addition (decimal-precision) |
+| `-` | Binary | `decRound(a - b)` | Subtraction (decimal-precision) |
+| `*` | Binary | `decRound(a * b)` | Multiplication (decimal-precision) |
+| `/` | Binary | `decRound(a / b)` | Division (decimal-precision, 0 on div-by-zero) |
+
+### Aggregators
+
+The `and` and `or` operators can be configured to use different aggregation functions:
+
+| Name | Formula | Use Case |
+|------|---------|----------|
+| `avg` | `sum(xs) / len(xs)` | Default for `and`; average truth value |
+| `min` | `min(xs)` | Kleene AND; pessimistic conjunction |
+| `max` | `max(xs)` | Default for `or`; Kleene OR |
+| `prod` | `∏ xs` | Probabilistic AND (independent events) |
+| `ps` | `1 - ∏(1 - xi)` | Probabilistic sum/OR (independent events) |
+
+Operators are redefinable at runtime via LiNo syntax:
+```lino
+(and: min)       # Switch AND to use minimum
+(!=: not =)      # Define != as composition of not and =
+```
+
+## Key Design Decisions
+
+1. **No operator precedence:** All grouping is explicit via parentheses. This keeps the parser minimal and unambiguous.
+
+2. **Decimal rounding over arbitrary precision:** Using 12-digit decimal rounding instead of arbitrary-precision decimal libraries. This is sufficient for logic/probability use cases and keeps both implementations dependency-free (Rust has zero external dependencies; JavaScript uses only the LiNo parser).
+
+3. **Arithmetic is unclamped:** Arithmetic results are not restricted to the logic range `[lo, hi]`. Clamping only happens when results enter the logical domain (queries, logical operators). This allows natural arithmetic while preserving logic semantics.
+
+4. **Equivalent dual implementations:** JavaScript and Rust implementations are kept in sync with identical test suites (93 tests each), ensuring behavioral equivalence.
+
+5. **Redefinable operators:** All operators can be redefined at runtime, enabling exploration of different logical semantics within the same framework.
+
+## Testing
+
+Both implementations share 93 identical tests organized in these categories:
+
+- **Tokenization** (4 tests): Simple/nested links, inline comments, paren balancing
+- **Parsing** (3 tests): Simple/nested/deeply nested AST construction
+- **Environment** (6 tests): Default ops, custom ops, expression probabilities, range/valence config
+- **Evaluation** (10 tests): Literals, definitions, redefinitions, operators, queries
+- **Quantization** (11 tests): Binary, ternary, 5-level, balanced ranges
+- **Logic types** (35+ tests): Unary through continuous, both ranges
+- **Liar paradox** (6 tests): Resolution across logic types and ranges
+- **Decimal arithmetic** (15 tests): Precision, all four operators, equality comparison, nested expressions, edge cases
+
+Run tests:
+```bash
+cd js && npm test       # JavaScript
+cd rust && cargo test   # Rust
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/7
-Your prepared branch: issue-7-b39bc0ce6481
-Your prepared working directory: /tmp/gh-issue-solver-1770042976758
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/7
+Your prepared branch: issue-7-b39bc0ce6481
+Your prepared working directory: /tmp/gh-issue-solver-1770042976758
+
+Proceed.

--- a/js/README.md
+++ b/js/README.md
@@ -45,7 +45,7 @@ npm run demo
 ## API
 
 ```javascript
-import { run, tokenizeOne, parseOne, Env, evalNode, quantize } from './src/adl-links.mjs';
+import { run, tokenizeOne, parseOne, Env, evalNode, quantize, decRound } from './src/adl-links.mjs';
 
 // Run a complete LiNo knowledge base
 const results = run(linoText);
@@ -68,12 +68,13 @@ const q = quantize(0.4, 3, 0, 1); // -> 0.5 (nearest ternary level)
 npm test
 ```
 
-The test suite includes 78 tests covering:
+The test suite includes 93 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
+- Decimal-precision arithmetic and numeric equality
 
 ## Dependencies
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "associative-dependent-logic",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Unlicense",
       "dependencies": {
         "@linksplatform/protocols-lino": "^0.7.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/adl-links.mjs",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "associative-dependent-logic"
-version = "0.3.0"
+version = "0.4.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "associative-dependent-logic"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/README.md
+++ b/rust/README.md
@@ -45,7 +45,7 @@ Or after building:
 ## API
 
 ```rust
-use adl::{run, tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize};
+use adl::{run, tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round};
 
 // Run a complete LiNo knowledge base
 let results = run(lino_text, None);
@@ -69,12 +69,13 @@ let q = quantize(0.4, 3, 0.0, 1.0); // -> 0.5 (nearest ternary level)
 cargo test
 ```
 
-The test suite includes 78 tests covering:
+The test suite includes 93 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
+- Decimal-precision arithmetic and numeric equality
 
 ## Implementation Notes
 


### PR DESCRIPTION
## Summary

Adds decimal-precision arithmetic operators (`+`, `-`, `*`, `/`) to both JavaScript and Rust implementations, ensuring that floating-point artefacts are eliminated. For example, `0.1 + 0.2 = 0.3` (not `0.30000000000000004`).

- **Decimal rounding:** All arithmetic uses 12-digit decimal-precision rounding (`decRound`/`dec_round`) to eliminate IEEE-754 floating-point artefacts
- **Arithmetic context:** Numeric operands in arithmetic expressions are not clamped to the logic range, allowing natural computation; clamping occurs only in logical context (queries, `and`, `or`)
- **Numeric equality fallback:** The `=` operator now falls back to numeric comparison (with decimal precision) when there is no explicit probability assignment or structural match — so `((0.1 + 0.2) = 0.3)` evaluates to `1` (true)
- **ARCHITECTURE.md:** Comprehensive documentation of the processing pipeline, decimal arithmetic implementation, operator system, and design decisions
- **Tests:** 15 new tests per implementation (93 total, up from 78), covering all four arithmetic operators, decimal precision, equality comparison, nested expressions, and edge cases
- **Version bump:** 0.3.0 → 0.4.0

### Key test cases from the issue
```lino
(? (0.1 + 0.2))              # → 0.3 ✓
(? ((0.1 + 0.2) = 0.3))      # → 1 (true) ✓
(? ((0.3 - 0.1) = 0.2))      # → 1 (true) ✓
```

## Test plan
- [x] All 93 JavaScript tests pass (`npm test`)
- [x] All 93 Rust tests pass (`cargo test`)
- [x] Existing 78 tests unchanged and passing
- [x] New decimal arithmetic tests verify precision for `+`, `-`, `*`, `/`
- [x] Numeric equality tests verify `((0.1 + 0.2) = 0.3)` → true
- [x] Edge cases: division by zero, non-finite values, nested arithmetic

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)