### PR TITLE
Implement dependent type system with full names and prefix type notation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/13
-Your prepared branch: issue-13-1e0df12d54e8
-Your prepared working directory: /tmp/gh-issue-solver-1770045979836
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/link-foundation/associative-dependent-logic/issues/13
+Your prepared branch: issue-13-1e0df12d54e8
+Your prepared working directory: /tmp/gh-issue-solver-1770045979836
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -224,16 +224,29 @@ Queries are evaluated and their truth value is printed to stdout.
 
 Types are just links — "everything is a link". The type system coexists with probabilistic logic.
 
+#### Universe Hierarchy
+
+The type system uses a **universe hierarchy** to avoid paradoxes (like Russell's paradox). Each `(Type N)` is itself a member of `(Type N+1)`:
+
+- `(Type 0)` — the universe of "small" types (Natural, Boolean, etc.)
+- `(Type 1)` — the universe that contains `(Type 0)` and types formed from `(Type 0)` types
+- `(Type 2)` — contains `(Type 1)`, and so on
+
+This mirrors the universe hierarchy in Lean 4 (`Type 0`, `Type 1`, ...) and Rocq (`Set`, `Type`, ...). The stratification prevents a type from containing itself, which would lead to logical inconsistency.
+
+In LiNo, universes are declared and automatically stratified:
+
+```lino
+(Type 0)                         # universe of small types
+(Type 1)                         # (Type 0) : (Type 1)
+```
+
 #### Type Declarations
 
 ```lino
-# Universe hierarchy
-(Type 0)
-(Type 1)
-
-# Type definition (complex type expression)
-(Natural: (Type 0))
-(Boolean: (Type 0))
+# Type definition follows the pattern: (SubType: Type SubType)
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 
 # Typed term via prefix type notation: (name: TypeName name)
 (zero: Natural zero)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides two equivalent implementations:
 - **[JavaScript](./js/)** — Node.js implementation using the official [links-notation](https://github.com/link-foundation/links-notation) parser
 - **[Rust](./rust/)** — Rust implementation using the official [links-notation](https://github.com/link-foundation/links-notation) crate
 
-Both implementations pass the same 122 tests and produce identical results.
+Both implementations pass the same 170 tests and produce identical results.
 
 For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
@@ -26,6 +26,8 @@ ADL (Associative-Dependent Logic) is a minimal probabilistic logic system built 
 - Resolve paradoxical statements (e.g. the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox))
 - Perform decimal-precision arithmetic (`+`, `-`, `*`, `/`) — `0.1 + 0.2 = 0.3`, not `0.30000000000000004`
 - Query the truth value of complex expressions
+- Define dependent types as links — universe hierarchy, Pi-types, lambdas, type queries
+- Combine types with probabilistic logic in a unified framework
 
 ## Supported Logic Types
 
@@ -218,6 +220,76 @@ Queries are evaluated and their truth value is printed to stdout.
 (a: a is a)  # Inline comments are also supported
 ```
 
+### Dependent Type System
+
+Types are just links — "everything is a link". The type system coexists with probabilistic logic.
+
+#### Type Declarations
+
+```lino
+# Universe hierarchy
+(Type 0)
+(Type 1)
+
+# Type definition (complex type expression)
+(Natural: (Type 0))
+(Boolean: (Type 0))
+
+# Typed term via prefix type notation: (name: TypeName name)
+(zero: Natural zero)
+(true-val: Boolean true-val)
+```
+
+#### Pi-types (Dependent Products)
+
+```lino
+# (Pi (TypeName varName) ReturnType)
+(succ: (Pi (Natural n) Natural))
+```
+
+#### Lambda Abstraction
+
+```lino
+# (lambda (TypeName varName) body)
+(identity: lambda (Natural x) x)
+
+# Multi-parameter: (lambda (TypeName x, TypeName y) body)
+(add: lambda (Natural x, Natural y) (x + y))
+```
+
+#### Application
+
+```lino
+# Explicit: (apply function argument)
+(? (apply identity 0.7))         # -> 0.7
+
+# Prefix: (functionName argument)
+(? (identity 0.7))               # -> 0.7
+```
+
+#### Type Queries
+
+```lino
+# Type check: (expr of Type) — returns 1 (true) or 0 (false)
+(? (zero of Natural))            # -> 1
+(? (Natural of (Type 0)))        # -> 1
+
+# Type inference: (type of expr) — returns the type name
+(? (type of zero))               # -> Natural
+```
+
+#### Type Hierarchy Example
+
+```lino
+(Type 0)
+(Type: (Type 0) Type)
+(Boolean: Type Boolean)
+(True: Boolean True)
+(False: Boolean False)
+(? (Boolean of Type))            # -> 1
+(? (True of Boolean))            # -> 1
+```
+
 ## Built-in Operators
 
 - `=`: Equality (checks assigned probability, then structural equality, then numeric comparison with decimal precision)
@@ -321,7 +393,7 @@ In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Pr
 
 ## Testing
 
-Both implementations have 122 matching tests:
+Both implementations have 170 matching tests:
 
 ```bash
 # JavaScript
@@ -339,6 +411,7 @@ The test suites cover:
 - Truth constants (`true`, `false`, `unknown`, `undefined`): defaults, redefinition, range changes, use in expressions, quantization
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
+- Dependent type system: universes, Pi-types, lambdas, application, type queries, prefix type notation
 
 ## API
 

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -1,0 +1,592 @@
+# Case Study: Defining Dependent Types in Links Notation
+
+**Issue:** [#13 — Is it possible to have enough apparatus to define types and dependent types like Lean/Rocq have, but to define the very core of their systems using our system?](https://github.com/link-foundation/associative-dependent-logic/issues/13)
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Background: What Lean and Rocq Do](#background-what-lean-and-rocq-do)
+3. [Background: What ADL Currently Does](#background-what-adl-currently-does)
+4. [The Gap: What's Missing](#the-gap-whats-missing)
+5. [Key Insight: Links as a Meta-Theory](#key-insight-links-as-a-meta-theory)
+6. [Implementation Options](#implementation-options)
+7. [Existing Tools and Libraries](#existing-tools-and-libraries)
+8. [Recommended Approach](#recommended-approach)
+9. [References](#references)
+
+---
+
+## Executive Summary
+
+The question is whether the ADL (Associative-Dependent Logic) system, built on Links Notation (LiNo), can serve as a **meta-theory** capable of defining the very core of dependent type systems like Lean 4 and Rocq (formerly Coq). The answer is **yes, in principle**, but it requires extending ADL with several new capabilities. This document analyzes the gap, proposes concrete implementation options with LiNo syntax, and identifies existing libraries that can help.
+
+The key insight from [Links Theory](https://github.com/link-foundation/deep-theory) is that a **link** is a universal unit of meaning — it can represent types, terms, proofs, and propositions uniformly. This is analogous to how the Calculus of Constructions (CoC) unifies terms and types into a single syntactic category. The "associative" in ADL and the "dependent" in dependent types can be bridged through this shared principle of **self-reference and unification**.
+
+---
+
+## Background: What Lean and Rocq Do
+
+### The Calculus of Constructions (CoC)
+
+Both [Lean 4](https://lean-lang.org/theorem_proving_in_lean4/dependent_type_theory.html) and [Rocq](https://rocq-prover.org/doc/V9.1.0/refman/language/core/index.html) are built on variants of the **Calculus of Inductive Constructions (CIC)**, which extends the [Calculus of Constructions](https://en.wikipedia.org/wiki/Calculus_of_constructions). At their core, they need only a handful of expression forms:
+
+| Expression | Notation | Meaning |
+|-----------|----------|---------|
+| **Variable** | `x` | A reference to a bound name |
+| **Sort/Universe** | `Type₀`, `Type₁`, `Prop` | The type of types at a given level |
+| **Dependent Product (Π-type)** | `∀ (x : A), B` | Function type where `B` may depend on `x` |
+| **Lambda Abstraction** | `λ (x : A), e` | A function taking `x` of type `A` and returning `e` |
+| **Application** | `f a` | Applying function `f` to argument `a` |
+
+That's it — just **5 expression forms**. Everything else (inductive types, pattern matching, records, tactics) is built on top of this minimal core through elaboration.
+
+Source: [Andrej Bauer — How to implement dependent type theory](https://math.andrej.com/2012/11/08/how-to-implement-dependent-type-theory-i/) shows a complete implementation in ~92 lines.
+
+### The Kernel
+
+The kernel is the trusted core that checks well-typedness. Both Lean and Rocq follow the **de Bruijn criterion**: the kernel is kept small so it can be independently audited. The kernel only needs to implement:
+
+1. **Type checking**: Given a term and a type, verify the term has that type
+2. **Type inference**: Given a term, compute its type
+3. **Definitional equality**: Check if two terms are equal after normalization (β-reduction, δ-unfolding)
+4. **Substitution**: Replace a variable with a term, avoiding capture
+
+### The Curry-Howard Correspondence
+
+The [Curry-Howard correspondence](https://en.wikipedia.org/wiki/Curry%E2%80%93Howard_correspondence) is the key insight that makes proof assistants work:
+
+| Logic | Type Theory |
+|-------|-------------|
+| Proposition | Type |
+| Proof | Term (program) |
+| Implication A → B | Function type A → B |
+| ∀x. P(x) | Dependent product Π(x:A). B(x) |
+| ∃x. P(x) | Dependent sum Σ(x:A). B(x) |
+| True | Unit type |
+| False | Empty type |
+
+In classical ADL, we assign **probabilities** to propositions. In dependent type theory, a proposition is **proven or not** (it's a type that is either inhabited or empty). The bridge between these two worlds is explored in the section on [Probabilistic Type Theory](#option-c-probabilistic-dependent-type-theory).
+
+### Universe Hierarchy
+
+Types themselves have types, forming a hierarchy:
+
+```
+term : Type₀ : Type₁ : Type₂ : ...
+```
+
+This prevents Russell's paradox (the type-theoretic analog of "the set of all sets that don't contain themselves"). Lean uses a **non-cumulative** hierarchy; Rocq uses a **cumulative** one where `Type₀ ⊆ Type₁`.
+
+---
+
+## Background: What ADL Currently Does
+
+ADL is a **probabilistic logic framework** built on [Links Notation (LiNo)](https://github.com/link-foundation/links-notation). Its current capabilities:
+
+| Feature | ADL Has It? | Notes |
+|---------|-------------|-------|
+| Term definitions | Yes | `(a: a is a)` |
+| Probability assignments | Yes | `((a = a) has probability 1)` |
+| Many-valued logic | Yes | Unary through continuous (fuzzy) |
+| Configurable range | Yes | `[0, 1]` or `[-1, 1]` |
+| Configurable valence | Yes | 2-valued, 3-valued, N-valued, continuous |
+| Redefinable operators | Yes | `(and: min)`, `(!=: not =)` |
+| Decimal-precision arithmetic | Yes | `0.1 + 0.2 = 0.3` |
+| Paradox resolution | Yes | Liar paradox → midpoint |
+| **Type annotations** | **No** | No way to say `(x : Nat)` |
+| **Dependent products** | **No** | No `∀ (x : A), B` |
+| **Lambda abstraction** | **No** | No `λ (x : A), e` |
+| **Application** | **Partial** | Prefix operators exist but not general application |
+| **Universe hierarchy** | **No** | No `Type₀ : Type₁ : ...` |
+| **Substitution** | **No** | No β-reduction |
+| **Normalization** | **No** | No reduction to normal form |
+| **Type checking** | **No** | No judgment `Γ ⊢ e : T` |
+
+### LiNo Syntax Recap
+
+LiNo is parenthesized notation where everything is a **link** (an ordered tuple of references):
+
+```lino
+(a: a is a)                    # Definition: a 3-element link
+((a = a) has probability 1)    # A nested link structure
+(? (a = a))                    # Query
+(and: avg)                     # Operator configuration
+```
+
+The key property of LiNo is that **there is no fixed grammar** — the semantics are determined by the evaluator, not the parser. This makes it ideal for defining new language constructs.
+
+---
+
+## The Gap: What's Missing
+
+To define the core of Lean/Rocq within ADL, we need to add these capabilities:
+
+### 1. Type Annotations
+
+Currently, `(a: a is a)` defines a term. We need a way to **annotate terms with types**:
+
+```lino
+(a : Nat)          # a has type Nat
+(f : Nat -> Bool)  # f is a function from Nat to Bool
+```
+
+### 2. Dependent Products (Π-types)
+
+The ability to express types that depend on values:
+
+```lino
+(forall (n : Nat) (Vec n Nat))   # For all n:Nat, the type Vec n Nat
+```
+
+### 3. Lambda Abstraction
+
+The ability to create functions:
+
+```lino
+(lambda (x : Nat) (x + 1))      # A function that adds 1
+```
+
+### 4. Application and β-Reduction
+
+Applying a function to an argument and reducing:
+
+```lino
+((lambda (x : Nat) (x + 1)) 3)  # Should reduce to 4
+```
+
+### 5. Universe Hierarchy
+
+A hierarchy of types:
+
+```lino
+(Type 0)    # The type of "small" types (Nat, Bool, etc.)
+(Type 1)    # The type of Type 0
+```
+
+### 6. Inductive Types (Optional, for full CIC)
+
+For the full Calculus of Inductive Constructions:
+
+```lino
+(inductive Nat
+  (zero : Nat)
+  (succ : (forall (n : Nat) Nat)))
+```
+
+---
+
+## Key Insight: Links as a Meta-Theory
+
+The [Links Theory](https://github.com/link-foundation/deep-theory) (Deep Theory) establishes that:
+
+1. A **link** is the universal unit of meaning — it can represent anything
+2. **Doublets** (2-tuples) and **triplets** (3-tuples) can represent any data structure
+3. The associative model is **self-referential**: links can reference other links, including themselves
+4. Unlike set theory (which distinguishes sets from elements) or type theory (which distinguishes types from terms), Links Theory uses a **single concept**: the link
+
+This maps naturally to dependent type theory, where **terms and types are the same syntactic category**. In the CoC:
+
+- A type is just a term: `Nat` is a term of type `Type₀`
+- A function type is just a term: `Nat → Bool` is a term of type `Type₀`
+- A proof is just a term: a proof of `P` is a term of type `P`
+
+In Links Theory:
+
+- A link is just a link: whether it represents a type, a term, or a proof
+- The distinction comes from **context** (which other links reference it), not from any intrinsic property
+
+This parallel suggests that LiNo is a natural notation for expressing dependent type theory.
+
+### The Associative Network as a Type Context
+
+In dependent type theory, a **context** Γ is a sequence of (name, type) pairs:
+
+```
+Γ = x₁ : A₁, x₂ : A₂, ..., xₙ : Aₙ
+```
+
+In the associative model, this is simply a network of links:
+
+```
+link₁ = (x₁, A₁)    # x₁ has type A₁
+link₂ = (x₂, A₂)    # x₂ has type A₂
+...
+```
+
+The **typing judgment** `Γ ⊢ e : T` ("in context Γ, expression e has type T") becomes:
+
+```
+(in context Γ, e has type T)
+```
+
+Which in LiNo could be:
+
+```lino
+((e has type T) in (x₁ : A₁) (x₂ : A₂))
+```
+
+---
+
+## Implementation Options
+
+### Option A: Pure LiNo Encoding (Shallow Embedding)
+
+**Approach:** Define type-theoretic constructs as LiNo expressions interpreted by the existing ADL evaluator, extended with new evaluation rules.
+
+**Syntax:**
+
+```lino
+# Universes
+(Type 0)
+(Type 1)
+
+# Type annotations
+(x : Nat)
+(f : (Pi (x : Nat) Nat))
+
+# Dependent product (Π-type / forall)
+(Pi (x : Nat) (Vec x Bool))
+
+# Non-dependent function type (sugar for Pi where x doesn't appear in body)
+(Nat -> Bool)
+
+# Lambda abstraction
+(lam (x : Nat) (+ x 1))
+
+# Application
+(app (lam (x : Nat) (+ x 1)) 3)
+
+# Let binding
+(let (x : Nat) 5 (+ x 1))
+
+# Inductive type definition
+(inductive Nat
+  (zero : Nat)
+  (succ : (Pi (n : Nat) Nat)))
+
+# Pattern matching
+(match n
+  (zero => 0)
+  ((succ m) => (+ 1 (f m))))
+
+# Type checking query
+(?type (lam (x : Nat) (+ x 1)))   # -> (Pi (x : Nat) Nat)
+
+# Proof term
+(theorem plus_comm
+  (Pi (a : Nat) (Pi (b : Nat) (= (+ a b) (+ b a))))
+  proof_term)
+```
+
+**Probability integration:**
+
+```lino
+# A proposition with probability
+((P x) has probability 0.8)
+
+# Type-checked with probability
+(?type ((P x) has probability 0.8))   # -> Prop with confidence 0.8
+
+# Dependent type with probabilistic witness
+(Sigma (x : Nat) ((P x) has probability (> 0.5)))
+```
+
+**Pros:**
+- Uses existing LiNo parser unchanged
+- Familiar parenthesized syntax
+- Natural extension of current ADL
+- All constructs are links (consistent with Links Theory)
+
+**Cons:**
+- Requires significant new evaluation rules in the ADL engine
+- β-reduction and normalization are complex to implement
+- Mixing probabilities and types needs careful design
+
+**Implementation effort:** Medium-high. Requires adding type checking, substitution, normalization, and universe checking to the ADL evaluator (~500-1000 lines per implementation).
+
+---
+
+### Option B: Compiled Core (Deep Embedding)
+
+**Approach:** Define a separate type-theoretic core language that compiles to/from LiNo. The ADL evaluator handles probabilistic logic; a separate type checker handles dependent types.
+
+**Architecture:**
+
+```
+LiNo text → LiNo Parser → AST
+                              ├─→ ADL Evaluator (probabilities, logic)
+                              └─→ Type Checker (dependent types, proofs)
+```
+
+**Syntax (same LiNo surface syntax, different evaluation):**
+
+```lino
+# Mode switch
+(mode: types)
+
+# Now all expressions are type-checked
+(def Nat : (Type 0)
+  (inductive
+    (zero : Nat)
+    (succ : (Pi (_ : Nat) Nat))))
+
+(def plus : (Pi (a : Nat) (Pi (b : Nat) Nat))
+  (lam (a : Nat) (lam (b : Nat)
+    (match a
+      (zero => b)
+      ((succ n) => (succ (plus n b)))))))
+
+# Switch back to probabilistic mode
+(mode: logic)
+
+# Now we can assign probabilities to type-theoretic propositions
+((plus (succ zero) (succ zero) = succ (succ zero)) has probability 1)
+```
+
+**Pros:**
+- Clean separation of concerns
+- Can leverage existing type checker implementations
+- Easier to verify correctness of each component independently
+- Follows the de Bruijn criterion naturally
+
+**Cons:**
+- Two separate evaluation engines
+- Interop between probabilistic and type-theoretic modes needs design
+- More complex overall architecture
+
+**Implementation effort:** Medium. The type checker itself is well-understood (~300-500 lines using existing algorithms), but integration with ADL requires design work.
+
+---
+
+### Option C: Probabilistic Dependent Type Theory
+
+**Approach:** Extend dependent type theory itself with probabilities, creating a novel system that unifies ADL's probabilistic logic with dependent types.
+
+This is inspired by the research paper ["A Type Theory for Probabilistic and Bayesian Reasoning"](https://arxiv.org/abs/1511.09230) (Adams & Jacobs, 2015) and ["A Probabilistic Dependent Type System"](https://arxiv.org/abs/1602.06420) (2016).
+
+**Core idea:** Instead of a type being either inhabited or empty (as in classical dependent type theory), a type can be **partially inhabited** with a probability:
+
+```lino
+# Classical: P is either true or false
+(P : Prop)
+
+# Probabilistic: P has a degree of truth
+(P : Prop 0.8)     # P is true with probability 0.8
+
+# Dependent product with probabilistic types
+(Pi (x : Nat) (Prop (prob x)))   # A family of propositions with varying probability
+```
+
+**Syntax in LiNo:**
+
+```lino
+# Probabilistic Prop
+(PProp : (Type 0))
+
+# A probabilistic proposition
+(raining : (PProp 0.7))       # "It is raining" with probability 0.7
+
+# Conditional probability as dependent type
+(umbrella_given_rain :
+  (Pi (r : (PProp p)) (PProp (cond_prob umbrella r))))
+
+# Bayesian update as a type-theoretic operation
+(bayes :
+  (Pi (prior : (PProp p))
+  (Pi (likelihood : (Pi (_ : A) (PProp l)))
+  (Pi (evidence : (PProp e))
+  (PProp (bayesian_update p l e))))))
+
+# ADL's existing probability operations become type-theoretic
+(and : (Pi (a : (PProp p)) (Pi (b : (PProp q)) (PProp (agg_and p q)))))
+(or  : (Pi (a : (PProp p)) (Pi (b : (PProp q)) (PProp (agg_or p q)))))
+(not : (Pi (a : (PProp p)) (PProp (negate p))))
+```
+
+**Pros:**
+- Truly novel: unifies two powerful formalisms
+- ADL's existing probabilistic logic becomes a special case
+- Lean/Rocq's classical logic becomes a special case (when all probabilities are 0 or 1)
+- Directly addresses the issue's goal of being a meta-theory for all theories
+
+**Cons:**
+- Research-level difficulty; no off-the-shelf implementation exists
+- Soundness and decidability need careful analysis
+- May require new theoretical results
+
+**Implementation effort:** High. This is a research project, not just an engineering task. However, a prototype could be built incrementally.
+
+---
+
+### Option D: Links-Native Type Theory (Maximally Associative)
+
+**Approach:** Define types and terms purely as links in an associative network, without any special syntax. This is the most faithful to Links Theory.
+
+In this approach, the entire type system is encoded as an associative network of doublets and triplets:
+
+```lino
+# Everything is a link. A link has an ID and references other links.
+
+# Define the concept "type-of" as a link
+(type-of: type-of is type-of)
+
+# Define universe levels as links
+(Type-0: Type-0 is Type-0)
+(Type-1: Type-1 is Type-1)
+((Type-0 type-of Type-1) has probability 1)   # Type₀ : Type₁
+
+# Define Nat as a link of type Type-0
+(Nat: Nat is Nat)
+((Nat type-of Type-0) has probability 1)       # Nat : Type₀
+
+# Define zero as a link of type Nat
+(zero: zero is zero)
+((zero type-of Nat) has probability 1)         # zero : Nat
+
+# Define succ as a function link
+(succ: succ is succ)
+((succ type-of (Pi Nat Nat)) has probability 1)  # succ : Nat → Nat
+
+# Dependent product as a link pattern
+(Pi: Pi is Pi)
+((Pi type-of (Pi Type-0 (Pi Type-0 Type-0))) has probability 1)
+
+# Application: (succ zero) is a link
+((succ zero): (succ zero) is (succ zero))
+((succ zero) type-of Nat)
+
+# Lambda: represented as a link with binding structure
+(lambda: lambda is lambda)
+((lambda x Nat (+ x 1)) type-of (Pi Nat Nat))
+```
+
+**The key principle:** Every construct (type, term, function, proof) is just a link with other links indicating its relationships (type-of, reduces-to, equivalent-to).
+
+**Pros:**
+- Maximally faithful to Links Theory and the associative model
+- No new syntax needed — uses existing LiNo features
+- The type system itself is data, not baked into the evaluator
+- Self-describing: the type system can describe itself
+
+**Cons:**
+- Very verbose
+- Performance concerns (type checking via associative network traversal)
+- Needs an external "type checker" that operates on the link network
+- May be too abstract for practical use
+
+**Implementation effort:** Low for syntax, high for the type-checking engine that traverses the link network.
+
+---
+
+## Existing Tools and Libraries
+
+### JavaScript
+
+| Library | Description | Relevance |
+|---------|-------------|-----------|
+| [calculus-of-constructions](https://www.npmjs.com/package/calculus-of-constructions) | Minimal CoC in JS (~400 lines) by Victor Taelin | **High** — Could be adapted to work with LiNo AST |
+| [formcore-js](https://www.npmjs.com/package/formcore-js) | Minimal proof language with self-types (~700 lines) | **High** — Kernel of Kind language, very small |
+| [links-notation](https://www.npmjs.com/package/links-notation) | Official LiNo parser (already used by ADL) | **Already integrated** |
+
+### Rust
+
+| Library | Description | Relevance |
+|---------|-------------|-----------|
+| [Typechecker Zoo — CoC](https://sdiehl.github.io/typechecker-zoo/coc/calculus-of-constructions.html) | CoC type checker in Rust | **High** — Reference implementation |
+| [links-notation crate](https://crates.io/crates/links-notation) | Official LiNo parser (already used by ADL) | **Already integrated** |
+| [Interaction-Type-Theory](https://github.com/VictorTaelin/Interaction-Type-Theory) | CoC via interaction combinators | **Medium** — Novel approach |
+
+### Reference Implementations (Other Languages)
+
+| Library | Language | Description |
+|---------|----------|-------------|
+| [elaboration-zoo](https://github.com/AndrasKovacs/elaboration-zoo) | Haskell | Progressive dependent type elaboration examples |
+| [nano-Agda](https://github.com/jyp/nano-Agda) | Haskell | Tiny type-checker (~200 lines) |
+| [LaTTe Kernel](https://github.com/latte-central/latte-kernel) | Clojure | Small trusted kernel for proof assistant |
+| [tt (Andrej Bauer)](https://math.andrej.com/2012/11/08/how-to-implement-dependent-type-theory-i/) | OCaml | ~92 lines, complete CoC implementation |
+
+### Academic References
+
+| Paper | Year | Relevance |
+|-------|------|-----------|
+| [A Type Theory for Probabilistic and Bayesian Reasoning](https://arxiv.org/abs/1511.09230) | 2015 | **High** — Formal foundation for Option C |
+| [A Probabilistic Dependent Type System](https://arxiv.org/abs/1602.06420) | 2016 | **High** — Non-deterministic β-reduction with probabilities |
+| [Propositions as Types (Wadler)](https://homepages.inf.ed.ac.uk/wadler/papers/propositions-as-types/propositions-as-types.pdf) | 2015 | Background on Curry-Howard |
+
+---
+
+## Recommended Approach
+
+### Phase 1: Option A (Shallow Embedding) — Start Here
+
+Begin by extending the ADL evaluator to handle the 5 core expression forms of the CoC. This is the minimum viable step:
+
+1. Add `(Type N)` as universe sorts
+2. Add `(Pi (x : A) B)` for dependent products
+3. Add `(lam (x : A) e)` for lambda abstraction
+4. Add `(app f x)` for application (or detect it from list structure)
+5. Implement substitution and β-reduction
+6. Implement basic type checking/inference
+
+**Estimated scope:** ~500 lines of new code per implementation (JS + Rust), plus ~100 new tests.
+
+This can be done using [VictorTaelin's CoC implementation](https://github.com/VictorTaelin/calculus-of-constructions) as a reference for the JavaScript side, and the [Typechecker Zoo](https://sdiehl.github.io/typechecker-zoo/coc/calculus-of-constructions.html) for the Rust side.
+
+### Phase 2: Option C (Probabilistic Extension) — The Novel Contribution
+
+Once the basic type system works, extend it with ADL's probabilistic semantics:
+
+1. Add `(PProp p)` as probabilistic propositions
+2. Define how `and`, `or`, `not` interact with typed propositions
+3. Implement Bayesian conditioning as a type-theoretic operation
+4. Show that classical dependent types are the special case where all probabilities are 0 or 1
+
+This would be a genuine research contribution.
+
+### Phase 3: Option D (Links-Native) — The Meta-Theory
+
+Finally, show that the type system itself can be described as a network of links:
+
+1. Encode the typing rules as links
+2. Show that type checking is link network traversal
+3. Demonstrate that the system can describe itself (self-referential meta-theory)
+
+This achieves the original goal: the system becomes a meta-theory that can describe any theory, including its own foundations.
+
+---
+
+## References
+
+### Dependent Type Theory
+- [Lean 4 — Dependent Type Theory](https://lean-lang.org/theorem_proving_in_lean4/dependent_type_theory.html)
+- [Rocq/Coq — Calculus of Inductive Constructions](https://rocq-prover.org/doc/v8.9/refman/language/cic.html)
+- [Rocq — Core Language (v9.1.0)](https://rocq-prover.org/doc/V9.1.0/refman/language/core/index.html)
+- [How to implement dependent type theory (Andrej Bauer)](https://math.andrej.com/2012/11/08/how-to-implement-dependent-type-theory-i/)
+- [Calculus of Constructions — Wikipedia](https://en.wikipedia.org/wiki/Calculus_of_constructions)
+- [Curry-Howard Correspondence — Wikipedia](https://en.wikipedia.org/wiki/Curry%E2%80%93Howard_correspondence)
+- [Propositions as Types (Philip Wadler)](https://homepages.inf.ed.ac.uk/wadler/papers/propositions-as-types/propositions-as-types.pdf)
+- [Dependent Type — Wikipedia](https://en.wikipedia.org/wiki/Dependent_type)
+- [Lean (proof assistant) — Wikipedia](https://en.wikipedia.org/wiki/Lean_(proof_assistant))
+- [Rocq — Wikipedia](https://en.wikipedia.org/wiki/Rocq)
+
+### Probabilistic Type Theory
+- [A Type Theory for Probabilistic and Bayesian Reasoning (arXiv)](https://arxiv.org/abs/1511.09230)
+- [A Probabilistic Dependent Type System (arXiv)](https://arxiv.org/abs/1602.06420)
+
+### Links Theory and Associative Models
+- [Links Theory — GitHub](https://github.com/link-foundation/deep-theory)
+- [Math introduction to Deep Theory (Habr)](https://habr.com/en/companies/deepfoundation/articles/658705/)
+- [Associative Links (DEV Community)](https://dev.to/deepfoundation/associative-links-4cda)
+- [Associative Links Explained (HackerNoon)](https://hackernoon.com/associative-links-explained)
+- [Deep.Foundation](https://deep.foundation/)
+
+### Implementations
+- [VictorTaelin/calculus-of-constructions (JS, npm)](https://github.com/VictorTaelin/calculus-of-constructions)
+- [FormCoreJS (JS, npm)](https://github.com/HigherOrderCO/FormCoreJS)
+- [Typechecker Zoo — CoC (Rust)](https://sdiehl.github.io/typechecker-zoo/coc/calculus-of-constructions.html)
+- [elaboration-zoo (Haskell)](https://github.com/AndrasKovacs/elaboration-zoo)
+- [nano-Agda (Haskell)](https://github.com/jyp/nano-Agda)
+- [LaTTe Kernel (Clojure)](https://github.com/latte-central/latte-kernel)
+- [Interaction-Type-Theory](https://github.com/VictorTaelin/Interaction-Type-Theory)
+- [links-notation (npm)](https://www.npmjs.com/package/links-notation)
+- [links-notation (crate)](https://crates.io/crates/links-notation)

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -522,15 +522,19 @@ In this approach, the entire type system is encoded as an associative network of
 The ADL evaluator has been extended with all 5 core expression forms of the CoC:
 
 1. ✅ `(Type N)` — universe sorts with automatic hierarchy `(Type 0) : (Type 1) : ...`
-2. ✅ `(Pi (Natural x) B)` — dependent products (Π-types)
-3. ✅ `(lambda (Natural x) e)` — lambda abstraction with typed parameters
-4. ✅ `(apply f x)` — application with full β-reduction
-5. ✅ Substitution with variable shadowing support
-6. ✅ Type checking via `(expr of Type)` queries and `(? (type of expr))` inference
+2. ✅ `(Type: Type Type)` — self-referential type (ADL's primary approach, enabled by paradox resolution)
+3. ✅ `(Pi (Natural x) B)` — dependent products (Π-types)
+4. ✅ `(lambda (Natural x) e)` — lambda abstraction with typed parameters
+5. ✅ `(apply f x)` — application with full β-reduction
+6. ✅ Substitution with variable shadowing support
+7. ✅ Type checking via `(expr of Type)` queries and `(? (type of expr))` inference
 
-**Implementation:** ~500 lines of new code in each implementation (JS + Rust), plus 46 new tests each (all backward-compatible with existing 124 tests).
+**Implementation:** ~500 lines of new code in each implementation (JS + Rust), plus 52 new tests each (all backward-compatible with existing 124 tests).
 
-**Key design principle:** "Everything is a link" — types are stored as associations in the link network, type-checking is querying the network, and the type system coexists with the probabilistic logic engine.
+**Key design principles:**
+- **"Everything is a link"** — types are stored as associations in the link network, type-checking is querying the network, and the type system coexists with the probabilistic logic engine.
+- **Dynamic axiomatic system** — every link is a recursive fractal, definitions can be changed at any time, and the system embraces self-reference rather than forbidding it.
+- **Self-referential Type** — `(Type: Type Type)` is the primary way to define the root type. Unlike classical type theory which forbids `Type : Type` to avoid Russell's paradox, ADL's many-valued logic resolves paradoxes to the midpoint truth value (0.5 in `[0,1]`). Both `(Type: Type Type)` and `(Type N)` can coexist.
 
 ### Phase 2: Option C (Probabilistic Extension) — The Novel Contribution
 

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -126,8 +126,8 @@ To define the core of Lean/Rocq within ADL, we need to add these capabilities:
 Currently, `(a: a is a)` defines a term. We need a way to **annotate terms with types**:
 
 ```lino
-(a : Nat)          # a has type Nat
-(f : Nat -> Bool)  # f is a function from Nat to Bool
+(a: Nat)          # a has type Nat
+(f: Nat -> Bool)  # f is a function from Nat to Bool
 ```
 
 ### 2. Dependent Products (Π-types)
@@ -135,7 +135,7 @@ Currently, `(a: a is a)` defines a term. We need a way to **annotate terms with 
 The ability to express types that depend on values:
 
 ```lino
-(forall (n : Nat) (Vec n Nat))   # For all n:Nat, the type Vec n Nat
+(forall (n: Nat) (Vec n Nat))   # For all n:Nat, the type Vec n Nat
 ```
 
 ### 3. Lambda Abstraction
@@ -143,7 +143,7 @@ The ability to express types that depend on values:
 The ability to create functions:
 
 ```lino
-(lambda (x : Nat) (x + 1))      # A function that adds 1
+(lambda (x: Nat) (x + 1))      # A function that adds 1
 ```
 
 ### 4. Application and β-Reduction
@@ -151,7 +151,7 @@ The ability to create functions:
 Applying a function to an argument and reducing:
 
 ```lino
-((lambda (x : Nat) (x + 1)) 3)  # Should reduce to 4
+((lambda (x: Nat) (x + 1)) 3)  # Should reduce to 4
 ```
 
 ### 5. Universe Hierarchy
@@ -169,8 +169,8 @@ For the full Calculus of Inductive Constructions:
 
 ```lino
 (inductive Nat
-  (zero : Nat)
-  (succ : (forall (n : Nat) Nat)))
+  (zero: Nat)
+  (succ: (forall (n: Nat) Nat)))
 ```
 
 ---
@@ -222,7 +222,7 @@ The **typing judgment** `Γ ⊢ e : T` ("in context Γ, expression e has type T"
 Which in LiNo could be:
 
 ```lino
-((e has type T) in (x₁ : A₁) (x₂ : A₂))
+((e has type T) in (x₁: A₁) (x₂: A₂))
 ```
 
 ---
@@ -241,28 +241,28 @@ Which in LiNo could be:
 (Type 1)
 
 # Type annotations
-(x : Nat)
-(f : (Pi (x : Nat) Nat))
+(x: Nat)
+(f: (Pi (x: Nat) Nat))
 
 # Dependent product (Π-type / forall)
-(Pi (x : Nat) (Vec x Bool))
+(Pi (x: Nat) (Vec x Bool))
 
 # Non-dependent function type (sugar for Pi where x doesn't appear in body)
 (Nat -> Bool)
 
 # Lambda abstraction
-(lam (x : Nat) (+ x 1))
+(lam (x: Nat) (+ x 1))
 
 # Application
-(app (lam (x : Nat) (+ x 1)) 3)
+(app (lam (x: Nat) (+ x 1)) 3)
 
 # Let binding
-(let (x : Nat) 5 (+ x 1))
+(let (x: Nat) 5 (+ x 1))
 
 # Inductive type definition
 (inductive Nat
-  (zero : Nat)
-  (succ : (Pi (n : Nat) Nat)))
+  (zero: Nat)
+  (succ: (Pi (n: Nat) Nat)))
 
 # Pattern matching
 (match n
@@ -270,11 +270,11 @@ Which in LiNo could be:
   ((succ m) => (+ 1 (f m))))
 
 # Type checking query
-(?type (lam (x : Nat) (+ x 1)))   # -> (Pi (x : Nat) Nat)
+(?type (lam (x: Nat) (+ x 1)))   # -> (Pi (x: Nat) Nat)
 
 # Proof term
 (theorem plus_comm
-  (Pi (a : Nat) (Pi (b : Nat) (= (+ a b) (+ b a))))
+  (Pi (a: Nat) (Pi (b: Nat) (= (+ a b) (+ b a))))
   proof_term)
 ```
 
@@ -288,7 +288,7 @@ Which in LiNo could be:
 (?type ((P x) has probability 0.8))   # -> Prop with confidence 0.8
 
 # Dependent type with probabilistic witness
-(Sigma (x : Nat) ((P x) has probability (> 0.5)))
+(Sigma (x: Nat) ((P x) has probability (> 0.5)))
 ```
 
 **Pros:**
@@ -325,13 +325,13 @@ LiNo text → LiNo Parser → AST
 (mode: types)
 
 # Now all expressions are type-checked
-(def Nat : (Type 0)
+(def Nat: (Type 0)
   (inductive
-    (zero : Nat)
-    (succ : (Pi (_ : Nat) Nat))))
+    (zero: Nat)
+    (succ: (Pi (_: Nat) Nat))))
 
-(def plus : (Pi (a : Nat) (Pi (b : Nat) Nat))
-  (lam (a : Nat) (lam (b : Nat)
+(def plus: (Pi (a: Nat) (Pi (b: Nat) Nat))
+  (lam (a: Nat) (lam (b: Nat)
     (match a
       (zero => b)
       ((succ n) => (succ (plus n b)))))))
@@ -368,39 +368,39 @@ This is inspired by the research paper ["A Type Theory for Probabilistic and Bay
 
 ```lino
 # Classical: P is either true or false
-(P : Prop)
+(P: Prop)
 
 # Probabilistic: P has a degree of truth
-(P : Prop 0.8)     # P is true with probability 0.8
+(P: Prop 0.8)     # P is true with probability 0.8
 
 # Dependent product with probabilistic types
-(Pi (x : Nat) (Prop (prob x)))   # A family of propositions with varying probability
+(Pi (x: Nat) (Prop (prob x)))   # A family of propositions with varying probability
 ```
 
 **Syntax in LiNo:**
 
 ```lino
 # Probabilistic Prop
-(PProp : (Type 0))
+(PProp: (Type 0))
 
 # A probabilistic proposition
-(raining : (PProp 0.7))       # "It is raining" with probability 0.7
+(raining: (PProp 0.7))       # "It is raining" with probability 0.7
 
 # Conditional probability as dependent type
-(umbrella_given_rain :
-  (Pi (r : (PProp p)) (PProp (cond_prob umbrella r))))
+(umbrella_given_rain:
+  (Pi (r: (PProp p)) (PProp (cond_prob umbrella r))))
 
 # Bayesian update as a type-theoretic operation
-(bayes :
-  (Pi (prior : (PProp p))
-  (Pi (likelihood : (Pi (_ : A) (PProp l)))
-  (Pi (evidence : (PProp e))
+(bayes:
+  (Pi (prior: (PProp p))
+  (Pi (likelihood: (Pi (_: A) (PProp l)))
+  (Pi (evidence: (PProp e))
   (PProp (bayesian_update p l e))))))
 
 # ADL's existing probability operations become type-theoretic
-(and : (Pi (a : (PProp p)) (Pi (b : (PProp q)) (PProp (agg_and p q)))))
-(or  : (Pi (a : (PProp p)) (Pi (b : (PProp q)) (PProp (agg_or p q)))))
-(not : (Pi (a : (PProp p)) (PProp (negate p))))
+(and: (Pi (a: (PProp p)) (Pi (b: (PProp q)) (PProp (agg_and p q)))))
+(or:  (Pi (a: (PProp p)) (Pi (b: (PProp q)) (PProp (agg_or p q)))))
+(not: (Pi (a: (PProp p)) (PProp (negate p))))
 ```
 
 **Pros:**

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -93,14 +93,14 @@ ADL is a **probabilistic logic framework** built on [Links Notation (LiNo)](http
 | Redefinable operators | Yes | `(and: min)`, `(!=: not =)` |
 | Decimal-precision arithmetic | Yes | `0.1 + 0.2 = 0.3` |
 | Paradox resolution | Yes | Liar paradox → midpoint |
-| **Type annotations** | **No** | No way to say `(x : Nat)` |
-| **Dependent products** | **No** | No `∀ (x : A), B` |
-| **Lambda abstraction** | **No** | No `λ (x : A), e` |
-| **Application** | **Partial** | Prefix operators exist but not general application |
-| **Universe hierarchy** | **No** | No `Type₀ : Type₁ : ...` |
-| **Substitution** | **No** | No β-reduction |
-| **Normalization** | **No** | No reduction to normal form |
-| **Type checking** | **No** | No judgment `Γ ⊢ e : T` |
+| **Type annotations** | **Yes** (v0.7.0) | `(x: Nat)` — typed declarations stored as links |
+| **Dependent products** | **Yes** (v0.7.0) | `(Pi (x: A) B)` — Π-types as links |
+| **Lambda abstraction** | **Yes** (v0.7.0) | `(lam (x: A) e)` — lambdas as links |
+| **Application** | **Yes** (v0.7.0) | `(app f x)` with β-reduction |
+| **Universe hierarchy** | **Yes** (v0.7.0) | `(Type 0)`, `(Type 1)`, ... |
+| **Substitution** | **Yes** (v0.7.0) | Full β-reduction with variable shadowing |
+| **Normalization** | **Partial** | Single-step β-reduction (no full normalization) |
+| **Type checking** | **Partial** | `type-of` queries and `?type` inference |
 
 ### LiNo Syntax Recap
 
@@ -517,20 +517,20 @@ In this approach, the entire type system is encoded as an associative network of
 
 ## Recommended Approach
 
-### Phase 1: Option A (Shallow Embedding) — Start Here
+### Phase 1: Option A (Shallow Embedding) — ✅ Implemented (v0.7.0)
 
-Begin by extending the ADL evaluator to handle the 5 core expression forms of the CoC. This is the minimum viable step:
+The ADL evaluator has been extended with all 5 core expression forms of the CoC:
 
-1. Add `(Type N)` as universe sorts
-2. Add `(Pi (x : A) B)` for dependent products
-3. Add `(lam (x : A) e)` for lambda abstraction
-4. Add `(app f x)` for application (or detect it from list structure)
-5. Implement substitution and β-reduction
-6. Implement basic type checking/inference
+1. ✅ `(Type N)` — universe sorts with automatic hierarchy `(Type 0) : (Type 1) : ...`
+2. ✅ `(Pi (x: A) B)` — dependent products (Π-types)
+3. ✅ `(lam (x: A) e)` — lambda abstraction with typed parameters
+4. ✅ `(app f x)` — application with full β-reduction
+5. ✅ Substitution with variable shadowing support
+6. ✅ Type checking via `type-of` queries and `?type` inference
 
-**Estimated scope:** ~500 lines of new code per implementation (JS + Rust), plus ~100 new tests.
+**Implementation:** ~500 lines of new code in each implementation (JS + Rust), plus 41 new tests each (all backward-compatible with existing 122 tests).
 
-This can be done using [VictorTaelin's CoC implementation](https://github.com/VictorTaelin/calculus-of-constructions) as a reference for the JavaScript side, and the [Typechecker Zoo](https://sdiehl.github.io/typechecker-zoo/coc/calculus-of-constructions.html) for the Rust side.
+**Key design principle:** "Everything is a link" — types are stored as associations in the link network, type-checking is querying the network, and the type system coexists with the probabilistic logic engine.
 
 ### Phase 2: Option C (Probabilistic Extension) — The Novel Contribution
 

--- a/docs/case-studies/issue-13/README.md
+++ b/docs/case-studies/issue-13/README.md
@@ -93,14 +93,14 @@ ADL is a **probabilistic logic framework** built on [Links Notation (LiNo)](http
 | Redefinable operators | Yes | `(and: min)`, `(!=: not =)` |
 | Decimal-precision arithmetic | Yes | `0.1 + 0.2 = 0.3` |
 | Paradox resolution | Yes | Liar paradox → midpoint |
-| **Type annotations** | **Yes** (v0.7.0) | `(x: Nat)` — typed declarations stored as links |
-| **Dependent products** | **Yes** (v0.7.0) | `(Pi (x: A) B)` — Π-types as links |
-| **Lambda abstraction** | **Yes** (v0.7.0) | `(lam (x: A) e)` — lambdas as links |
-| **Application** | **Yes** (v0.7.0) | `(app f x)` with β-reduction |
+| **Type annotations** | **Yes** (v0.7.0) | `(x: Natural x)` — prefix type notation stored as links |
+| **Dependent products** | **Yes** (v0.7.0) | `(Pi (Natural x) B)` — Π-types as links |
+| **Lambda abstraction** | **Yes** (v0.7.0) | `(lambda (Natural x) e)` — lambdas as links |
+| **Application** | **Yes** (v0.7.0) | `(apply f x)` with β-reduction |
 | **Universe hierarchy** | **Yes** (v0.7.0) | `(Type 0)`, `(Type 1)`, ... |
 | **Substitution** | **Yes** (v0.7.0) | Full β-reduction with variable shadowing |
 | **Normalization** | **Partial** | Single-step β-reduction (no full normalization) |
-| **Type checking** | **Partial** | `type-of` queries and `?type` inference |
+| **Type checking** | **Partial** | `(expr of Type)` queries and `(type of expr)` inference |
 
 ### LiNo Syntax Recap
 
@@ -126,8 +126,8 @@ To define the core of Lean/Rocq within ADL, we need to add these capabilities:
 Currently, `(a: a is a)` defines a term. We need a way to **annotate terms with types**:
 
 ```lino
-(a: Nat)          # a has type Nat
-(f: Nat -> Bool)  # f is a function from Nat to Bool
+(a: Natural a)          # a has type Natural (prefix type notation)
+(f: (Type 0) f)         # f is a type
 ```
 
 ### 2. Dependent Products (Π-types)
@@ -135,7 +135,7 @@ Currently, `(a: a is a)` defines a term. We need a way to **annotate terms with 
 The ability to express types that depend on values:
 
 ```lino
-(forall (n: Nat) (Vec n Nat))   # For all n:Nat, the type Vec n Nat
+(forall (Natural n) (Vec n Natural))   # For all n:Natural, the type Vec n Natural
 ```
 
 ### 3. Lambda Abstraction
@@ -143,7 +143,7 @@ The ability to express types that depend on values:
 The ability to create functions:
 
 ```lino
-(lambda (x: Nat) (x + 1))      # A function that adds 1
+(lambda (Natural x) (x + 1))      # A function that adds 1
 ```
 
 ### 4. Application and β-Reduction
@@ -151,7 +151,7 @@ The ability to create functions:
 Applying a function to an argument and reducing:
 
 ```lino
-((lambda (x: Nat) (x + 1)) 3)  # Should reduce to 4
+((lambda (Natural x) (x + 1)) 3)  # Should reduce to 4
 ```
 
 ### 5. Universe Hierarchy
@@ -159,7 +159,7 @@ Applying a function to an argument and reducing:
 A hierarchy of types:
 
 ```lino
-(Type 0)    # The type of "small" types (Nat, Bool, etc.)
+(Type 0)    # The type of "small" types (Natural, Boolean, etc.)
 (Type 1)    # The type of Type 0
 ```
 
@@ -168,9 +168,9 @@ A hierarchy of types:
 For the full Calculus of Inductive Constructions:
 
 ```lino
-(inductive Nat
-  (zero: Nat)
-  (succ: (forall (n: Nat) Nat)))
+(inductive Natural
+  (zero: Natural zero)
+  (succ: (forall (Natural n) Natural)))
 ```
 
 ---
@@ -186,8 +186,8 @@ The [Links Theory](https://github.com/link-foundation/deep-theory) (Deep Theory)
 
 This maps naturally to dependent type theory, where **terms and types are the same syntactic category**. In the CoC:
 
-- A type is just a term: `Nat` is a term of type `Type₀`
-- A function type is just a term: `Nat → Bool` is a term of type `Type₀`
+- A type is just a term: `Natural` is a term of type `Type₀`
+- A function type is just a term: `Natural → Boolean` is a term of type `Type₀`
 - A proof is just a term: a proof of `P` is a term of type `P`
 
 In Links Theory:
@@ -222,7 +222,7 @@ The **typing judgment** `Γ ⊢ e : T` ("in context Γ, expression e has type T"
 Which in LiNo could be:
 
 ```lino
-((e has type T) in (x₁: A₁) (x₂: A₂))
+((e has type T) in (A₁ x₁) (A₂ x₂))
 ```
 
 ---
@@ -240,41 +240,41 @@ Which in LiNo could be:
 (Type 0)
 (Type 1)
 
-# Type annotations
-(x: Nat)
-(f: (Pi (x: Nat) Nat))
+# Type annotations (prefix type notation)
+(x: Natural x)
+(f: (Pi (Natural x) Natural) f)
 
 # Dependent product (Π-type / forall)
-(Pi (x: Nat) (Vec x Bool))
+(Pi (Natural x) (Vec x Boolean))
 
 # Non-dependent function type (sugar for Pi where x doesn't appear in body)
-(Nat -> Bool)
+(Natural -> Boolean)
 
 # Lambda abstraction
-(lam (x: Nat) (+ x 1))
+(lambda (Natural x) (x + 1))
 
 # Application
-(app (lam (x: Nat) (+ x 1)) 3)
+(apply (lambda (Natural x) (x + 1)) 3)
 
 # Let binding
-(let (x: Nat) 5 (+ x 1))
+(let (Natural x) 5 (x + 1))
 
 # Inductive type definition
-(inductive Nat
-  (zero: Nat)
-  (succ: (Pi (n: Nat) Nat)))
+(inductive Natural
+  (zero: Natural zero)
+  (succ: (Pi (Natural n) Natural)))
 
 # Pattern matching
 (match n
   (zero => 0)
   ((succ m) => (+ 1 (f m))))
 
-# Type checking query
-(?type (lam (x: Nat) (+ x 1)))   # -> (Pi (x: Nat) Nat)
+# Type inference query
+(? (type of (lambda (Natural x) (x + 1))))   # -> (Pi (Natural x) Natural)
 
 # Proof term
 (theorem plus_comm
-  (Pi (a: Nat) (Pi (b: Nat) (= (+ a b) (+ b a))))
+  (Pi (Natural a) (Pi (Natural b) (= (a + b) (b + a))))
   proof_term)
 ```
 
@@ -284,11 +284,11 @@ Which in LiNo could be:
 # A proposition with probability
 ((P x) has probability 0.8)
 
-# Type-checked with probability
-(?type ((P x) has probability 0.8))   # -> Prop with confidence 0.8
+# Type inference with probability
+(? (type of ((P x) has probability 0.8)))   # -> Prop with confidence 0.8
 
 # Dependent type with probabilistic witness
-(Sigma (x: Nat) ((P x) has probability (> 0.5)))
+(Sigma (Natural x) ((P x) has probability (> 0.5)))
 ```
 
 **Pros:**
@@ -325,13 +325,13 @@ LiNo text → LiNo Parser → AST
 (mode: types)
 
 # Now all expressions are type-checked
-(def Nat: (Type 0)
+(def Natural: (Type 0)
   (inductive
-    (zero: Nat)
-    (succ: (Pi (_: Nat) Nat))))
+    (zero: Natural zero)
+    (succ: (Pi (Natural _) Natural))))
 
-(def plus: (Pi (a: Nat) (Pi (b: Nat) Nat))
-  (lam (a: Nat) (lam (b: Nat)
+(def plus: (Pi (Natural a) (Pi (Natural b) Natural))
+  (lambda (Natural a) (lambda (Natural b)
     (match a
       (zero => b)
       ((succ n) => (succ (plus n b)))))))
@@ -374,7 +374,7 @@ This is inspired by the research paper ["A Type Theory for Probabilistic and Bay
 (P: Prop 0.8)     # P is true with probability 0.8
 
 # Dependent product with probabilistic types
-(Pi (x: Nat) (Prop (prob x)))   # A family of propositions with varying probability
+(Pi (Natural x) (Prop (prob x)))   # A family of propositions with varying probability
 ```
 
 **Syntax in LiNo:**
@@ -388,19 +388,19 @@ This is inspired by the research paper ["A Type Theory for Probabilistic and Bay
 
 # Conditional probability as dependent type
 (umbrella_given_rain:
-  (Pi (r: (PProp p)) (PProp (cond_prob umbrella r))))
+  (Pi (PProp p) r) (PProp (cond_prob umbrella r))))
 
 # Bayesian update as a type-theoretic operation
 (bayes:
-  (Pi (prior: (PProp p))
-  (Pi (likelihood: (Pi (_: A) (PProp l)))
-  (Pi (evidence: (PProp e))
-  (PProp (bayesian_update p l e))))))
+  (Pi (PProp p) prior)
+  (Pi (Pi (A _) (PProp l)) likelihood)
+  (Pi (PProp e) evidence)
+  (PProp (bayesian_update p l e)))))
 
 # ADL's existing probability operations become type-theoretic
-(and: (Pi (a: (PProp p)) (Pi (b: (PProp q)) (PProp (agg_and p q)))))
-(or:  (Pi (a: (PProp p)) (Pi (b: (PProp q)) (PProp (agg_or p q)))))
-(not: (Pi (a: (PProp p)) (PProp (negate p))))
+(and: (Pi (PProp p) a) (Pi (PProp q) b) (PProp (agg_and p q)))))
+(or:  (Pi (PProp p) a) (Pi (PProp q) b) (PProp (agg_or p q)))))
+(not: (Pi (PProp p) a) (PProp (negate p))))
 ```
 
 **Pros:**
@@ -427,40 +427,40 @@ In this approach, the entire type system is encoded as an associative network of
 ```lino
 # Everything is a link. A link has an ID and references other links.
 
-# Define the concept "type-of" as a link
-(type-of: type-of is type-of)
+# Define the concept "of" as a link
+(of: of is of)
 
 # Define universe levels as links
 (Type-0: Type-0 is Type-0)
 (Type-1: Type-1 is Type-1)
-((Type-0 type-of Type-1) has probability 1)   # Type₀ : Type₁
+((Type-0 of Type-1) has probability 1)   # Type₀ : Type₁
 
-# Define Nat as a link of type Type-0
-(Nat: Nat is Nat)
-((Nat type-of Type-0) has probability 1)       # Nat : Type₀
+# Define Natural as a link of type Type-0
+(Natural: Natural is Natural)
+((Natural of Type-0) has probability 1)       # Natural : Type₀
 
-# Define zero as a link of type Nat
+# Define zero as a link of type Natural
 (zero: zero is zero)
-((zero type-of Nat) has probability 1)         # zero : Nat
+((zero of Natural) has probability 1)         # zero : Natural
 
 # Define succ as a function link
 (succ: succ is succ)
-((succ type-of (Pi Nat Nat)) has probability 1)  # succ : Nat → Nat
+((succ of (Pi Natural Natural)) has probability 1)  # succ : Natural → Natural
 
 # Dependent product as a link pattern
 (Pi: Pi is Pi)
-((Pi type-of (Pi Type-0 (Pi Type-0 Type-0))) has probability 1)
+((Pi of (Pi Type-0 (Pi Type-0 Type-0))) has probability 1)
 
 # Application: (succ zero) is a link
 ((succ zero): (succ zero) is (succ zero))
-((succ zero) type-of Nat)
+((succ zero) of Natural)
 
 # Lambda: represented as a link with binding structure
 (lambda: lambda is lambda)
-((lambda x Nat (+ x 1)) type-of (Pi Nat Nat))
+((lambda x Natural (x + 1)) of (Pi Natural Natural))
 ```
 
-**The key principle:** Every construct (type, term, function, proof) is just a link with other links indicating its relationships (type-of, reduces-to, equivalent-to).
+**The key principle:** Every construct (type, term, function, proof) is just a link with other links indicating its relationships (of, reduces-to, equivalent-to).
 
 **Pros:**
 - Maximally faithful to Links Theory and the associative model
@@ -522,13 +522,13 @@ In this approach, the entire type system is encoded as an associative network of
 The ADL evaluator has been extended with all 5 core expression forms of the CoC:
 
 1. ✅ `(Type N)` — universe sorts with automatic hierarchy `(Type 0) : (Type 1) : ...`
-2. ✅ `(Pi (x: A) B)` — dependent products (Π-types)
-3. ✅ `(lam (x: A) e)` — lambda abstraction with typed parameters
-4. ✅ `(app f x)` — application with full β-reduction
+2. ✅ `(Pi (Natural x) B)` — dependent products (Π-types)
+3. ✅ `(lambda (Natural x) e)` — lambda abstraction with typed parameters
+4. ✅ `(apply f x)` — application with full β-reduction
 5. ✅ Substitution with variable shadowing support
-6. ✅ Type checking via `type-of` queries and `?type` inference
+6. ✅ Type checking via `(expr of Type)` queries and `(? (type of expr))` inference
 
-**Implementation:** ~500 lines of new code in each implementation (JS + Rust), plus 41 new tests each (all backward-compatible with existing 122 tests).
+**Implementation:** ~500 lines of new code in each implementation (JS + Rust), plus 46 new tests each (all backward-compatible with existing 124 tests).
 
 **Key design principle:** "Everything is a link" — types are stored as associations in the link network, type-checking is querying the network, and the type system coexists with the probabilistic logic engine.
 

--- a/docs/case-studies/issue-13/existing-tools.md
+++ b/docs/case-studies/issue-13/existing-tools.md
@@ -1,0 +1,147 @@
+# Existing Tools and Libraries Analysis
+
+This document catalogs existing implementations, libraries, and academic work that can help implement dependent types in the ADL/LiNo system.
+
+## Tier 1: Directly Usable (JavaScript + Rust)
+
+### calculus-of-constructions (JavaScript)
+
+- **Repository:** [VictorTaelin/calculus-of-constructions](https://github.com/VictorTaelin/calculus-of-constructions)
+- **npm:** [calculus-of-constructions](https://www.npmjs.com/package/calculus-of-constructions)
+- **Size:** ~400 lines, ~2.3kb minified
+- **Features:** Full CoC with type checking, normalization, parsing
+- **API:** `CoC.read()`, `CoC.type()`, `CoC.norm()`, `CoC.show()`
+- **Approach:** HOAS (Higher-Order Abstract Syntax) — no explicit substitution
+- **Why relevant:** Could be used as the type-checking backend for ADL's JavaScript implementation. The LiNo AST could be translated to CoC terms, type-checked, and results mapped back.
+
+### FormCoreJS (JavaScript)
+
+- **Repository:** [HigherOrderCO/FormCoreJS](https://github.com/HigherOrderCO/FormCoreJS)
+- **npm:** [formcore-js](https://www.npmjs.com/package/formcore-js)
+- **Size:** ~700 lines, zero dependencies
+- **Features:** Self-dependent types, inductive reasoning, compilation to efficient JS
+- **Why relevant:** More powerful than basic CoC (has self types for inductive reasoning). This is the kernel of Kind, a full proof assistant. Very small and auditable — follows the de Bruijn criterion.
+
+### Typechecker Zoo — CoC (Rust)
+
+- **Website:** [sdiehl.github.io/typechecker-zoo/coc](https://sdiehl.github.io/typechecker-zoo/coc/calculus-of-constructions.html)
+- **Features:** Full CoC implementation in Rust with bidirectional type checking, universe hierarchy, dependent products, Σ-types, constraint solving
+- **Why relevant:** Reference implementation for the Rust side of ADL. Uses standard Rust enum for term representation.
+
+### links-notation (JavaScript + Rust)
+
+- **npm:** [links-notation](https://www.npmjs.com/package/links-notation) (v0.13.0)
+- **crate:** [links-notation](https://crates.io/crates/links-notation) (v0.13.0)
+- **Status:** Already integrated in ADL
+- **Why relevant:** The parser is already there. No new parsing infrastructure needed — new constructs like `(Pi ...)`, `(lam ...)` are just new LiNo expressions with new evaluation rules.
+
+## Tier 2: Reference Implementations (Other Languages)
+
+### elaboration-zoo (Haskell)
+
+- **Repository:** [AndrasKovacs/elaboration-zoo](https://github.com/AndrasKovacs/elaboration-zoo)
+- **Features:** Progressive series of dependent type elaboration implementations
+- **Coverage:** Basics of unification, inference, implicit argument handling
+- **Why relevant:** Best pedagogical resource for understanding how elaboration (the process of turning user-friendly syntax into core type theory) works. Each package adds one feature.
+
+### nano-Agda (Haskell)
+
+- **Repository:** [jyp/nano-Agda](https://github.com/jyp/nano-Agda)
+- **Size:** ~200 lines
+- **Based on:** "A Tutorial Implementation of a Dependently Typed Lambda Calculus" (Löh, McBride, Swierstra)
+- **Why relevant:** Minimal working example showing exactly what's needed.
+
+### LaTTe Kernel (Clojure/ClojureScript)
+
+- **Repository:** [latte-central/latte-kernel](https://github.com/latte-central/latte-kernel)
+- **Features:** Small trusted kernel for a proof assistant
+- **Principle:** Follows the de Bruijn criterion — small code base that can be independently verified
+- **Why relevant:** Shows how to build a minimal kernel that's correct by design. Could inform the architecture of ADL's type checker.
+
+### tt (OCaml, by Andrej Bauer)
+
+- **Tutorial:** [How to implement dependent type theory I](https://math.andrej.com/2012/11/08/how-to-implement-dependent-type-theory-i/)
+- **Tutorial Part II:** [How to implement dependent type theory II](https://math.andrej.com/2012/11/11/how-to-implement-dependent-type-theory-ii/)
+- **Size:** ~92 lines of core logic
+- **Features:** Variables, universes, Π-types, λ, application, substitution, normalization, type checking
+- **Why relevant:** The gold standard for "how small can a dependent type checker be?" Clear code, excellent documentation.
+
+### Interaction-Type-Theory (Rust)
+
+- **Repository:** [VictorTaelin/Interaction-Type-Theory](https://github.com/VictorTaelin/Interaction-Type-Theory)
+- **Features:** CoC via interaction combinators + a "Decay" rule
+- **Why relevant:** Novel approach that represents type theory as a graph rewriting system. This is conceptually close to the associative model where everything is links/nodes.
+
+## Tier 3: Academic Papers
+
+### A Type Theory for Probabilistic and Bayesian Reasoning
+
+- **Authors:** Robin Adams, Bart Jacobs
+- **Year:** 2015
+- **arXiv:** [1511.09230](https://arxiv.org/abs/1511.09230)
+- **Published:** LIPIcs, TYPES 2015
+- **Key contribution:** COMET system — type theory with fuzzy predicates, normalization, and conditioning of probabilistic states. Shows how to do Bayesian inference as type-theoretic operations.
+- **Why relevant:** Provides the theoretical foundation for Option C (Probabilistic Dependent Type Theory). This is the closest academic work to what ADL would become.
+
+### A Probabilistic Dependent Type System based on Non-Deterministic Beta Reduction
+
+- **Year:** 2016
+- **arXiv:** [1602.06420](https://arxiv.org/abs/1602.06420)
+- **Key contribution:** Extends intuitionistic type theory (dependent sums and products) with stochastic functions via non-deterministic β-reduction.
+- **Why relevant:** Shows how to add randomness/probability directly into the reduction rules of type theory, rather than as an external layer.
+
+### Probabilistic Type Theory and Natural Language Semantics
+
+- **Author:** Robin Cooper
+- **Published:** LILT 2015
+- **Key contribution:** Uses TTR (Type Theory with Records) with probabilistic judgments for natural language semantics.
+- **Why relevant:** Shows real-world application of probabilistic type theory, specifically for modeling gradience in meaning (not just true/false).
+
+### Propositions as Types
+
+- **Author:** Philip Wadler
+- **Year:** 2015
+- **PDF:** [propositions-as-types.pdf](https://homepages.inf.ed.ac.uk/wadler/papers/propositions-as-types/propositions-as-types.pdf)
+- **Why relevant:** Definitive accessible overview of the Curry-Howard correspondence, which underpins the entire connection between logic (ADL) and type theory (Lean/Rocq).
+
+## Integration Strategy
+
+### For JavaScript Implementation
+
+1. **Quick start:** Use `calculus-of-constructions` npm package as backend
+2. **Translation layer:** Convert LiNo AST ↔ CoC terms
+3. **Extended features:** Port additional features from `formcore-js` as needed
+
+```javascript
+import { parse as parseLiNo } from 'links-notation';
+import CoC from 'calculus-of-constructions';
+
+function typeCheck(linoSource) {
+  const links = parseLiNo(linoSource);
+  const cocTerms = translateToCoC(links);  // LiNo AST → CoC terms
+  return CoC.type(cocTerms);               // Type inference
+}
+```
+
+### For Rust Implementation
+
+1. **Reference:** Use Typechecker Zoo CoC implementation as starting point
+2. **Custom implementation:** Write a minimal type checker (~300-500 lines) that operates on the existing ADL AST
+3. **Integration:** Add type checking as an optional mode alongside probabilistic evaluation
+
+```rust
+use links_notation::parse_lino_to_links;
+
+fn type_check(source: &str) -> Result<Type, TypeError> {
+    let links = parse_lino_to_links(source);
+    let ast = parse_to_typed_ast(links)?;
+    infer_type(&Context::new(), &ast)
+}
+```
+
+### Incremental Path
+
+1. **v0.7.0:** Add `(Type N)`, `(Pi ...)`, `(lam ...)`, `(app ...)` — basic CoC
+2. **v0.8.0:** Add inductive types, pattern matching
+3. **v0.9.0:** Add probabilistic propositions (PProp)
+4. **v1.0.0:** Self-describing meta-theory (the system can describe its own type rules)

--- a/docs/case-studies/issue-13/syntax-comparison.md
+++ b/docs/case-studies/issue-13/syntax-comparison.md
@@ -137,8 +137,8 @@ Inductive nat : Set :=
 ```lino
 # LiNo (Proposed)
 (inductive Nat (Type 0)
-  (zero : Nat)
-  (succ : (Pi (_ : Nat) Nat)))
+  (zero: Nat)
+  (succ: (Pi (_: Nat) Nat)))
 ```
 
 ### 9. Pattern Matching / Recursion 📋
@@ -161,8 +161,8 @@ Fixpoint add (a b : nat) : nat :=
 
 ```lino
 # LiNo (Proposed)
-(def add : (Pi (a : Nat) (Pi (b : Nat) Nat))
-  (lam (a : Nat) (lam (b : Nat)
+(def add: (Pi (a: Nat) (Pi (b: Nat) Nat))
+  (lam (a: Nat) (lam (b: Nat)
     (match a
       (zero => b)
       ((succ n) => (succ (add n b)))))))
@@ -191,8 +191,8 @@ Qed.
 ```lino
 # LiNo (Proposed) - explicit proof term
 (theorem plus_zero
-  : (Pi (n : Nat) (= (+ n zero) n))
-  (lam (n : Nat)
+  : (Pi (n: Nat) (= (+ n zero) n))
+  (lam (n: Nat)
     (match n
       (zero => (refl zero))
       ((succ m) => (cong succ (plus_zero m))))))
@@ -216,9 +216,9 @@ exists n : nat, n > 0
 
 ```lino
 # LiNo (Proposed)
-(Sigma (n : Nat) (> n 0))
+(Sigma (n: Nat) (> n 0))
 # or:
-(exists (n : Nat) (> n 0))
+(exists (n: Nat) (> n 0))
 ```
 
 ## Integration with ADL Probabilistic Logic
@@ -233,11 +233,11 @@ exists n : nat, n > 0
 ((raining today) has probability 0.7)
 
 # Type-checked probabilistic proposition
-(raining : (PProp 0.7))
+(raining: (PProp 0.7))
 
 # Query type
-(?type (lam (x : Nat) (+ x 1)))
-# Output: (Pi (x : Nat) Nat)
+(?type (lam (x: Nat) (+ x 1)))
+# Output: (Pi (x: Nat) Nat)
 
 # Query probability
 (? (raining today))
@@ -249,9 +249,9 @@ exists n : nat, n > 0
 ```lino
 # Define a type
 (inductive Weather (Type 0)
-  (sunny : Weather)
-  (rainy : Weather)
-  (cloudy : Weather))
+  (sunny: Weather)
+  (rainy: Weather)
+  (cloudy: Weather))
 
 # Assign probabilities to inhabitants
 ((sunny has probability 0.3) in Weather)
@@ -259,7 +259,7 @@ exists n : nat, n > 0
 ((cloudy has probability 0.2) in Weather)
 
 # Dependent type with probabilistic index
-(forecast : (Pi (w : Weather) (PProp (weather_prob w))))
+(forecast: (Pi (w: Weather) (PProp (weather_prob w))))
 ```
 
 ## Encoding in Pure Associative Links

--- a/docs/case-studies/issue-13/syntax-comparison.md
+++ b/docs/case-studies/issue-13/syntax-comparison.md
@@ -25,8 +25,8 @@ Variable x : nat.
 ```
 
 ```lino
-# LiNo (Implemented)
-(x: Nat)
+# LiNo (Implemented) — prefix type notation
+(x: Natural x)
 ```
 
 ### 3. Function Types (Non-Dependent) ✅
@@ -43,7 +43,7 @@ nat -> bool
 
 ```lino
 # LiNo (Implemented)
-(Pi (_: Nat) Bool)
+(Pi (Natural _) Boolean)
 ```
 
 ### 4. Dependent Product (Π-Type / Forall) ✅
@@ -62,7 +62,7 @@ forall (n : nat), Vec n bool
 
 ```lino
 # LiNo (Implemented)
-(Pi (n: Nat) (Vec n Bool))
+(Pi (Natural n) (Vec n Boolean))
 ```
 
 ### 5. Lambda Abstraction ✅
@@ -79,7 +79,7 @@ fun (x : nat) => x + 1
 
 ```lino
 # LiNo (Implemented)
-(lam (x: Nat) (+ x 1))
+(lambda (Natural x) (x + 1))
 ```
 
 ### 6. Function Application ✅
@@ -98,7 +98,7 @@ f x y z
 
 ```lino
 # LiNo (Implemented)
-(app f x)
+(apply f x)
 ```
 
 ### 7. Let Binding 📋
@@ -115,7 +115,7 @@ let x : nat := 5 in x + 1
 
 ```lino
 # LiNo (Proposed)
-(let (x: Nat) 5 (+ x 1))
+(let (Natural x) 5 (x + 1))
 ```
 
 ### 8. Inductive Type Definitions 📋
@@ -136,9 +136,9 @@ Inductive nat : Set :=
 
 ```lino
 # LiNo (Proposed)
-(inductive Nat (Type 0)
-  (zero: Nat)
-  (succ: (Pi (_: Nat) Nat)))
+(inductive Natural (Type 0)
+  (zero: Natural zero)
+  (succ: (Pi (Natural _) Natural)))
 ```
 
 ### 9. Pattern Matching / Recursion 📋
@@ -161,8 +161,8 @@ Fixpoint add (a b : nat) : nat :=
 
 ```lino
 # LiNo (Proposed)
-(def add: (Pi (a: Nat) (Pi (b: Nat) Nat))
-  (lam (a: Nat) (lam (b: Nat)
+(def add: (Pi (Natural a) (Pi (Natural b) Natural))
+  (lambda (Natural a) (lambda (Natural b)
     (match a
       (zero => b)
       ((succ n) => (succ (add n b)))))))
@@ -191,8 +191,8 @@ Qed.
 ```lino
 # LiNo (Proposed) - explicit proof term
 (theorem plus_zero
-  : (Pi (n: Nat) (= (+ n zero) n))
-  (lam (n: Nat)
+  : (Pi (Natural n) (= (n + zero) n))
+  (lambda (Natural n)
     (match n
       (zero => (refl zero))
       ((succ m) => (cong succ (plus_zero m))))))
@@ -216,9 +216,9 @@ exists n : nat, n > 0
 
 ```lino
 # LiNo (Proposed)
-(Sigma (n: Nat) (> n 0))
+(Sigma (Natural n) (> n 0))
 # or:
-(exists (n: Nat) (> n 0))
+(exists (Natural n) (> n 0))
 ```
 
 ## Integration with ADL Probabilistic Logic
@@ -236,8 +236,8 @@ exists n : nat, n > 0
 (raining: (PProp 0.7))
 
 # Query type
-(?type (lam (x: Nat) (+ x 1)))
-# Output: (Pi (x: Nat) Nat)
+(? (type of (lambda (Natural x) (x + 1))))
+# Output: (Pi (Natural x) Natural)
 
 # Query probability
 (? (raining today))
@@ -249,9 +249,9 @@ exists n : nat, n > 0
 ```lino
 # Define a type
 (inductive Weather (Type 0)
-  (sunny: Weather)
-  (rainy: Weather)
-  (cloudy: Weather))
+  (sunny: Weather sunny)
+  (rainy: Weather rainy)
+  (cloudy: Weather cloudy))
 
 # Assign probabilities to inhabitants
 ((sunny has probability 0.3) in Weather)
@@ -259,7 +259,7 @@ exists n : nat, n > 0
 ((cloudy has probability 0.2) in Weather)
 
 # Dependent type with probabilistic index
-(forecast: (Pi (w: Weather) (PProp (weather_prob w))))
+(forecast: (Pi (Weather w) (PProp (weather_prob w))))
 ```
 
 ## Encoding in Pure Associative Links
@@ -268,40 +268,40 @@ For completeness, here is how the above would look using only the associative li
 
 ```lino
 # Define meta-concepts as links
-(type-of: type-of is type-of)
+(of: of is of)
 (reduces-to: reduces-to is reduces-to)
 (has-constructor: has-constructor is has-constructor)
 
 # Universe hierarchy
 (Type-0: Type-0 is Type-0)
 (Type-1: Type-1 is Type-1)
-((Type-0 type-of Type-1) has probability 1)
+((Type-0 of Type-1) has probability 1)
 
-# Nat type
-(Nat: Nat is Nat)
-((Nat type-of Type-0) has probability 1)
+# Natural type
+(Natural: Natural is Natural)
+((Natural of Type-0) has probability 1)
 
 # Constructors
 (zero: zero is zero)
-((zero type-of Nat) has probability 1)
-((Nat has-constructor zero) has probability 1)
+((zero of Natural) has probability 1)
+((Natural has-constructor zero) has probability 1)
 
 (succ: succ is succ)
-((succ type-of (Pi Nat Nat)) has probability 1)
-((Nat has-constructor succ) has probability 1)
+((succ of (Pi Natural Natural)) has probability 1)
+((Natural has-constructor succ) has probability 1)
 
 # A function: add
 (add: add is add)
-((add type-of (Pi Nat (Pi Nat Nat))) has probability 1)
+((add of (Pi Natural (Pi Natural Natural))) has probability 1)
 
 # Reduction rules as links
 (((add zero b) reduces-to b) has probability 1)
 (((add (succ n) b) reduces-to (succ (add n b))) has probability 1)
 
 # Type checking is querying the network
-(? (zero type-of Nat))          # -> 1 (true)
-(? (succ type-of (Pi Nat Nat))) # -> 1 (true)
-(? ((succ zero) type-of Nat))   # -> 1 (true, by reduction)
+(? (zero of Natural))                    # -> 1 (true)
+(? (succ of (Pi Natural Natural)))       # -> 1 (true)
+(? ((succ zero) of Natural))             # -> 1 (true, by reduction)
 ```
 
 This encoding treats the entire type system as data within the associative network, which aligns with the Links Theory principle that everything is a link.

--- a/docs/case-studies/issue-13/syntax-comparison.md
+++ b/docs/case-studies/issue-13/syntax-comparison.md
@@ -1,18 +1,18 @@
-# Syntax Comparison: Lean 4 / Rocq / LiNo (Proposed)
+# Syntax Comparison: Lean 4 / Rocq / LiNo
 
-This document shows how core dependent type theory constructs would look in Lean 4, Rocq, and our proposed LiNo encoding.
+This document shows how core dependent type theory constructs look in Lean 4, Rocq, and our LiNo encoding. Items marked ✅ are implemented in v0.7.0; items marked 📋 are proposed for future phases.
 
 ## Core Constructs
 
-### 1. Universe Sorts
+### 1. Universe Sorts ✅
 
-| Concept | Lean 4 | Rocq | LiNo (Proposed) |
-|---------|--------|------|-----------------|
+| Concept | Lean 4 | Rocq | LiNo |
+|---------|--------|------|------|
 | Type of small types | `Type` or `Type 0` | `Set` or `Type` | `(Type 0)` |
 | Type of types | `Type 1` | `Type` | `(Type 1)` |
 | Propositions | `Prop` | `Prop` | `(Prop)` or `(Type 0)` |
 
-### 2. Variable Declarations
+### 2. Variable Declarations ✅
 
 ```lean
 -- Lean 4
@@ -25,11 +25,11 @@ Variable x : nat.
 ```
 
 ```lino
-# LiNo (Proposed)
-(x : Nat)
+# LiNo (Implemented)
+(x: Nat)
 ```
 
-### 3. Function Types (Non-Dependent)
+### 3. Function Types (Non-Dependent) ✅
 
 ```lean
 -- Lean 4
@@ -42,13 +42,11 @@ nat -> bool
 ```
 
 ```lino
-# LiNo (Proposed)
-(Pi (_ : Nat) Bool)
-# or sugar:
-(Nat -> Bool)
+# LiNo (Implemented)
+(Pi (_: Nat) Bool)
 ```
 
-### 4. Dependent Product (Π-Type / Forall)
+### 4. Dependent Product (Π-Type / Forall) ✅
 
 ```lean
 -- Lean 4
@@ -63,13 +61,11 @@ forall (n : nat), Vec n bool
 ```
 
 ```lino
-# LiNo (Proposed)
-(Pi (n : Nat) (Vec n Bool))
-# or:
-(forall (n : Nat) (Vec n Bool))
+# LiNo (Implemented)
+(Pi (n: Nat) (Vec n Bool))
 ```
 
-### 5. Lambda Abstraction
+### 5. Lambda Abstraction ✅
 
 ```lean
 -- Lean 4
@@ -82,13 +78,11 @@ fun (x : nat) => x + 1
 ```
 
 ```lino
-# LiNo (Proposed)
-(lam (x : Nat) (+ x 1))
-# or:
-(fun (x : Nat) (+ x 1))
+# LiNo (Implemented)
+(lam (x: Nat) (+ x 1))
 ```
 
-### 6. Function Application
+### 6. Function Application ✅
 
 ```lean
 -- Lean 4
@@ -103,14 +97,11 @@ f x y z
 ```
 
 ```lino
-# LiNo (Proposed)
-(f x)
-(f x y z)
-# Note: multi-argument application is sugar for nested applications:
-# (f x y z) = (((f x) y) z)
+# LiNo (Implemented)
+(app f x)
 ```
 
-### 7. Let Binding
+### 7. Let Binding 📋
 
 ```lean
 -- Lean 4
@@ -124,10 +115,10 @@ let x : nat := 5 in x + 1
 
 ```lino
 # LiNo (Proposed)
-(let (x : Nat) 5 (+ x 1))
+(let (x: Nat) 5 (+ x 1))
 ```
 
-### 8. Inductive Type Definitions
+### 8. Inductive Type Definitions 📋
 
 ```lean
 -- Lean 4
@@ -150,7 +141,7 @@ Inductive nat : Set :=
   (succ : (Pi (_ : Nat) Nat)))
 ```
 
-### 9. Pattern Matching / Recursion
+### 9. Pattern Matching / Recursion 📋
 
 ```lean
 -- Lean 4
@@ -177,7 +168,7 @@ Fixpoint add (a b : nat) : nat :=
       ((succ n) => (succ (add n b)))))))
 ```
 
-### 10. Propositions and Proofs
+### 10. Propositions and Proofs 📋
 
 ```lean
 -- Lean 4
@@ -207,7 +198,7 @@ Qed.
       ((succ m) => (cong succ (plus_zero m))))))
 ```
 
-### 11. Dependent Sum (Σ-Type / Exists)
+### 11. Dependent Sum (Σ-Type / Exists) 📋
 
 ```lean
 -- Lean 4

--- a/docs/case-studies/issue-13/syntax-comparison.md
+++ b/docs/case-studies/issue-13/syntax-comparison.md
@@ -1,0 +1,316 @@
+# Syntax Comparison: Lean 4 / Rocq / LiNo (Proposed)
+
+This document shows how core dependent type theory constructs would look in Lean 4, Rocq, and our proposed LiNo encoding.
+
+## Core Constructs
+
+### 1. Universe Sorts
+
+| Concept | Lean 4 | Rocq | LiNo (Proposed) |
+|---------|--------|------|-----------------|
+| Type of small types | `Type` or `Type 0` | `Set` or `Type` | `(Type 0)` |
+| Type of types | `Type 1` | `Type` | `(Type 1)` |
+| Propositions | `Prop` | `Prop` | `(Prop)` or `(Type 0)` |
+
+### 2. Variable Declarations
+
+```lean
+-- Lean 4
+variable (x : Nat)
+```
+
+```coq
+(* Rocq *)
+Variable x : nat.
+```
+
+```lino
+# LiNo (Proposed)
+(x : Nat)
+```
+
+### 3. Function Types (Non-Dependent)
+
+```lean
+-- Lean 4
+Nat → Bool
+```
+
+```coq
+(* Rocq *)
+nat -> bool
+```
+
+```lino
+# LiNo (Proposed)
+(Pi (_ : Nat) Bool)
+# or sugar:
+(Nat -> Bool)
+```
+
+### 4. Dependent Product (Π-Type / Forall)
+
+```lean
+-- Lean 4
+(n : Nat) → Vec n Bool
+-- or
+∀ (n : Nat), Vec n Bool
+```
+
+```coq
+(* Rocq *)
+forall (n : nat), Vec n bool
+```
+
+```lino
+# LiNo (Proposed)
+(Pi (n : Nat) (Vec n Bool))
+# or:
+(forall (n : Nat) (Vec n Bool))
+```
+
+### 5. Lambda Abstraction
+
+```lean
+-- Lean 4
+fun (x : Nat) => x + 1
+```
+
+```coq
+(* Rocq *)
+fun (x : nat) => x + 1
+```
+
+```lino
+# LiNo (Proposed)
+(lam (x : Nat) (+ x 1))
+# or:
+(fun (x : Nat) (+ x 1))
+```
+
+### 6. Function Application
+
+```lean
+-- Lean 4
+f x
+f x y z
+```
+
+```coq
+(* Rocq *)
+f x
+f x y z
+```
+
+```lino
+# LiNo (Proposed)
+(f x)
+(f x y z)
+# Note: multi-argument application is sugar for nested applications:
+# (f x y z) = (((f x) y) z)
+```
+
+### 7. Let Binding
+
+```lean
+-- Lean 4
+let x : Nat := 5; x + 1
+```
+
+```coq
+(* Rocq *)
+let x : nat := 5 in x + 1
+```
+
+```lino
+# LiNo (Proposed)
+(let (x : Nat) 5 (+ x 1))
+```
+
+### 8. Inductive Type Definitions
+
+```lean
+-- Lean 4
+inductive Nat where
+  | zero : Nat
+  | succ : Nat → Nat
+```
+
+```coq
+(* Rocq *)
+Inductive nat : Set :=
+  | zero : nat
+  | succ : nat -> nat.
+```
+
+```lino
+# LiNo (Proposed)
+(inductive Nat (Type 0)
+  (zero : Nat)
+  (succ : (Pi (_ : Nat) Nat)))
+```
+
+### 9. Pattern Matching / Recursion
+
+```lean
+-- Lean 4
+def add : Nat → Nat → Nat
+  | .zero, b => b
+  | .succ a, b => .succ (add a b)
+```
+
+```coq
+(* Rocq *)
+Fixpoint add (a b : nat) : nat :=
+  match a with
+  | zero => b
+  | succ n => succ (add n b)
+  end.
+```
+
+```lino
+# LiNo (Proposed)
+(def add : (Pi (a : Nat) (Pi (b : Nat) Nat))
+  (lam (a : Nat) (lam (b : Nat)
+    (match a
+      (zero => b)
+      ((succ n) => (succ (add n b)))))))
+```
+
+### 10. Propositions and Proofs
+
+```lean
+-- Lean 4
+theorem plus_zero (n : Nat) : n + 0 = n := by
+  induction n with
+  | zero => rfl
+  | succ n ih => simp [Nat.add_succ, ih]
+```
+
+```coq
+(* Rocq *)
+Theorem plus_zero : forall n : nat, n + 0 = n.
+Proof.
+  intro n. induction n.
+  - reflexivity.
+  - simpl. rewrite IHn. reflexivity.
+Qed.
+```
+
+```lino
+# LiNo (Proposed) - explicit proof term
+(theorem plus_zero
+  : (Pi (n : Nat) (= (+ n zero) n))
+  (lam (n : Nat)
+    (match n
+      (zero => (refl zero))
+      ((succ m) => (cong succ (plus_zero m))))))
+```
+
+### 11. Dependent Sum (Σ-Type / Exists)
+
+```lean
+-- Lean 4
+(n : Nat) × (n > 0)
+-- or
+∃ n : Nat, n > 0
+```
+
+```coq
+(* Rocq *)
+{ n : nat | n > 0 }
+-- or
+exists n : nat, n > 0
+```
+
+```lino
+# LiNo (Proposed)
+(Sigma (n : Nat) (> n 0))
+# or:
+(exists (n : Nat) (> n 0))
+```
+
+## Integration with ADL Probabilistic Logic
+
+### Probabilistic Propositions
+
+```lino
+# Classical proposition (probability 1 or 0)
+((= (+ zero (succ zero)) (succ zero)) has probability 1)
+
+# Probabilistic proposition
+((raining today) has probability 0.7)
+
+# Type-checked probabilistic proposition
+(raining : (PProp 0.7))
+
+# Query type
+(?type (lam (x : Nat) (+ x 1)))
+# Output: (Pi (x : Nat) Nat)
+
+# Query probability
+(? (raining today))
+# Output: 0.7
+```
+
+### Mixed Mode: Types + Probabilities
+
+```lino
+# Define a type
+(inductive Weather (Type 0)
+  (sunny : Weather)
+  (rainy : Weather)
+  (cloudy : Weather))
+
+# Assign probabilities to inhabitants
+((sunny has probability 0.3) in Weather)
+((rainy has probability 0.5) in Weather)
+((cloudy has probability 0.2) in Weather)
+
+# Dependent type with probabilistic index
+(forecast : (Pi (w : Weather) (PProp (weather_prob w))))
+```
+
+## Encoding in Pure Associative Links
+
+For completeness, here is how the above would look using only the associative link model (Option D from the main document):
+
+```lino
+# Define meta-concepts as links
+(type-of: type-of is type-of)
+(reduces-to: reduces-to is reduces-to)
+(has-constructor: has-constructor is has-constructor)
+
+# Universe hierarchy
+(Type-0: Type-0 is Type-0)
+(Type-1: Type-1 is Type-1)
+((Type-0 type-of Type-1) has probability 1)
+
+# Nat type
+(Nat: Nat is Nat)
+((Nat type-of Type-0) has probability 1)
+
+# Constructors
+(zero: zero is zero)
+((zero type-of Nat) has probability 1)
+((Nat has-constructor zero) has probability 1)
+
+(succ: succ is succ)
+((succ type-of (Pi Nat Nat)) has probability 1)
+((Nat has-constructor succ) has probability 1)
+
+# A function: add
+(add: add is add)
+((add type-of (Pi Nat (Pi Nat Nat))) has probability 1)
+
+# Reduction rules as links
+(((add zero b) reduces-to b) has probability 1)
+(((add (succ n) b) reduces-to (succ (add n b))) has probability 1)
+
+# Type checking is querying the network
+(? (zero type-of Nat))          # -> 1 (true)
+(? (succ type-of (Pi Nat Nat))) # -> 1 (true)
+(? ((succ zero) type-of Nat))   # -> 1 (true, by reduction)
+```
+
+This encoding treats the entire type system as data within the associative network, which aligns with the Links Theory principle that everything is a link.

--- a/js/README.md
+++ b/js/README.md
@@ -68,7 +68,7 @@ const q = quantize(0.4, 3, 0, 1); // -> 0.5 (nearest ternary level)
 npm test
 ```
 
-The test suite includes 170 tests covering:
+The test suite includes 176 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
@@ -76,6 +76,7 @@ The test suite includes 170 tests covering:
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, type queries
+- Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Dependencies
 

--- a/js/README.md
+++ b/js/README.md
@@ -68,13 +68,14 @@ const q = quantize(0.4, 3, 0, 1); // -> 0.5 (nearest ternary level)
 npm test
 ```
 
-The test suite includes 93 tests covering:
+The test suite includes 170 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
+- Dependent type system: universes, Pi-types, lambdas, application, type queries
 
 ## Dependencies
 

--- a/js/examples/dependent-types.lino
+++ b/js/examples/dependent-types.lino
@@ -11,30 +11,34 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
-# Colon notation: (Name: TypeExpr)
-(Nat: (Type 0))
-(Bool: (Type 0))
+# Complex type expression: (Name: (Type 0))
+(Natural: (Type 0))
+(Boolean: (Type 0))
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms
-(zero: Nat zero)
-(true-val: Bool true-val)
-(false-val: Bool false-val)
+(zero: Natural zero)
+(true-val: Boolean true-val)
+(false-val: Boolean false-val)
 
 # Pi-types for function constructors
-(succ: (Pi (n: Nat) Nat))
+(succ: (Pi (Natural n) Natural))
 
 # === Type Checking via Queries ===
-# "Is zero of type Nat?" — querying the link network
-(? (zero type-of Nat))
-(? (Nat type-of (Type 0)))
+# "Is zero of type Natural?" — querying the link network
+(? (zero of Natural))
+(? (Natural of (Type 0)))
 
 # === Functions as Links ===
-# Define identity function: id(x) = x
-(id: lam (x: Nat) x)
+# Define identity function: identity(x) = x
+(identity: lambda (Natural x) x)
 
 # Apply identity function
-(? (app id 0.7))
+(? (apply identity 0.7))
+
+# === Type Queries ===
+# "What is the type of x?"
+(? (type of zero))
 
 # === Combining Types with Probabilistic Logic ===
 # The type system coexists with the probabilistic logic

--- a/js/examples/dependent-types.lino
+++ b/js/examples/dependent-types.lino
@@ -1,0 +1,44 @@
+# Dependent Types in Links Notation
+# Demonstrating how types are just links — "everything is a link"
+#
+# This example shows how the core of dependent type systems like
+# Lean 4 and Rocq (Coq) can be expressed in LiNo.
+
+# === Universe Hierarchy ===
+# (Type 0) : (Type 1) : (Type 2) : ...
+(Type 0)
+(Type 1)
+
+# === Define Types as Links ===
+# Types are just links with type annotations
+(Nat: (Type 0))
+(Bool: (Type 0))
+
+# === Constructors ===
+# Constructors are links with Pi-types
+(zero: Nat)
+(succ: (Pi (n: Nat) Nat))
+(true-val: Bool)
+(false-val: Bool)
+
+# === Type Checking via Queries ===
+# "Is zero of type Nat?" — querying the link network
+(? (zero type-of Nat))
+(? (Nat type-of (Type 0)))
+
+# === Functions as Links ===
+# Define identity function: id(x) = x
+(id: lam (x: Nat) x)
+
+# Apply identity function
+(? (app id 0.7))
+
+# === Combining Types with Probabilistic Logic ===
+# The type system coexists with the probabilistic logic
+((zero = zero) has probability 1)
+(? (zero = zero))
+
+# The liar paradox still works alongside types
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))

--- a/js/examples/dependent-types.lino
+++ b/js/examples/dependent-types.lino
@@ -11,15 +11,18 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
+# Colon notation: (Name: TypeExpr)
 (Nat: (Type 0))
 (Bool: (Type 0))
 
-# === Constructors ===
-# Constructors are links with Pi-types
-(zero: Nat)
+# === Constructors using Prefix Type Notation ===
+# (name: TypeName name) — the LiNo-native way to declare typed terms
+(zero: Nat zero)
+(true-val: Bool true-val)
+(false-val: Bool false-val)
+
+# Pi-types for function constructors
 (succ: (Pi (n: Nat) Nat))
-(true-val: Bool)
-(false-val: Bool)
 
 # === Type Checking via Queries ===
 # "Is zero of type Nat?" — querying the link network

--- a/js/examples/dependent-types.lino
+++ b/js/examples/dependent-types.lino
@@ -3,17 +3,18 @@
 #
 # This example shows how the core of dependent type systems like
 # Lean 4 and Rocq (Coq) can be expressed in LiNo.
+# ADL is a dynamic axiomatic system: it embraces self-reference
+# and resolves paradoxes to the midpoint truth value (0.5).
 
-# === Universe Hierarchy ===
-# (Type 0) : (Type 1) : (Type 2) : ...
-(Type 0)
-(Type 1)
+# === Self-Referential Type: Type is its own type ===
+# Unlike classical type theory which forbids Type : Type,
+# ADL allows it — paradoxes resolve to 0.5
+(Type: Type Type)
 
 # === Define Types as Links ===
-# Types are just links with type annotations
-# Prefix type notation: (SubType: Type SubType)
-(Natural: (Type 0) Natural)
-(Boolean: (Type 0) Boolean)
+# Types follow the pattern: (SubType: Type SubType)
+(Natural: Type Natural)
+(Boolean: Type Boolean)
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms
@@ -27,7 +28,8 @@
 # === Type Checking via Queries ===
 # "Is zero of type Natural?" — querying the link network
 (? (zero of Natural))
-(? (Natural of (Type 0)))
+(? (Natural of Type))
+(? (Type of Type))
 
 # === Functions as Links ===
 # Define identity function: identity(x) = x
@@ -37,7 +39,7 @@
 (? (apply identity 0.7))
 
 # === Type Queries ===
-# "What is the type of x?"
+# "What is the type of zero?"
 (? (type of zero))
 
 # === Combining Types with Probabilistic Logic ===
@@ -45,7 +47,14 @@
 ((zero = zero) has probability 1)
 (? (zero = zero))
 
-# The liar paradox still works alongside types
+# === Paradox Resolution ===
+# The liar paradox works alongside types — resolves to 0.5
 (s: s is s)
 ((s = false) has probability 0.5)
 (? (s = false))
+
+# === Universe Hierarchy (Lean/Rocq compatibility) ===
+# Both (Type: Type Type) and (Type N) coexist
+(Type 0)
+(Type 1)
+(? ((Type 0) of (Type 1)))

--- a/js/examples/dependent-types.lino
+++ b/js/examples/dependent-types.lino
@@ -11,9 +11,9 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
-# Complex type expression: (Name: (Type 0))
-(Natural: (Type 0))
-(Boolean: (Type 0))
+# Prefix type notation: (SubType: Type SubType)
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "associative-dependent-logic",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "associative-dependent-logic",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "associative-dependent-logic",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/adl-links.mjs",

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -554,7 +554,7 @@ function defineForm(head, rhs, env){
   }
 
   // Prefix type notation: (name: TypeName name) → typed self-referential declaration
-  // e.g. (zero: Nat zero), (boolean: Type boolean), (true: Boolean true)
+  // e.g. (zero: Natural zero), (boolean: Type boolean), (true: Boolean true)
   if (rhs.length === 2 && typeof rhs[0] === 'string' && typeof rhs[1] === 'string' && rhs[1] === head) {
     const typeName = rhs[0];
     // Only if typeName starts with uppercase (type convention) and is not an operator
@@ -574,9 +574,9 @@ function defineForm(head, rhs, env){
     return 1;
   }
 
-  // Typed declaration with complex type expression: (Nat: (Type 0)), (succ: (Pi (Natural n) Natural))
+  // Typed declaration with complex type expression: (Natural: (Type 0)), (succ: (Pi (Natural n) Natural))
   // Only complex expressions (arrays) are accepted as type annotations in single-element form.
-  // Simple name type annotations like (x: Nat) are NOT supported — use (x: Nat x) prefix form instead.
+  // Simple name type annotations like (x: Natural) are NOT supported — use (x: Natural x) prefix form instead.
   if (rhs.length === 1 && Array.isArray(rhs[0])) {
     const isOp = ['=','!=','and','or','not','is','?:'].includes(head) || /[=!]/.test(head);
     if (!isOp) {

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -574,7 +574,7 @@ function defineForm(head, rhs, env){
     return 1;
   }
 
-  // Typed declaration with complex type expression: (Natural: (Type 0)), (succ: (Pi (Natural n) Natural))
+  // Typed declaration with complex type expression: (succ: (Pi (Natural n) Natural))
   // Only complex expressions (arrays) are accepted as type annotations in single-element form.
   // Simple name type annotations like (x: Natural) are NOT supported — use (x: Natural x) prefix form instead.
   if (rhs.length === 1 && Array.isArray(rhs[0])) {

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -501,6 +501,27 @@ function defineForm(head, rhs, env){
     return 1;
   }
 
+  // Prefix type notation: (name: TypeName name) → typed self-referential declaration
+  // e.g. (zero: Nat zero), (boolean: Type boolean), (true: Boolean true)
+  if (rhs.length === 2 && typeof rhs[0] === 'string' && typeof rhs[1] === 'string' && rhs[1] === head) {
+    const typeName = rhs[0];
+    // Only if typeName starts with uppercase (type convention) and is not an operator
+    if (/^[A-Z]/.test(typeName)) {
+      env.terms.add(head);
+      env.setType(head, typeName);
+      return 1;
+    }
+  }
+
+  // Prefix type notation with complex type: (name: (Type 0) name) → typed self-referential declaration
+  if (rhs.length === 2 && Array.isArray(rhs[0]) && typeof rhs[1] === 'string' && rhs[1] === head) {
+    const typeExpr = rhs[0];
+    env.terms.add(head);
+    env.setType(head, typeExpr);
+    evalNode(typeExpr, env);
+    return 1;
+  }
+
   // Typed variable/type declaration: (x : A) where A is not numeric
   // This sets the type of x to A, e.g. (x : Nat), (Nat : (Type 0))
   if (rhs.length === 1 && !isNum(typeof rhs[0] === 'string' ? rhs[0] : '')) {

--- a/js/src/adl-links.mjs
+++ b/js/src/adl-links.mjs
@@ -616,7 +616,9 @@ function defineForm(head, rhs, env){
 // ---------- Runner ----------
 function run(text, options){
   const parser = new Parser();
-  const links = parser.parse(text);
+  // Strip line comments (# ...) before parsing — LiNo parser doesn't handle them
+  const stripped = text.replace(/^[ \t]*#.*$/gm, '').replace(/\n{3,}/g, '\n\n');
+  const links = parser.parse(stripped);
 
   // Convert each top-level LiNo link to an AST by re-tokenizing that link only.
   // Filter out comment-only links (starting with #)
@@ -661,7 +663,13 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   }
   const text = fs.readFileSync(file, 'utf8');
   const outs = run(text);
-  for (const v of outs) console.log(String(+v.toFixed(6)).replace(/\.0+$/,''));
+  for (const v of outs) {
+    if (typeof v === 'string') {
+      console.log(v);
+    } else {
+      console.log(String(+v.toFixed(6)).replace(/\.0+$/,''));
+    }
+  }
 }
 
 export { run, tokenizeOne, parseOne, Env, evalNode, quantize, decRound, substitute };

--- a/js/test/adl-links.test.mjs
+++ b/js/test/adl-links.test.mjs
@@ -1614,3 +1614,92 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
     assert.strictEqual(results[0], 1);
   });
 });
+
+describe('Type System: self-referential (Type: Type Type) — dynamic axiomatic system', () => {
+  it('(Type: Type Type) defines Type as its own type', () => {
+    const results = run(`
+(Type: Type Type)
+(? (Type of Type))
+`);
+    assert.strictEqual(results[0], 1);
+  });
+
+  it('(Type: Type Type) supports full type hierarchy', () => {
+    const results = run(`
+(Type: Type Type)
+(Natural: Type Natural)
+(Boolean: Type Boolean)
+(zero: Natural zero)
+(true-val: Boolean true-val)
+(? (zero of Natural))
+(? (Natural of Type))
+(? (Boolean of Type))
+(? (Type of Type))
+`);
+    assert.strictEqual(results.length, 4);
+    assert.strictEqual(results[0], 1);
+    assert.strictEqual(results[1], 1);
+    assert.strictEqual(results[2], 1);
+    assert.strictEqual(results[3], 1);
+  });
+
+  it('(type of Natural) returns Type when using self-referential Type', () => {
+    const results = run(`
+(Type: Type Type)
+(Natural: Type Natural)
+(? (type of Natural))
+(? (type of Type))
+`);
+    assert.strictEqual(results[0], 'Type');
+    assert.strictEqual(results[1], 'Type');
+  });
+
+  it('(Type: Type Type) coexists with (Type N) universe hierarchy', () => {
+    const results = run(`
+(Type: Type Type)
+(Type 0)
+(Type 1)
+(Natural: (Type 0) Natural)
+(Boolean: Type Boolean)
+(zero: Natural zero)
+(? (Type of Type))
+(? (Natural of (Type 0)))
+(? (Boolean of Type))
+(? (zero of Natural))
+(? ((Type 0) of (Type 1)))
+`);
+    assert.strictEqual(results.length, 5);
+    assert.strictEqual(results[0], 1);
+    assert.strictEqual(results[1], 1);
+    assert.strictEqual(results[2], 1);
+    assert.strictEqual(results[3], 1);
+    assert.strictEqual(results[4], 1);
+  });
+
+  it('paradox resolution: liar paradox alongside self-referential types', () => {
+    const results = run(`
+(Type: Type Type)
+(Natural: Type Natural)
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))
+(? (not (s = false)))
+(? (Natural of Type))
+`);
+    assert.strictEqual(results[0], 0.5);
+    assert.strictEqual(results[1], 0.5);
+    assert.strictEqual(results[2], 1);
+  });
+
+  it('paradox resolution: self-referential equality resolves to 0.5', () => {
+    const results = run(`
+(Type: Type Type)
+(R: R is R)
+((R = R) has probability 0.5)
+(? (R = R))
+(? (not (R = R)))
+`);
+    assert.strictEqual(results[0], 0.5);
+    assert.strictEqual(results[1], 0.5);
+  });
+});

--- a/js/test/adl-links.test.mjs
+++ b/js/test/adl-links.test.mjs
@@ -1531,3 +1531,66 @@ describe('Type System: backward compatibility', () => {
     assert.strictEqual(results[2], 1);
   });
 });
+
+describe('Type System: prefix type notation — (name: Type name)', () => {
+  it('(zero: Nat zero) declares zero has type Nat', () => {
+    const env = new Env();
+    run('(Nat : (Type 0))');
+    const results = run(`
+(Nat : (Type 0))
+(zero: Nat zero)
+(? (zero type-of Nat))
+`);
+    assert.strictEqual(results[0], 1);
+  });
+
+  it('(boolean: Type boolean) declares boolean has type Type', () => {
+    const results = run(`
+(Type 0)
+(Boolean: (Type 0) Boolean)
+(? (Boolean type-of (Type 0)))
+`);
+    assert.strictEqual(results[0], 1);
+  });
+
+  it('prefix notation with simple type names', () => {
+    const results = run(`
+(Nat : (Type 0))
+(Bool : (Type 0))
+(zero: Nat zero)
+(true-val: Bool true-val)
+(? (zero type-of Nat))
+(? (true-val type-of Bool))
+`);
+    assert.strictEqual(results[0], 1);
+    assert.strictEqual(results[1], 1);
+  });
+
+  it('prefix notation coexists with colon notation', () => {
+    const results = run(`
+(Nat : (Type 0))
+(zero: Nat zero)
+(succ : Nat)
+(? (zero type-of Nat))
+(? (succ type-of Nat))
+`);
+    assert.strictEqual(results[0], 1);
+    assert.strictEqual(results[1], 1);
+  });
+
+  it('type hierarchy: (type: type type), (boolean: type boolean)', () => {
+    const results = run(`
+(Type 0)
+(Type: (Type 0) Type)
+(Boolean: Type Boolean)
+(True: Boolean True)
+(False: Boolean False)
+(? (Boolean type-of Type))
+(? (True type-of Boolean))
+(? (False type-of Boolean))
+`);
+    assert.strictEqual(results[0], 1);
+    assert.strictEqual(results[1], 1);
+    assert.strictEqual(results[2], 1);
+  });
+});

--- a/js/test/adl-links.test.mjs
+++ b/js/test/adl-links.test.mjs
@@ -1216,20 +1216,20 @@ describe('Type System: substitute (beta-reduction helper)', () => {
   });
 
   it('should not substitute inside shadowing lambda bindings', () => {
-    const expr = ['lam', ['x', ':', 'Nat'], 'x'];
+    const expr = ['lam', ['x:', 'Nat'], 'x'];
     assert.deepStrictEqual(substitute(expr, 'x', '5'), expr);
   });
 
   it('should not substitute inside shadowing Pi bindings', () => {
-    const expr = ['Pi', ['x', ':', 'Nat'], 'x'];
+    const expr = ['Pi', ['x:', 'Nat'], 'x'];
     assert.deepStrictEqual(substitute(expr, 'x', 'Bool'), expr);
   });
 
   it('should substitute free variables in lambda body', () => {
-    const expr = ['lam', ['y', ':', 'Nat'], 'x'];
+    const expr = ['lam', ['y:', 'Nat'], 'x'];
     assert.deepStrictEqual(
       substitute(expr, 'x', '5'),
-      ['lam', ['y', ':', 'Nat'], '5']
+      ['lam', ['y:', 'Nat'], '5']
     );
   });
 });
@@ -1260,10 +1260,10 @@ describe('Type System: universe sorts — (Type N)', () => {
   });
 });
 
-describe('Type System: typed variable declarations — (x : A)', () => {
+describe('Type System: typed variable declarations — (x: A)', () => {
   it('should declare a typed variable', () => {
     const results = run(`
-(x : Nat)
+(x: Nat)
 (? (x type-of Nat))
 `);
     assert.strictEqual(results.length, 1);
@@ -1272,7 +1272,7 @@ describe('Type System: typed variable declarations — (x : A)', () => {
 
   it('should return false for wrong type', () => {
     const results = run(`
-(x : Nat)
+(x: Nat)
 (? (x type-of Bool))
 `);
     assert.strictEqual(results[0], 0);
@@ -1280,8 +1280,8 @@ describe('Type System: typed variable declarations — (x : A)', () => {
 
   it('should support multiple typed declarations', () => {
     const results = run(`
-(x : Nat)
-(y : Bool)
+(x: Nat)
+(y: Bool)
 (? (x type-of Nat))
 (? (y type-of Bool))
 (? (x type-of Bool))
@@ -1293,62 +1293,62 @@ describe('Type System: typed variable declarations — (x : A)', () => {
   });
 });
 
-describe('Type System: Pi-types — (Pi (x : A) B)', () => {
+describe('Type System: Pi-types — (Pi (x: A) B)', () => {
   it('should evaluate a Pi-type as valid', () => {
-    const results = run('(? (Pi (x : Nat) Nat))');
+    const results = run('(? (Pi (x: Nat) Nat))');
     assert.strictEqual(results[0], 1);
   });
 
   it('should register Pi-type in the type environment', () => {
     const env = new Env();
-    evalNode(['Pi', ['x', ':', 'Nat'], 'Nat'], env);
-    const typeOfPi = env.getType(['Pi', ['x', ':', 'Nat'], 'Nat']);
+    evalNode(['Pi', ['x:', 'Nat'], 'Nat'], env);
+    const typeOfPi = env.getType(['Pi', ['x:', 'Nat'], 'Nat']);
     assert.ok(typeOfPi !== null);
   });
 
   it('should register the parameter type from Pi', () => {
     const env = new Env();
-    evalNode(['Pi', ['n', ':', 'Nat'], ['Vec', 'n', 'Bool']], env);
+    evalNode(['Pi', ['n:', 'Nat'], ['Vec', 'n', 'Bool']], env);
     assert.ok(env.terms.has('n'));
     assert.strictEqual(env.getType('n'), 'Nat');
   });
 
-  it('non-dependent function type: (Pi (_ : Nat) Bool)', () => {
-    const results = run('(? (Pi (_ : Nat) Bool))');
+  it('non-dependent function type: (Pi (_: Nat) Bool)', () => {
+    const results = run('(? (Pi (_: Nat) Bool))');
     assert.strictEqual(results[0], 1);
   });
 });
 
-describe('Type System: lambda abstraction — (lam (x : A) body)', () => {
+describe('Type System: lambda abstraction — (lam (x: A) body)', () => {
   it('should evaluate a lambda as valid', () => {
-    const results = run('(? (lam (x : Nat) x))');
+    const results = run('(? (lam (x: Nat) x))');
     assert.strictEqual(results[0], 1);
   });
 
   it('should store lambda type as a Pi-type', () => {
     const env = new Env();
-    evalNode(['lam', ['x', ':', 'Nat'], 'x'], env);
-    const t = env.getType(['lam', ['x', ':', 'Nat'], 'x']);
+    evalNode(['lam', ['x:', 'Nat'], 'x'], env);
+    const t = env.getType(['lam', ['x:', 'Nat'], 'x']);
     assert.ok(t !== null);
     assert.ok(t.includes('Pi'));
   });
 });
 
 describe('Type System: application — (app f x) with beta-reduction', () => {
-  it('should beta-reduce (app (lam (x : Nat) x) 0.5) to 0.5', () => {
-    const results = run('(? (app (lam (x : Nat) x) 0.5))');
+  it('should beta-reduce (app (lam (x: Nat) x) 0.5) to 0.5', () => {
+    const results = run('(? (app (lam (x: Nat) x) 0.5))');
     assert.strictEqual(results.length, 1);
     assert.strictEqual(results[0], 0.5);
   });
 
   it('should beta-reduce with arithmetic in body', () => {
-    const results = run('(? (app (lam (x : Nat) (x + 0.1)) 0.2))');
+    const results = run('(? (app (lam (x: Nat) (x + 0.1)) 0.2))');
     assert.strictEqual(results[0], 0.3);
   });
 
   it('should apply named lambda via (app name arg)', () => {
     const results = run(`
-(id: lam (x : Nat) x)
+(id: lam (x: Nat) x)
 (? (app id 0.7))
 `);
     assert.strictEqual(results[0], 0.7);
@@ -1356,14 +1356,14 @@ describe('Type System: application — (app f x) with beta-reduction', () => {
 
   it('should apply named lambda via prefix form (name arg)', () => {
     const results = run(`
-(id: lam (x : Nat) x)
+(id: lam (x: Nat) x)
 (? (id 0.7))
 `);
     assert.strictEqual(results[0], 0.7);
   });
 
   it('should apply const function', () => {
-    const results = run('(? (app (lam (x : Nat) 0.5) 0.9))');
+    const results = run('(? (app (lam (x: Nat) 0.5) 0.9))');
     assert.strictEqual(results[0], 0.5);
   });
 });
@@ -1371,7 +1371,7 @@ describe('Type System: application — (app f x) with beta-reduction', () => {
 describe('Type System: type-of query — (expr type-of Type)', () => {
   it('should confirm type with type-of link', () => {
     const results = run(`
-(x : Nat)
+(x: Nat)
 (? (x type-of Nat))
 `);
     assert.strictEqual(results[0], 1);
@@ -1379,7 +1379,7 @@ describe('Type System: type-of query — (expr type-of Type)', () => {
 
   it('should reject wrong type', () => {
     const results = run(`
-(x : Nat)
+(x: Nat)
 (? (x type-of Bool))
 `);
     assert.strictEqual(results[0], 0);
@@ -1397,7 +1397,7 @@ describe('Type System: type-of query — (expr type-of Type)', () => {
 describe('Type System: ?type query — type inference', () => {
   it('should infer type of a typed variable', () => {
     const results = run(`
-(x : Nat)
+(x: Nat)
 (?type x)
 `);
     assert.strictEqual(results.length, 1);
@@ -1416,9 +1416,9 @@ describe('Type System: ?type query — type inference', () => {
 describe('Type System: encoding Lean/Rocq core concepts as links', () => {
   it('should define natural number type and constructors', () => {
     const results = run(`
-(Nat : (Type 0))
-(zero : Nat)
-(succ : (Pi (n : Nat) Nat))
+(Nat: (Type 0))
+(zero: Nat)
+(succ: (Pi (n: Nat) Nat))
 (? (zero type-of Nat))
 (? (Nat type-of (Type 0)))
 `);
@@ -1429,9 +1429,9 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should define Bool type and constructors', () => {
     const results = run(`
-(Bool : (Type 0))
-(true-val : Bool)
-(false-val : Bool)
+(Bool: (Type 0))
+(true-val: Bool)
+(false-val: Bool)
 (? (true-val type-of Bool))
 (? (false-val type-of Bool))
 `);
@@ -1441,17 +1441,17 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should define identity function with type', () => {
     const results = run(`
-(Nat : (Type 0))
-(id : (Pi (x : Nat) Nat))
-(? (id type-of (Pi (x : Nat) Nat)))
+(Nat: (Type 0))
+(id: (Pi (x: Nat) Nat))
+(? (id type-of (Pi (x: Nat) Nat)))
 `);
     assert.strictEqual(results[0], 1);
   });
 
   it('should combine types with probability assignments', () => {
     const results = run(`
-(Nat : (Type 0))
-(zero : Nat)
+(Nat: (Type 0))
+(zero: Nat)
 (? (zero type-of Nat))
 ((zero = zero) has probability 1)
 (? (zero = zero))
@@ -1463,7 +1463,7 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should define and apply identity function', () => {
     const results = run(`
-(id: lam (x : Nat) x)
+(id: lam (x: Nat) x)
 (? (app id 0.5))
 `);
     assert.strictEqual(results[0], 0.5);
@@ -1518,8 +1518,8 @@ describe('Type System: backward compatibility', () => {
   it('mixed: types alongside probabilistic logic', () => {
     const results = run(`
 (a: a is a)
-(Nat : (Type 0))
-(x : Nat)
+(Nat: (Type 0))
+(x: Nat)
 ((a = a) has probability 1)
 (? (a = a))
 (? (x type-of Nat))
@@ -1535,9 +1535,9 @@ describe('Type System: backward compatibility', () => {
 describe('Type System: prefix type notation — (name: Type name)', () => {
   it('(zero: Nat zero) declares zero has type Nat', () => {
     const env = new Env();
-    run('(Nat : (Type 0))');
+    run('(Nat: (Type 0))');
     const results = run(`
-(Nat : (Type 0))
+(Nat: (Type 0))
 (zero: Nat zero)
 (? (zero type-of Nat))
 `);
@@ -1555,8 +1555,8 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
 
   it('prefix notation with simple type names', () => {
     const results = run(`
-(Nat : (Type 0))
-(Bool : (Type 0))
+(Nat: (Type 0))
+(Bool: (Type 0))
 (zero: Nat zero)
 (true-val: Bool true-val)
 (? (zero type-of Nat))
@@ -1568,9 +1568,9 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
 
   it('prefix notation coexists with colon notation', () => {
     const results = run(`
-(Nat : (Type 0))
+(Nat: (Type 0))
 (zero: Nat zero)
-(succ : Nat)
+(succ: Nat)
 (? (zero type-of Nat))
 (? (succ type-of Nat))
 `);

--- a/js/test/adl-links.test.mjs
+++ b/js/test/adl-links.test.mjs
@@ -1268,7 +1268,7 @@ describe('Type System: universe sorts — (Type N)', () => {
 describe('Type System: typed variable declarations — (name: Type name)', () => {
   it('should declare a typed variable via prefix notation', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (x of Natural))
 `);
@@ -1278,8 +1278,8 @@ describe('Type System: typed variable declarations — (name: Type name)', () =>
 
   it('should return false for wrong type', () => {
     const results = run(`
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (? (x of Boolean))
 `);
@@ -1288,8 +1288,8 @@ describe('Type System: typed variable declarations — (name: Type name)', () =>
 
   it('should support multiple typed declarations', () => {
     const results = run(`
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (y: Boolean y)
 (? (x of Natural))
@@ -1381,7 +1381,7 @@ describe('Type System: application — (apply f x) with beta-reduction', () => {
 describe('Type System: type check query — (expr of Type)', () => {
   it('should confirm type with of link', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (x of Natural))
 `);
@@ -1390,8 +1390,8 @@ describe('Type System: type check query — (expr of Type)', () => {
 
   it('should reject wrong type', () => {
     const results = run(`
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (? (x of Boolean))
 `);
@@ -1410,7 +1410,7 @@ describe('Type System: type check query — (expr of Type)', () => {
 describe('Type System: type of query — (type of expr)', () => {
   it('should infer type of a typed variable', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (type of x))
 `);
@@ -1430,7 +1430,7 @@ describe('Type System: type of query — (type of expr)', () => {
 describe('Type System: encoding Lean/Rocq core concepts as links', () => {
   it('should define natural number type and constructors', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (succ: (Pi (Natural n) Natural))
 (? (zero of Natural))
@@ -1443,7 +1443,7 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should define Boolean type and constructors', () => {
     const results = run(`
-(Boolean: (Type 0))
+(Boolean: (Type 0) Boolean)
 (true-val: Boolean true-val)
 (false-val: Boolean false-val)
 (? (true-val of Boolean))
@@ -1455,7 +1455,7 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should define identity function with type', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (identity: (Pi (Natural x) Natural))
 (? (identity of (Pi (Natural x) Natural)))
 `);
@@ -1464,7 +1464,7 @@ describe('Type System: encoding Lean/Rocq core concepts as links', () => {
 
   it('should combine types with probability assignments', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (? (zero of Natural))
 ((zero = zero) has probability 1)
@@ -1532,7 +1532,7 @@ describe('Type System: backward compatibility', () => {
   it('mixed: types alongside probabilistic logic', () => {
     const results = run(`
 (a: a is a)
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 ((a = a) has probability 1)
 (? (a = a))
@@ -1549,7 +1549,7 @@ describe('Type System: backward compatibility', () => {
 describe('Type System: prefix type notation — (name: Type name)', () => {
   it('(zero: Natural zero) declares zero has type Natural', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (? (zero of Natural))
 `);
@@ -1567,8 +1567,8 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
 
   it('prefix notation with simple type names', () => {
     const results = run(`
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (zero: Natural zero)
 (true-val: Boolean true-val)
 (? (zero of Natural))
@@ -1580,7 +1580,7 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
 
   it('prefix notation with Pi-type constructor', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (succ: (Pi (Natural n) Natural))
 (? (zero of Natural))
@@ -1608,7 +1608,7 @@ describe('Type System: prefix type notation — (name: Type name)', () => {
 
   it('lambda with multi-param binding: (lambda (Natural x, Natural y) body)', () => {
     const results = run(`
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (? (lambda (Natural x, Natural y) (x + y)))
 `);
     assert.strictEqual(results[0], 1);

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "associative-dependent-logic"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "associative-dependent-logic"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,7 +69,7 @@ let q = quantize(0.4, 3, 0.0, 1.0); // -> 0.5 (nearest ternary level)
 cargo test
 ```
 
-The test suite includes 170 tests covering:
+The test suite includes 176 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
@@ -77,6 +77,7 @@ The test suite includes 170 tests covering:
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, type queries
+- Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Implementation Notes
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,13 +69,14 @@ let q = quantize(0.4, 3, 0.0, 1.0); // -> 0.5 (nearest ternary level)
 cargo test
 ```
 
-The test suite includes 93 tests covering:
+The test suite includes 170 tests covering:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
+- Dependent type system: universes, Pi-types, lambdas, application, type queries
 
 ## Implementation Notes
 

--- a/rust/examples/dependent-types.lino
+++ b/rust/examples/dependent-types.lino
@@ -11,30 +11,34 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
-# Colon notation: (Name: TypeExpr)
-(Nat: (Type 0))
-(Bool: (Type 0))
+# Complex type expression: (Name: (Type 0))
+(Natural: (Type 0))
+(Boolean: (Type 0))
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms
-(zero: Nat zero)
-(true-val: Bool true-val)
-(false-val: Bool false-val)
+(zero: Natural zero)
+(true-val: Boolean true-val)
+(false-val: Boolean false-val)
 
 # Pi-types for function constructors
-(succ: (Pi (n: Nat) Nat))
+(succ: (Pi (Natural n) Natural))
 
 # === Type Checking via Queries ===
-# "Is zero of type Nat?" — querying the link network
-(? (zero type-of Nat))
-(? (Nat type-of (Type 0)))
+# "Is zero of type Natural?" — querying the link network
+(? (zero of Natural))
+(? (Natural of (Type 0)))
 
 # === Functions as Links ===
-# Define identity function: id(x) = x
-(id: lam (x: Nat) x)
+# Define identity function: identity(x) = x
+(identity: lambda (Natural x) x)
 
 # Apply identity function
-(? (app id 0.7))
+(? (apply identity 0.7))
+
+# === Type Queries ===
+# "What is the type of x?"
+(? (type of zero))
 
 # === Combining Types with Probabilistic Logic ===
 # The type system coexists with the probabilistic logic

--- a/rust/examples/dependent-types.lino
+++ b/rust/examples/dependent-types.lino
@@ -1,0 +1,44 @@
+# Dependent Types in Links Notation
+# Demonstrating how types are just links — "everything is a link"
+#
+# This example shows how the core of dependent type systems like
+# Lean 4 and Rocq (Coq) can be expressed in LiNo.
+
+# === Universe Hierarchy ===
+# (Type 0) : (Type 1) : (Type 2) : ...
+(Type 0)
+(Type 1)
+
+# === Define Types as Links ===
+# Types are just links with type annotations
+(Nat: (Type 0))
+(Bool: (Type 0))
+
+# === Constructors ===
+# Constructors are links with Pi-types
+(zero: Nat)
+(succ: (Pi (n: Nat) Nat))
+(true-val: Bool)
+(false-val: Bool)
+
+# === Type Checking via Queries ===
+# "Is zero of type Nat?" — querying the link network
+(? (zero type-of Nat))
+(? (Nat type-of (Type 0)))
+
+# === Functions as Links ===
+# Define identity function: id(x) = x
+(id: lam (x: Nat) x)
+
+# Apply identity function
+(? (app id 0.7))
+
+# === Combining Types with Probabilistic Logic ===
+# The type system coexists with the probabilistic logic
+((zero = zero) has probability 1)
+(? (zero = zero))
+
+# The liar paradox still works alongside types
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))

--- a/rust/examples/dependent-types.lino
+++ b/rust/examples/dependent-types.lino
@@ -11,15 +11,18 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
+# Colon notation: (Name: TypeExpr)
 (Nat: (Type 0))
 (Bool: (Type 0))
 
-# === Constructors ===
-# Constructors are links with Pi-types
-(zero: Nat)
+# === Constructors using Prefix Type Notation ===
+# (name: TypeName name) — the LiNo-native way to declare typed terms
+(zero: Nat zero)
+(true-val: Bool true-val)
+(false-val: Bool false-val)
+
+# Pi-types for function constructors
 (succ: (Pi (n: Nat) Nat))
-(true-val: Bool)
-(false-val: Bool)
 
 # === Type Checking via Queries ===
 # "Is zero of type Nat?" — querying the link network

--- a/rust/examples/dependent-types.lino
+++ b/rust/examples/dependent-types.lino
@@ -3,17 +3,18 @@
 #
 # This example shows how the core of dependent type systems like
 # Lean 4 and Rocq (Coq) can be expressed in LiNo.
+# ADL is a dynamic axiomatic system: it embraces self-reference
+# and resolves paradoxes to the midpoint truth value (0.5).
 
-# === Universe Hierarchy ===
-# (Type 0) : (Type 1) : (Type 2) : ...
-(Type 0)
-(Type 1)
+# === Self-Referential Type: Type is its own type ===
+# Unlike classical type theory which forbids Type : Type,
+# ADL allows it — paradoxes resolve to 0.5
+(Type: Type Type)
 
 # === Define Types as Links ===
-# Types are just links with type annotations
-# Prefix type notation: (SubType: Type SubType)
-(Natural: (Type 0) Natural)
-(Boolean: (Type 0) Boolean)
+# Types follow the pattern: (SubType: Type SubType)
+(Natural: Type Natural)
+(Boolean: Type Boolean)
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms
@@ -27,7 +28,8 @@
 # === Type Checking via Queries ===
 # "Is zero of type Natural?" — querying the link network
 (? (zero of Natural))
-(? (Natural of (Type 0)))
+(? (Natural of Type))
+(? (Type of Type))
 
 # === Functions as Links ===
 # Define identity function: identity(x) = x
@@ -37,7 +39,7 @@
 (? (apply identity 0.7))
 
 # === Type Queries ===
-# "What is the type of x?"
+# "What is the type of zero?"
 (? (type of zero))
 
 # === Combining Types with Probabilistic Logic ===
@@ -45,7 +47,14 @@
 ((zero = zero) has probability 1)
 (? (zero = zero))
 
-# The liar paradox still works alongside types
+# === Paradox Resolution ===
+# The liar paradox works alongside types — resolves to 0.5
 (s: s is s)
 ((s = false) has probability 0.5)
 (? (s = false))
+
+# === Universe Hierarchy (Lean/Rocq compatibility) ===
+# Both (Type: Type Type) and (Type N) coexist
+(Type 0)
+(Type 1)
+(? ((Type 0) of (Type 1)))

--- a/rust/examples/dependent-types.lino
+++ b/rust/examples/dependent-types.lino
@@ -11,9 +11,9 @@
 
 # === Define Types as Links ===
 # Types are just links with type annotations
-# Complex type expression: (Name: (Type 0))
-(Natural: (Type 0))
-(Boolean: (Type 0))
+# Prefix type notation: (SubType: Type SubType)
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 
 # === Constructors using Prefix Type Notation ===
 # (name: TypeName name) — the LiNo-native way to declare typed terms

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1105,7 +1105,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
     }
 
     // Prefix type notation: (name: TypeName name) → typed self-referential declaration
-    // e.g. (zero: Nat zero), (boolean: Type boolean), (true: Boolean true)
+    // e.g. (zero: Natural zero), (boolean: Type boolean), (true: Boolean true)
     if rhs.len() == 2 {
         if let Node::Leaf(ref last) = rhs[1] {
             if last == head {
@@ -1224,9 +1224,9 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         }
     }
 
-    // Typed declaration with complex type expression: (Nat: (Type 0)), (succ: (Pi (Natural n) Natural))
+    // Typed declaration with complex type expression: (Natural: (Type 0)), (succ: (Pi (Natural n) Natural))
     // Only complex expressions (arrays/lists) are accepted as type annotations in single-element form.
-    // Simple name type annotations like (x: Nat) are NOT supported — use (x: Nat x) prefix form instead.
+    // Simple name type annotations like (x: Natural) are NOT supported — use (x: Natural x) prefix form instead.
     if rhs.len() == 1 {
         let is_op = head == "="
             || head == "!="

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -19,10 +19,20 @@ use std::fmt;
 
 /// Parse LiNo text into a vector of link strings (each a top-level parenthesized expression).
 pub fn parse_lino(text: &str) -> Vec<String> {
+    // Strip line comments (# ...) before parsing — LiNo parser doesn't handle them
+    let stripped: String = text
+        .lines()
+        .map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with('#') { "" } else { line }
+        })
+        .collect::<Vec<&str>>()
+        .join("\n");
+
     // The links-notation crate treats blank lines as group separators,
     // so we split the input by blank lines and parse each segment separately.
     let mut all_links = Vec::new();
-    for segment in text.split("\n\n") {
+    for segment in stripped.split("\n\n") {
         let trimmed = segment.trim();
         if trimmed.is_empty() {
             continue;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3564,4 +3564,117 @@ mod tests {
         );
         assert_eq!(results[0], 1.0);
     }
+
+    // ===== Self-referential (Type: Type Type) — dynamic axiomatic system =====
+
+    #[test]
+    fn self_referential_type_type() {
+        let results = run(
+            r#"
+(Type: Type Type)
+(? (Type of Type))
+"#,
+            None,
+        );
+        assert_eq!(results[0], 1.0);
+    }
+
+    #[test]
+    fn self_referential_type_full_hierarchy() {
+        let results = run(
+            r#"
+(Type: Type Type)
+(Natural: Type Natural)
+(Boolean: Type Boolean)
+(zero: Natural zero)
+(true-val: Boolean true-val)
+(? (zero of Natural))
+(? (Natural of Type))
+(? (Boolean of Type))
+(? (Type of Type))
+"#,
+            None,
+        );
+        assert_eq!(results.len(), 4);
+        assert_eq!(results[0], 1.0);
+        assert_eq!(results[1], 1.0);
+        assert_eq!(results[2], 1.0);
+        assert_eq!(results[3], 1.0);
+    }
+
+    #[test]
+    fn self_referential_type_of_query() {
+        let results = run_typed(
+            r#"
+(Type: Type Type)
+(Natural: Type Natural)
+(? (type of Natural))
+(? (type of Type))
+"#,
+            None,
+        );
+        assert_eq!(results[0], RunResult::Type("Type".to_string()));
+        assert_eq!(results[1], RunResult::Type("Type".to_string()));
+    }
+
+    #[test]
+    fn self_referential_type_coexists_with_universe_hierarchy() {
+        let results = run(
+            r#"
+(Type: Type Type)
+(Type 0)
+(Type 1)
+(Natural: (Type 0) Natural)
+(Boolean: Type Boolean)
+(zero: Natural zero)
+(? (Type of Type))
+(? (Natural of (Type 0)))
+(? (Boolean of Type))
+(? (zero of Natural))
+(? ((Type 0) of (Type 1)))
+"#,
+            None,
+        );
+        assert_eq!(results.len(), 5);
+        assert_eq!(results[0], 1.0);
+        assert_eq!(results[1], 1.0);
+        assert_eq!(results[2], 1.0);
+        assert_eq!(results[3], 1.0);
+        assert_eq!(results[4], 1.0);
+    }
+
+    #[test]
+    fn self_referential_type_liar_paradox_alongside() {
+        let results = run(
+            r#"
+(Type: Type Type)
+(Natural: Type Natural)
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))
+(? (not (s = false)))
+(? (Natural of Type))
+"#,
+            None,
+        );
+        approx(results[0], 0.5);
+        approx(results[1], 0.5);
+        assert_eq!(results[2], 1.0);
+    }
+
+    #[test]
+    fn self_referential_type_paradox_resolution() {
+        let results = run(
+            r#"
+(Type: Type Type)
+(R: R is R)
+((R = R) has probability 0.5)
+(? (R = R))
+(? (not (R = R)))
+"#,
+            None,
+        );
+        approx(results[0], 0.5);
+        approx(results[1], 0.5);
+    }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1224,7 +1224,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         }
     }
 
-    // Typed declaration with complex type expression: (Natural: (Type 0)), (succ: (Pi (Natural n) Natural))
+    // Typed declaration with complex type expression: (succ: (Pi (Natural n) Natural))
     // Only complex expressions (arrays/lists) are accepted as type annotations in single-element form.
     // Simple name type annotations like (x: Natural) are NOT supported — use (x: Natural x) prefix form instead.
     if rhs.len() == 1 {
@@ -3074,7 +3074,7 @@ mod tests {
     fn typed_var_declare() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (x of Natural))
 "#,
@@ -3088,8 +3088,8 @@ mod tests {
     fn typed_var_wrong_type() {
         let results = run(
             r#"
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (? (x of Boolean))
 "#,
@@ -3102,8 +3102,8 @@ mod tests {
     fn typed_var_multiple() {
         let results = run(
             r#"
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (y: Boolean y)
 (? (x of Natural))
@@ -3249,7 +3249,7 @@ mod tests {
     fn type_check_confirm() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (x of Natural))
 "#,
@@ -3262,8 +3262,8 @@ mod tests {
     fn type_check_reject() {
         let results = run(
             r#"
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (x: Natural x)
 (? (x of Boolean))
 "#,
@@ -3290,7 +3290,7 @@ mod tests {
     fn type_of_query_typed_var() {
         let results = run_typed(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 (? (type of x))
 "#,
@@ -3318,7 +3318,7 @@ mod tests {
     fn lean_natural_type_constructors() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (succ: (Pi (Natural n) Natural))
 (? (zero of Natural))
@@ -3335,7 +3335,7 @@ mod tests {
     fn lean_boolean_type_constructors() {
         let results = run(
             r#"
-(Boolean: (Type 0))
+(Boolean: (Type 0) Boolean)
 (true-val: Boolean true-val)
 (false-val: Boolean false-val)
 (? (true-val of Boolean))
@@ -3351,7 +3351,7 @@ mod tests {
     fn lean_identity_function_type() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (identity: (Pi (Natural x) Natural))
 (? (identity of (Pi (Natural x) Natural)))
 "#,
@@ -3364,7 +3364,7 @@ mod tests {
     fn types_with_probabilities() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (? (zero of Natural))
 ((zero = zero) has probability 1)
@@ -3457,7 +3457,7 @@ mod tests {
         let results = run(
             r#"
 (a: a is a)
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (x: Natural x)
 ((a = a) has probability 1)
 (? (a = a))
@@ -3478,7 +3478,7 @@ mod tests {
     fn prefix_type_zero_natural() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (? (zero of Natural))
 "#,
@@ -3504,8 +3504,8 @@ mod tests {
     fn prefix_type_multiple_constructors() {
         let results = run(
             r#"
-(Natural: (Type 0))
-(Boolean: (Type 0))
+(Natural: (Type 0) Natural)
+(Boolean: (Type 0) Boolean)
 (zero: Natural zero)
 (true-val: Boolean true-val)
 (? (zero of Natural))
@@ -3521,7 +3521,7 @@ mod tests {
     fn prefix_type_with_pi_constructor() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (zero: Natural zero)
 (succ: (Pi (Natural n) Natural))
 (? (zero of Natural))
@@ -3557,7 +3557,7 @@ mod tests {
     fn lambda_multi_param() {
         let results = run(
             r#"
-(Natural: (Type 0))
+(Natural: (Type 0) Natural)
 (? (lambda (Natural x, Natural y) (x + y)))
 "#,
             None,

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,5 +1,5 @@
 // ADL CLI — run a LiNo knowledge base and print query results
-use adl::run;
+use adl::{run_typed, RunResult};
 use std::env;
 use std::fs;
 
@@ -14,11 +14,15 @@ fn main() {
         eprintln!("Error reading {}: {}", file, e);
         std::process::exit(1);
     });
-    let outs = run(&text, None);
+    let outs = run_typed(&text, None);
     for v in outs {
-        let formatted = format!("{:.6}", v);
-        // Remove trailing zeros after decimal point
-        let formatted = formatted.trim_end_matches('0').trim_end_matches('.');
-        println!("{}", formatted);
+        match v {
+            RunResult::Num(n) => {
+                let formatted = format!("{:.6}", n);
+                let formatted = formatted.trim_end_matches('0').trim_end_matches('.');
+                println!("{}", formatted);
+            }
+            RunResult::Type(s) => println!("{}", s),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Implements a dependent type system for ADL (Associative-Dependent Logic) following the principle that "everything is a link" — types are stored as associations in the link network. ADL is a **dynamic axiomatic system** that embraces self-reference and resolves paradoxes to the midpoint truth value.

### Core Features (all 5 CoC expression forms)

- **Self-referential Type**: `(Type: Type Type)` — Type is its own type (paradoxes resolve to 0.5)
- **Universe hierarchy**: `(Type 0)`, `(Type 1)`, ... with automatic `(Type N) : (Type N+1)` (Lean/Rocq compatibility)
- **Pi-types** (dependent products): `(Pi (Natural n) ReturnType)`
- **Lambda abstraction**: `(lambda (Natural x) body)` with multi-param support `(lambda (Natural x, Natural y) body)`
- **Application**: `(apply f x)` with full β-reduction, plus prefix shorthand `(f x)`
- **Type queries**: `(? (zero of Natural))` → 1, `(? (type of zero))` → Natural
- **Prefix type notation**: `(zero: Natural zero)` — the LiNo-native way to declare typed terms

### Dynamic Axiomatic System

Unlike classical type theory (Lean, Rocq) which forbids `Type : Type` to avoid Russell's paradox, ADL allows it:

```lino
(Type: Type Type)                # Type defines itself
(Natural: Type Natural)          # Natural is a Type
(zero: Natural zero)             # zero is a Natural
(? (Type of Type))               # -> 1 (self-referential: works!)
```

Paradoxes resolve to the midpoint truth value (0.5 in `[0,1]`), making self-referential types safe. Both `(Type: Type Type)` and `(Type N)` can coexist.

### Syntax (per reviewer requirements)

- Full names: `lambda` (not `lam`), `apply` (not `app`), `identity` (not `id`), `Natural` (not `Nat`), `Boolean` (not `Bool`)
- `Pi` stays short
- Colon (`:`) exclusively for link definitions — never as standalone separator
- Type checking: `(expr of Type)` returns 1/0
- Type inference: `(type of expr)` returns the type name
- Lambda bindings use prefix type notation: `(lambda (Natural x) body)`
- **Type definitions follow `(SubType: Type SubType)` pattern**: `(Natural: Type Natural)`, `(Type: Type Type)`

### Example

```lino
(Type: Type Type)
(Natural: Type Natural)
(Boolean: Type Boolean)
(zero: Natural zero)
(true-val: Boolean true-val)
(succ: (Pi (Natural n) Natural))
(identity: lambda (Natural x) x)

(? (zero of Natural))        # -> 1
(? (Natural of Type))        # -> 1
(? (Type of Type))           # -> 1
(? (apply identity 0.7))     # -> 0.7
(? (type of zero))           # -> Natural
```

### Tests

- 176 tests pass in both JavaScript and Rust (124 existing + 52 new type system tests)
- All backward-compatible with existing probabilistic logic features
- Includes self-referential type tests and paradox resolution alongside types

## Test plan

- [x] All 176 JS tests pass (`npm test`)
- [x] All 176 Rust tests pass (`cargo test`)
- [x] Example .lino files updated with `(Type: Type Type)` as primary approach
- [x] Documentation updated (README.md, case study docs, syntax comparison)
- [x] Both implementations produce identical results
- [x] Type definitions use `(SubType: Type SubType)` pattern consistently
- [x] Self-referential `(Type: Type Type)` works alongside `(Type N)` universe hierarchy
- [x] Dynamic axiomatic system documented in README and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #13