### PR TITLE
Use links-notation as dependency for both JavaScript and Rust

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes the internal architecture of **Associative-Dependent Logic (ADL)**, a minimal probabilistic logic framework built on [LiNo (Links Notation)](https://github.com/linksplatform/protocols-lino).
+This document describes the internal architecture of **Associative-Dependent Logic (ADL)**, a minimal probabilistic logic framework built on [LiNo (Links Notation)](https://github.com/link-foundation/links-notation).
 
 ## Project Structure
 
@@ -51,8 +51,8 @@ LiNo text → Parse → AST → Evaluate → Results
 
 **Output:** A list of link strings, where each link is a top-level parenthesized expression.
 
-- **JavaScript:** Uses the official [`@linksplatform/protocols-lino`](https://www.npmjs.com/package/@linksplatform/protocols-lino) parser.
-- **Rust:** Uses a built-in minimal parser (`parse_lino`) with no external dependencies.
+- **JavaScript:** Uses the official [`links-notation`](https://www.npmjs.com/package/links-notation) parser.
+- **Rust:** Uses the official [`links-notation`](https://crates.io/crates/links-notation) crate.
 
 Lines starting with `#` are treated as comments and skipped.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/9
-Your prepared branch: issue-9-835a7e89ada9
-Your prepared working directory: /tmp/gh-issue-solver-1770043976322
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/9
+Your prepared branch: issue-9-835a7e89ada9
+Your prepared working directory: /tmp/gh-issue-solver-1770043976322
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A prototype for logic framework that can reason about anything relative to given
 
 This project provides two equivalent implementations:
 
-- **[JavaScript](./js/)** — Node.js implementation using the official [LiNo parser](https://github.com/linksplatform/protocols-lino)
-- **[Rust](./rust/)** — Rust implementation with a built-in LiNo parser (no external dependencies)
+- **[JavaScript](./js/)** — Node.js implementation using the official [links-notation](https://github.com/link-foundation/links-notation) parser
+- **[Rust](./rust/)** — Rust implementation using the official [links-notation](https://github.com/link-foundation/links-notation) crate
 
 Both implementations pass the same 93 tests and produce identical results.
 
@@ -15,7 +15,7 @@ For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
 ## Overview
 
-ADL (Associative-Dependent Logic) is a minimal probabilistic logic system built on top of [LiNo (Links Notation)](https://github.com/linksplatform/protocols-lino). It supports [many-valued logics](https://en.wikipedia.org/wiki/Many-valued_logic) from unary (1-valued) through continuous probabilistic ([fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic)), allowing you to:
+ADL (Associative-Dependent Logic) is a minimal probabilistic logic system built on top of [LiNo (Links Notation)](https://github.com/link-foundation/links-notation). It supports [many-valued logics](https://en.wikipedia.org/wiki/Many-valued_logic) from unary (1-valued) through continuous probabilistic ([fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic)), allowing you to:
 
 - Define terms
 - Assign probabilities (truth values) to logical expressions

--- a/js/README.md
+++ b/js/README.md
@@ -78,7 +78,7 @@ The test suite includes 93 tests covering:
 
 ## Dependencies
 
-- [`@linksplatform/protocols-lino`](https://github.com/linksplatform/protocols-lino) — official LiNo parser
+- [`links-notation`](https://github.com/link-foundation/links-notation) — official LiNo parser
 
 ## License
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "associative-dependent-logic",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Unlicense",
       "dependencies": {
-        "@linksplatform/protocols-lino": "^0.7.0"
+        "links-notation": "^0.13.0"
       },
       "devDependencies": {},
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@linksplatform/protocols-lino": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@linksplatform/protocols-lino/-/protocols-lino-0.7.0.tgz",
-      "integrity": "sha512-81a5QgACH2fRHE1iifc95UvXR4WhVno0xGIW+IgLUVBAAds1zoAvITBgAnwuMFXNvLT9j3GliamxYOQrXFyiOw==",
+    "node_modules/links-notation": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.13.0.tgz",
+      "integrity": "sha512-52FoUAVOhjfC23bdvrxv6b4Eosp02WeM3qTN9Rsb3ouPof5YVQ5fOMlRPMJmKMmdseVzEnewNLFq3lADRpWTFg==",
       "license": "Unlicense"
     }
   }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/adl-links.mjs",
@@ -18,7 +18,7 @@
   "author": "",
   "license": "Unlicense",
   "dependencies": {
-    "@linksplatform/protocols-lino": "^0.7.0"
+    "links-notation": "^0.13.0"
   },
   "devDependencies": {},
   "engines": {

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -3,7 +3,7 @@
 // Supports many-valued logics from unary (1-valued) through continuous probabilistic (∞-valued).
 // See: https://en.wikipedia.org/wiki/Many-valued_logic
 //
-// - Uses official LiNo parser to parse links
+// - Uses official links-notation parser to parse links
 // - Terms are defined via (x: x is x)
 // - Probabilities are assigned ONLY via: ((<expr>) has probability <p>)
 // - Redefinable ops: (=: ...), (!=: not =), (and: avg|min|max|prod|ps), (or: ...), (not: ...)
@@ -12,7 +12,7 @@
 // - Query: (? <expr>)
 
 import fs from 'node:fs';
-import { Parser } from '@linksplatform/protocols-lino';
+import { Parser } from 'links-notation';
 
 // ---------- helpers: canonical keys & tokenization of a single link string ----------
 function tokenizeOne(s) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,4 +4,31 @@ version = 4
 
 [[package]]
 name = "associative-dependent-logic"
-version = "0.4.0"
+version = "0.5.0"
+dependencies = [
+ "links-notation",
+]
+
+[[package]]
+name = "links-notation"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c952b42a8c6ff6f849d7cafe3b1e13f1063a51bbb144bc6c62026ab327814c"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "associative-dependent-logic"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"
@@ -12,3 +12,6 @@ path = "src/main.rs"
 [lib]
 name = "adl"
 path = "src/lib.rs"
+
+[dependencies]
+links-notation = "0.13.0"

--- a/rust/README.md
+++ b/rust/README.md
@@ -79,7 +79,7 @@ The test suite includes 93 tests covering:
 
 ## Implementation Notes
 
-The Rust implementation includes a built-in minimal LiNo parser, so no external dependencies are needed. The implementation is a direct port of the JavaScript version and produces identical results for all test cases.
+The Rust implementation uses the official [`links-notation`](https://crates.io/crates/links-notation) crate for LiNo parsing. The implementation is a direct port of the JavaScript version and produces identical results for all test cases.
 
 ## License
 


### PR DESCRIPTION
## Summary

Migrates both JavaScript and Rust implementations to use the official [links-notation](https://github.com/link-foundation/links-notation) parser as a dependency, replacing the previous `@linksplatform/protocols-lino` npm package (JS) and built-in minimal parser (Rust).

- **JavaScript:** Replaced `@linksplatform/protocols-lino` (0.7.0) with `links-notation` (0.13.0). Updated import in `adl-links.mjs`.
- **Rust:** Added `links-notation` (0.13.0) crate dependency. Replaced the 35-line built-in `parse_lino` function with a call to `links_notation::parse_lino_to_links`, with blank-line splitting to handle group separators.
- **Documentation:** Updated all references in README.md, ARCHITECTURE.md, js/README.md, and rust/README.md to point to the new `links-notation` package/crate.
- **Version bump:** 0.4.0 → 0.5.0

All 93 tests pass in both implementations. All example .lino files produce correct output.

## Test plan
- [x] All 93 JavaScript tests pass (`npm test`)
- [x] All 93 Rust tests pass (`cargo test`)
- [x] All .lino examples produce correct output (demo.lino, flipped-axioms.lino, liar-paradox.lino, liar-paradox-balanced.lino, ternary-kleene.lino)
- [x] No references to old `@linksplatform/protocols-lino` remain in codebase

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)