### PR TITLE
Support true, false, unknown, and undefined truth constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/11
-Your prepared branch: issue-11-7b743aa86308
-Your prepared working directory: /tmp/gh-issue-solver-1770045059484
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/11
+Your prepared branch: issue-11-7b743aa86308
+Your prepared working directory: /tmp/gh-issue-solver-1770045059484
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides two equivalent implementations:
 - **[JavaScript](./js/)** — Node.js implementation using the official [links-notation](https://github.com/link-foundation/links-notation) parser
 - **[Rust](./rust/)** — Rust implementation using the official [links-notation](https://github.com/link-foundation/links-notation) crate
 
-Both implementations pass the same 93 tests and produce identical results.
+Both implementations pass the same 122 tests and produce identical results.
 
 For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
@@ -22,6 +22,7 @@ ADL (Associative-Dependent Logic) is a minimal probabilistic logic system built 
 - Redefine logical operators with different semantics
 - Configure truth value ranges: `[0, 1]` or `[-1, 1]` (balanced/symmetric)
 - Configure logic valence: 2-valued ([Boolean](https://en.wikipedia.org/wiki/Boolean_algebra)), 3-valued ([ternary/Kleene](https://en.wikipedia.org/wiki/Three-valued_logic)), N-valued, or continuous
+- Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`
 - Resolve paradoxical statements (e.g. the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox))
 - Perform decimal-precision arithmetic (`+`, `-`, `*`, `/`) — `0.1 + 0.2 = 0.3`, not `0.30000000000000004`
 - Query the truth value of complex expressions
@@ -122,6 +123,38 @@ Sets the number of discrete truth values. Default is `0` (continuous, no quantiz
 - `(valence: 2)` — [Boolean logic](https://en.wikipedia.org/wiki/Boolean_algebra): truth values are quantized to `{0, 1}`
 - `(valence: 3)` — [Ternary logic](https://en.wikipedia.org/wiki/Three-valued_logic): truth values are quantized to `{0, 0.5, 1}`
 - `(valence: N)` — [N-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic): truth values are quantized to N evenly-spaced levels
+
+### Truth Constants
+
+The symbols `true`, `false`, `unknown`, and `undefined` are predefined with values based on the current range:
+
+| Constant | Default in `[0, 1]` | Default in `[-1, 1]` | Definition |
+|----------|---------------------|----------------------|------------|
+| `true`   | `1`                 | `1`                  | `max(range)` |
+| `false`  | `0`                 | `-1`                 | `min(range)` |
+| `unknown` | `0.5`              | `0`                  | `(max(range) - min(range)) / 2 + min(range)` |
+| `undefined` | `0.5`            | `0`                  | `(max(range) - min(range)) / 2 + min(range)` |
+
+These constants can be used directly in expressions:
+
+```lino
+(? true)              # -> 1 in [0,1], 1 in [-1,1]
+(? false)             # -> 0 in [0,1], -1 in [-1,1]
+(? unknown)           # -> 0.5 in [0,1], 0 in [-1,1]
+(? (not true))        # -> 0 in [0,1], -1 in [-1,1]
+(? (true and false))  # -> 0.5 (avg), 0 (avg in [-1,1])
+```
+
+Truth constants can be **redefined** to custom values:
+
+```lino
+(true: 0.8)           # Redefine true to 0.8
+(false: 0.2)          # Redefine false to 0.2
+(? true)              # -> 0.8
+(? false)             # -> 0.2
+```
+
+When the range changes (via `(range: ...)`), truth constants are automatically re-initialized to their defaults for the new range.
 
 ### Operator Redefinitions
 
@@ -288,7 +321,7 @@ In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Pr
 
 ## Testing
 
-Both implementations have 93 matching tests:
+Both implementations have 122 matching tests:
 
 ```bash
 # JavaScript
@@ -303,6 +336,7 @@ The test suites cover:
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
+- Truth constants (`true`, `false`, `unknown`, `undefined`): defaults, redefinition, range changes, use in expressions, quantization
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
 

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "associative-dependent-logic",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/adl-links.mjs",

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -148,6 +148,13 @@ class Env {
     this.defineOp('-', (a,b)=> decRound(a - b));
     this.defineOp('*', (a,b)=> decRound(a * b));
     this.defineOp('/', (a,b)=> b === 0 ? 0 : decRound(a / b));
+
+    // Initialize truth constants: true, false, unknown, undefined
+    // These are predefined symbol probabilities based on the current range.
+    // By default: (false: min(range)), (true: max(range)),
+    //             (unknown: mid(range)), (undefined: mid(range))
+    // They can be redefined by the user via (true: <value>), (false: <value>), etc.
+    this._initTruthConstants();
   }
 
   // Clamp and optionally quantize a value to the valid range
@@ -164,6 +171,16 @@ class Env {
 
   // Midpoint of the range (useful for paradox resolution, default symbol prob, etc.)
   get mid() { return (this.lo + this.hi) / 2; }
+
+  // Initialize truth constants based on current range.
+  // (false: min(range)), (true: max(range)),
+  // (unknown: mid(range)), (undefined: mid(range))
+  _initTruthConstants() {
+    this.symbolProb.set('true', this.hi);
+    this.symbolProb.set('false', this.lo);
+    this.symbolProb.set('unknown', this.mid);
+    this.symbolProb.set('undefined', this.mid);
+  }
 
   getOp(name){
     if (!this.ops.has(name)) throw new Error(`Unknown op: ${name}`);
@@ -297,6 +314,8 @@ function _reinitOps(env) {
   env.ops.set('-', (a,b) => decRound(a - b));
   env.ops.set('*', (a,b) => decRound(a * b));
   env.ops.set('/', (a,b) => b === 0 ? 0 : decRound(a / b));
+  // Re-initialize truth constants for new range
+  env._initTruthConstants();
 }
 
 function defineForm(head, rhs, env){

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "associative-dependent-logic"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "associative-dependent-logic"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"


### PR DESCRIPTION
## Summary

Adds predefined truth constants (`true`, `false`, `unknown`, `undefined`) as symbol probabilities, automatically initialized based on the current range and redefinable by the user.

- **Truth constants:** `true` defaults to `max(range)`, `false` to `min(range)`, `unknown` and `undefined` to `mid(range)`
- **Redefinition:** Users can override via `(true: 0.8)`, `(false: 0.2)`, etc.
- **Range-aware:** Constants are automatically re-initialized when range changes via `(range: ...)`
- **Expressions:** Constants work in all expression contexts: `(not true)`, `(true and false)`, `(? unknown)`, etc.
- **Both implementations:** JavaScript and Rust updated identically
- **Tests:** 29 new tests per implementation (122 total, up from 93)
- **Documentation:** README.md and ARCHITECTURE.md updated with truth constants section
- **Version bump:** 0.5.0 → 0.6.0

### Default values

| Constant | `[0, 1]` range | `[-1, 1]` range |
|----------|-----------------|-----------------|
| `true` | `1` | `1` |
| `false` | `0` | `-1` |
| `unknown` | `0.5` | `0` |
| `undefined` | `0.5` | `0` |

### Example usage

```lino
(? true)              # -> 1
(? false)             # -> 0
(? unknown)           # -> 0.5
(? (not true))        # -> 0
(? (true and false))  # -> 0.5

# Redefinition
(true: 0.8)
(? true)              # -> 0.8

# Range change re-initializes
(range: -1 1)
(? true)              # -> 1
(? false)             # -> -1
(? unknown)           # -> 0
```

## Test plan
- [x] All 122 JavaScript tests pass (`npm test`)
- [x] All 122 Rust tests pass (`cargo test`)
- [x] Existing 93 tests unchanged and passing
- [x] 29 new truth constant tests per implementation covering: defaults in both ranges, redefinition, range change re-initialization, use in expressions, quantization with valence, Env API, liar paradox with truth constants

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)