### PR TITLE
Add composite natural language operators, standard examples, reorder docs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T17:03:29.454Z for PR creation at branch issue-20-3d15ec4b70c9 for issue https://github.com/link-foundation/relative-meta-logic/issues/20

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T17:03:29.454Z for PR creation at branch issue-20-3d15ec4b70c9 for issue https://github.com/link-foundation/relative-meta-logic/issues/20

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ RML (Relative Meta-Logic, formerly Associative-Dependent Logic / ADL) is a minim
 - Redefine logical operators with different semantics
 - Configure truth value ranges: `[0, 1]` or `[-1, 1]` (balanced/symmetric)
 - Configure logic valence: 2-valued ([Boolean](https://en.wikipedia.org/wiki/Boolean_algebra)), 3-valued ([ternary/Kleene](https://en.wikipedia.org/wiki/Three-valued_logic)), N-valued, or continuous
-- Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`, `both`, `neither`
+- Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`
+- Use and redefine Belnap operators: `both` (contradiction/avg) and `neither` (gap/product)
 - Resolve paradoxical statements (e.g. the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox))
 - Perform decimal-precision arithmetic (`+`, `-`, `*`, `/`) — `0.1 + 0.2 = 0.3`, not `0.30000000000000004`
 - Query the truth value of complex expressions
@@ -135,7 +136,7 @@ Sets the number of discrete truth values. Default is `0` (continuous, no quantiz
 
 ### Truth Constants
 
-The symbols `true`, `false`, `unknown`, `undefined`, `both`, and `neither` are predefined with values based on the current range:
+The symbols `true`, `false`, `unknown`, and `undefined` are predefined with values based on the current range:
 
 | Constant | Default in `[0, 1]` | Default in `[-1, 1]` | Definition | Interpretation |
 |----------|---------------------|----------------------|------------|----------------|
@@ -143,10 +144,6 @@ The symbols `true`, `false`, `unknown`, `undefined`, `both`, and `neither` are p
 | `false`  | `0`                 | `-1`                 | `min(range)` | Definitely false |
 | `unknown` | `0.5`              | `0`                  | `mid(range)` | Truth value not known |
 | `undefined` | `0.5`            | `0`                  | `mid(range)` | Not yet defined |
-| `both`   | `0.5`               | `0`                  | `mid(range)` | Both true and false (contradiction) |
-| `neither` | `0.5`              | `0`                  | `mid(range)` | Neither true nor false (gap) |
-
-The constants `both` and `neither` come from [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where contradictions and gaps are first-class truth values. In RML, they map to the midpoint of the range — the same numeric value as `unknown`, but with distinct semantic meaning. This allows paradoxes like the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) to resolve naturally to 0.5.
 
 These constants can be used directly in expressions:
 
@@ -154,10 +151,7 @@ These constants can be used directly in expressions:
 (? true)              # -> 1 in [0,1], 1 in [-1,1]
 (? false)             # -> 0 in [0,1], -1 in [-1,1]
 (? unknown)           # -> 0.5 in [0,1], 0 in [-1,1]
-(? both)              # -> 0.5 in [0,1], 0 in [-1,1]
-(? neither)           # -> 0.5 in [0,1], 0 in [-1,1]
 (? (not true))        # -> 0 in [0,1], -1 in [-1,1]
-(? (not both))        # -> 0.5 (fixed point of negation)
 (? (true and false))  # -> 0.5 (avg), 0 (avg in [-1,1])
 ```
 
@@ -166,10 +160,46 @@ All truth constants can be **redefined** to custom values:
 ```lino
 (true: 0.8)           # Redefine true to 0.8
 (false: 0.2)          # Redefine false to 0.2
-(both: 0.7)           # Redefine both to 0.7
 (? true)              # -> 0.8
 (? false)             # -> 0.2
-(? both)              # -> 0.7
+```
+
+### Belnap Operators: `both` and `neither`
+
+The operators `both` and `neither` come from [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where contradictions and gaps are first-class concepts. Unlike truth constants, these are **operators** that alter the AND operation:
+
+| Operator | Default Aggregator | Example | Result | Interpretation |
+|----------|-------------------|---------|--------|----------------|
+| `both` | `avg` | `(true both false)` | `0.5` | Both true and false (contradiction) |
+| `neither` | `product` | `(true neither false)` | `0` | Neither true nor false (gap) |
+
+```lino
+# Contradiction: both true and false
+(? (true both false))     # -> 0.5 (avg of 1 and 0)
+(? (true both true))      # -> 1   (both agree: true)
+
+# Gap: neither true nor false
+(? (true neither false))  # -> 0   (product of 1 and 0)
+(? (true neither true))   # -> 1   (both agree: true)
+```
+
+Both operators are **redefinable** via aggregator selection, just like `and` and `or`:
+
+```lino
+(both: min)               # Redefine both to use min
+(? (true both false))     # -> 0
+(neither: max)            # Redefine neither to use max
+(? (true neither false))  # -> 1
+```
+
+This allows paradoxes like the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) to be expressed naturally:
+
+```lino
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? ((a = a) both (a != a)))     # -> 0.5 (contradiction resolves to midpoint)
+(? ((a = a) neither (a != a)))  # -> 0   (gap: no info propagates)
 ```
 
 When the range changes (via `(range: ...)`), all truth constants are automatically re-initialized to their defaults for the new range.
@@ -436,22 +466,20 @@ In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Pr
 
 ### Belnap's Four-Valued Logic
 
-See `examples/belnap-four-valued.lino` — extends classical logic with `both` (contradiction) and `neither` (gap) truth values. This is the standard framework for reasoning about paradoxes:
+See `examples/belnap-four-valued.lino` — extends classical logic with `both` (contradiction) and `neither` (gap) **operators** that alter the AND operation. This is the standard framework for reasoning about paradoxes:
 
 ```lino
 (and: min)
 (or: max)
 
-(? true)          # -> 1
-(? false)         # -> 0
-(? both)          # -> 0.5  (both true and false — contradiction)
-(? neither)       # -> 0.5  (neither true nor false — gap)
-(? (not both))    # -> 0.5  (fixed point of negation!)
+(? (true both false))     # -> 0.5  (contradiction: avg of 1 and 0)
+(? (true neither false))  # -> 0    (gap: product of 1 and 0)
+(? (true both true))      # -> 1    (agree: avg of 1 and 1)
 
-# The liar paradox resolves naturally to "both"
+# The liar paradox resolves naturally via "both"
 (s: s is s)
 ((s = false) has probability 0.5)
-(? (s = false))   # -> 0.5
+(? (s = false))           # -> 0.5
 ```
 
 See: [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap)
@@ -615,8 +643,8 @@ The test suites cover:
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
-- Truth constants (`true`, `false`, `unknown`, `undefined`, `both`, `neither`): defaults, redefinition, range changes, use in expressions, quantization
-- Belnap's four-valued logic: `both`/`neither` constants, fixed points, Belnap semantics
+- Truth constants (`true`, `false`, `unknown`, `undefined`): defaults, redefinition, range changes, use in expressions, quantization
+- Belnap operators (`both`, `neither`): default aggregators, redefinition, prefix/infix forms, fuzzy values, range changes
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, type queries, prefix type notation

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project provides two equivalent implementations:
 - **[JavaScript](./js/)** — Node.js implementation using the official [links-notation](https://github.com/link-foundation/links-notation) parser
 - **[Rust](./rust/)** — Rust implementation using the official [links-notation](https://github.com/link-foundation/links-notation) crate
 
-Both implementations pass the same 199 tests and produce identical results.
+Both implementations pass the same comprehensive test suites and produce identical results.
 
 For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
@@ -24,7 +24,7 @@ RML (Relative Meta-Logic, formerly Associative-Dependent Logic / ADL) is a minim
 - Redefine logical operators with different semantics
 - Configure truth value ranges: `[0, 1]` or `[-1, 1]` (balanced/symmetric)
 - Configure logic valence: 2-valued ([Boolean](https://en.wikipedia.org/wiki/Boolean_algebra)), 3-valued ([ternary/Kleene](https://en.wikipedia.org/wiki/Three-valued_logic)), N-valued, or continuous
-- Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`
+- Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`, `both`, `neither`
 - Resolve paradoxical statements (e.g. the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox))
 - Perform decimal-precision arithmetic (`+`, `-`, `*`, `/`) — `0.1 + 0.2 = 0.3`, not `0.30000000000000004`
 - Query the truth value of complex expressions
@@ -67,26 +67,29 @@ cargo run -- demo.lino
 Create a file `example.lino`:
 
 ```lino
-# Define a term
-(a: a is a)
-
-# Set up operators
-(!=: not =)
-(and: avg)
+# Classical Boolean logic
+(valence: 2)
+(and: min)
 (or: max)
 
-# Assign probabilities to axioms
-((a = a) has probability 1)
-((a != a) has probability 0)
+# Define propositions
+(p: p is p)
+(q: q is q)
 
-# Query probabilities
-(? ((a = a) and (a != a)))   # -> 0.5
-(? ((a = a) or  (a != a)))   # -> 1
+# Assign truth values
+((p = true) has probability 1)
+((q = true) has probability 0)
+
+# Query
+(? ((p = true) and (q = true)))          # -> 0 (true AND false = false)
+(? ((p = true) or (q = true)))           # -> 1 (true OR false = true)
+(? ((p = true) or (not (p = true))))     # -> 1 (law of excluded middle)
 ```
 
 Output:
 ```
-0.5
+0
+1
 1
 ```
 
@@ -132,14 +135,18 @@ Sets the number of discrete truth values. Default is `0` (continuous, no quantiz
 
 ### Truth Constants
 
-The symbols `true`, `false`, `unknown`, and `undefined` are predefined with values based on the current range:
+The symbols `true`, `false`, `unknown`, `undefined`, `both`, and `neither` are predefined with values based on the current range:
 
-| Constant | Default in `[0, 1]` | Default in `[-1, 1]` | Definition |
-|----------|---------------------|----------------------|------------|
-| `true`   | `1`                 | `1`                  | `max(range)` |
-| `false`  | `0`                 | `-1`                 | `min(range)` |
-| `unknown` | `0.5`              | `0`                  | `(max(range) - min(range)) / 2 + min(range)` |
-| `undefined` | `0.5`            | `0`                  | `(max(range) - min(range)) / 2 + min(range)` |
+| Constant | Default in `[0, 1]` | Default in `[-1, 1]` | Definition | Interpretation |
+|----------|---------------------|----------------------|------------|----------------|
+| `true`   | `1`                 | `1`                  | `max(range)` | Definitely true |
+| `false`  | `0`                 | `-1`                 | `min(range)` | Definitely false |
+| `unknown` | `0.5`              | `0`                  | `mid(range)` | Truth value not known |
+| `undefined` | `0.5`            | `0`                  | `mid(range)` | Not yet defined |
+| `both`   | `0.5`               | `0`                  | `mid(range)` | Both true and false (contradiction) |
+| `neither` | `0.5`              | `0`                  | `mid(range)` | Neither true nor false (gap) |
+
+The constants `both` and `neither` come from [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where contradictions and gaps are first-class truth values. In RML, they map to the midpoint of the range — the same numeric value as `unknown`, but with distinct semantic meaning. This allows paradoxes like the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) to resolve naturally to 0.5.
 
 These constants can be used directly in expressions:
 
@@ -147,20 +154,25 @@ These constants can be used directly in expressions:
 (? true)              # -> 1 in [0,1], 1 in [-1,1]
 (? false)             # -> 0 in [0,1], -1 in [-1,1]
 (? unknown)           # -> 0.5 in [0,1], 0 in [-1,1]
+(? both)              # -> 0.5 in [0,1], 0 in [-1,1]
+(? neither)           # -> 0.5 in [0,1], 0 in [-1,1]
 (? (not true))        # -> 0 in [0,1], -1 in [-1,1]
+(? (not both))        # -> 0.5 (fixed point of negation)
 (? (true and false))  # -> 0.5 (avg), 0 (avg in [-1,1])
 ```
 
-Truth constants can be **redefined** to custom values:
+All truth constants can be **redefined** to custom values:
 
 ```lino
 (true: 0.8)           # Redefine true to 0.8
 (false: 0.2)          # Redefine false to 0.2
+(both: 0.7)           # Redefine both to 0.7
 (? true)              # -> 0.8
 (? false)             # -> 0.2
+(? both)              # -> 0.7
 ```
 
-When the range changes (via `(range: ...)`), truth constants are automatically re-initialized to their defaults for the new range.
+When the range changes (via `(range: ...)`), all truth constants are automatically re-initialized to their defaults for the new range.
 
 ### Operator Redefinitions
 
@@ -353,41 +365,96 @@ This means ADL can serve as a **meta-theory** for both classical and non-classic
 
 ## Examples
 
-Example `.lino` files are available in both `js/` and `rust/` directories.
+Example `.lino` files are available in both `js/examples/` and `rust/examples/` directories. Examples progress from standard, familiar logic systems to more advanced and non-standard constructions.
 
-### Standard Logic (with avg semantics)
+### Classical Logic (Boolean, 2-valued)
 
-See `demo.lino`:
-
-```lino
-(a: a is a)
-(!=: not =)
-(and: avg)
-(or: max)
-
-((a = a) has probability 1)
-((a != a) has probability 0)
-
-(? ((a = a) and (a != a)))   # -> 0.5
-(? ((a = a) or  (a != a)))   # -> 1
-```
-
-### Flipped Axioms
-
-See `flipped-axioms.lino` — demonstrates that the system can handle arbitrary probability assignments:
+See `examples/classical-logic.lino` — the most familiar logic system where every proposition is either true or false:
 
 ```lino
-(a: a is a)
-(!=: not =)
-(and: avg)
+(valence: 2)
+(and: min)
 (or: max)
 
-((a = a) has probability 0)
-((a != a) has probability 1)
+(p: p is p)
+((p = true) has probability 1)
 
-(? ((a = a) and (a != a)))   # -> 0.5
-(? ((a = a) or  (a != a)))   # -> 1
+(? (p = true))                          # -> 1 (true)
+(? (not (p = true)))                    # -> 0 (false)
+(? ((p = true) or (not (p = true))))    # -> 1 (law of excluded middle)
+(? ((p = true) and (not (p = true))))   # -> 0 (law of non-contradiction)
 ```
+
+### Propositional Logic (Probabilistic)
+
+See `examples/propositional-logic.lino` — multiple propositions with standard probabilistic connectives:
+
+```lino
+(and: product)              # P(A ∩ B) = P(A) * P(B)
+(or: probabilistic_sum)     # P(A ∪ B) = 1 - (1-P(A))*(1-P(B))
+
+((rain = true) has probability 0.3)
+((umbrella = true) has probability 0.6)
+
+(? ((rain = true) and (umbrella = true)))   # -> 0.18
+(? ((rain = true) or (umbrella = true)))    # -> 0.72
+(? (not (rain = true)))                     # -> 0.7
+```
+
+### Fuzzy Logic (Continuous)
+
+See `examples/fuzzy-logic.lino` — standard [Zadeh fuzzy logic](https://en.wikipedia.org/wiki/Fuzzy_logic) where truth values represent degrees of membership:
+
+```lino
+(and: min)
+(or: max)
+
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.3)
+
+(? ((a = tall) and (b = tall)))   # -> 0.3  (min)
+(? ((a = tall) or (b = tall)))    # -> 0.8  (max)
+(? (not (a = tall)))              # -> 0.2  (complement)
+```
+
+### Ternary Kleene Logic (3-valued)
+
+See `examples/ternary-kleene.lino` — [Kleene's strong three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics):
+
+```lino
+(valence: 3)
+(and: min)
+(or: max)
+
+(? (0.5 and 1))          # -> 0.5  (unknown AND true = unknown)
+(? (0.5 and 0))          # -> 0    (unknown AND false = false)
+(? (0.5 or 1))           # -> 1    (unknown OR true = true)
+(? (0.5 or (not 0.5)))   # -> 0.5  (law of excluded middle FAILS!)
+```
+
+In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics), the law of excluded middle (`A ∨ ¬A`) is **not** a tautology — this is the key difference from [classical logic](https://en.wikipedia.org/wiki/Classical_logic).
+
+### Belnap's Four-Valued Logic
+
+See `examples/belnap-four-valued.lino` — extends classical logic with `both` (contradiction) and `neither` (gap) truth values. This is the standard framework for reasoning about paradoxes:
+
+```lino
+(and: min)
+(or: max)
+
+(? true)          # -> 1
+(? false)         # -> 0
+(? both)          # -> 0.5  (both true and false — contradiction)
+(? neither)       # -> 0.5  (neither true nor false — gap)
+(? (not both))    # -> 0.5  (fixed point of negation!)
+
+# The liar paradox resolves naturally to "both"
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))   # -> 0.5
+```
+
+See: [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap)
 
 ### Liar Paradox Resolution
 
@@ -397,9 +464,6 @@ See `examples/liar-paradox.lino` — resolution in `[0, 1]` range:
 
 ```lino
 (s: s is s)
-(!=: not =)
-(and: avg)
-(or: max)
 
 ((s = false) has probability 0.5)
 (? (s = false))          # -> 0.5  (50% from 0% to 100%)
@@ -410,35 +474,43 @@ See `examples/liar-paradox-balanced.lino` — resolution in `[-1, 1]` range:
 
 ```lino
 (range: -1 1)
-
 (s: s is s)
-(!=: not =)
-(and: avg)
-(or: max)
 
 ((s = false) has probability 0)
 (? (s = false))          # -> 0   (0% from -100% to 100%)
 (? (not (s = false)))    # -> 0   (fixed point: not(0) = 0)
 ```
 
-### Ternary Kleene Logic
+### Custom Operators (avg semantics)
 
-See `examples/ternary-kleene.lino` — demonstrates [Kleene's strong three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics) where AND=min, OR=max:
+See `demo.lino` — demonstrates the configurable nature of operators with avg-based AND:
 
 ```lino
-(valence: 3)
-(and: min)
+(a: a is a)
+(!=: not =)
+(and: avg)     # non-standard: average instead of min
 (or: max)
 
-(? (0.5 and 1))          # -> 0.5  (unknown AND true = unknown)
-(? (0.5 and 0))          # -> 0    (unknown AND false = false)
-(? (0.5 or 1))           # -> 1    (unknown OR true = true)
-(? (0.5 or 0))           # -> 0.5  (unknown OR false = unknown)
-(? (not 0.5))            # -> 0.5  (NOT unknown = unknown)
-(? (0.5 or (not 0.5)))   # -> 0.5  (law of excluded middle FAILS!)
+((a = a) has probability 1)
+((a != a) has probability 0)
+
+(? ((a = a) and (a != a)))   # -> 0.5
+(? ((a = a) or  (a != a)))   # -> 1
 ```
 
-In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics), the law of excluded middle (`A ∨ ¬A`) is **not** a tautology — this is the key difference from [classical logic](https://en.wikipedia.org/wiki/Classical_logic).
+See `flipped-axioms.lino` — demonstrates that the system handles arbitrary probability assignments:
+
+```lino
+(a: a is a)
+(!=: not =)
+(and: avg)
+(or: max)
+
+((a = a) has probability 0)
+((a != a) has probability 1)
+
+(? ((a = a) and (a != a)))   # -> 0.5 (same result — avg is symmetric)
+```
 
 ### Bayesian Inference
 
@@ -543,7 +615,8 @@ The test suites cover:
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
-- Truth constants (`true`, `false`, `unknown`, `undefined`): defaults, redefinition, range changes, use in expressions, quantization
+- Truth constants (`true`, `false`, `unknown`, `undefined`, `both`, `neither`): defaults, redefinition, range changes, use in expressions, quantization
+- Belnap's four-valued logic: `both`/`neither` constants, fixed points, Belnap semantics
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, type queries, prefix type notation
@@ -569,6 +642,7 @@ See language-specific documentation:
 - [Łukasiewicz logic](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic) — N-valued and infinite-valued extensions
 - [Fuzzy logic](https://en.wikipedia.org/wiki/Fuzzy_logic) — continuous-valued logic with degrees of truth
 - [Balanced ternary](https://en.wikipedia.org/wiki/Balanced_ternary) — ternary system using {-1, 0, 1}
+- [Four-valued logic (Belnap)](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap) — extends classical logic with "both" (contradiction) and "neither" (gap)
 - [Liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) — "this statement is false" and its resolution in many-valued logics
 - [Bayesian statistics](https://en.wikipedia.org/wiki/Bayesian_statistics) — probability as a measure of belief
 - [Bayesian inference](https://en.wikipedia.org/wiki/Bayesian_inference) — updating beliefs based on evidence

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ RML (Relative Meta-Logic, formerly Associative-Dependent Logic / ADL) is a minim
 - Configure truth value ranges: `[0, 1]` or `[-1, 1]` (balanced/symmetric)
 - Configure logic valence: 2-valued ([Boolean](https://en.wikipedia.org/wiki/Boolean_algebra)), 3-valued ([ternary/Kleene](https://en.wikipedia.org/wiki/Three-valued_logic)), N-valued, or continuous
 - Use and redefine truth constants: `true`, `false`, `unknown`, `undefined`
-- Use and redefine Belnap operators: `both` (contradiction/avg) and `neither` (gap/product)
+- Use and redefine Belnap operators: `both...and` (contradiction/avg) and `neither...nor` (gap/product)
 - Resolve paradoxical statements (e.g. the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox))
 - Perform decimal-precision arithmetic (`+`, `-`, `*`, `/`) — `0.1 + 0.2 = 0.3`, not `0.30000000000000004`
 - Query the truth value of complex expressions
@@ -166,30 +166,30 @@ All truth constants can be **redefined** to custom values:
 
 ### Belnap Operators: `both` and `neither`
 
-The operators `both` and `neither` come from [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where contradictions and gaps are first-class concepts. Unlike truth constants, these are **operators** that alter the AND operation:
+The operators `both` and `neither` come from [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where contradictions and gaps are first-class concepts. These are **composite natural language operators** that alter the AND operation:
 
 | Operator | Default Aggregator | Example | Result | Interpretation |
 |----------|-------------------|---------|--------|----------------|
-| `both` | `avg` | `(true both false)` | `0.5` | Both true and false (contradiction) |
-| `neither` | `product` | `(true neither false)` | `0` | Neither true nor false (gap) |
+| `both...and` | `avg` | `(both true and false)` | `0.5` | Both true and false (contradiction) |
+| `neither...nor` | `product` | `(neither true nor false)` | `0` | Neither true nor false (gap) |
 
 ```lino
 # Contradiction: both true and false
-(? (true both false))     # -> 0.5 (avg of 1 and 0)
-(? (true both true))      # -> 1   (both agree: true)
+(? (both true and false))     # -> 0.5 (avg of 1 and 0)
+(? (both true and true))      # -> 1   (both agree: true)
 
 # Gap: neither true nor false
-(? (true neither false))  # -> 0   (product of 1 and 0)
-(? (true neither true))   # -> 1   (both agree: true)
+(? (neither true nor false))  # -> 0   (product of 1 and 0)
+(? (neither true nor true))   # -> 1   (both agree: true)
 ```
 
 Both operators are **redefinable** via aggregator selection, just like `and` and `or`:
 
 ```lino
-(both: min)               # Redefine both to use min
-(? (true both false))     # -> 0
-(neither: max)            # Redefine neither to use max
-(? (true neither false))  # -> 1
+(both: min)                   # Redefine both to use min
+(? (both true and false))     # -> 0
+(neither: max)                # Redefine neither to use max
+(? (neither true nor false))  # -> 1
 ```
 
 This allows paradoxes like the [liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) to be expressed naturally:
@@ -198,8 +198,8 @@ This allows paradoxes like the [liar paradox](https://en.wikipedia.org/wiki/Liar
 (a: a is a)
 ((a = a) has probability 1)
 ((a != a) has probability 0)
-(? ((a = a) both (a != a)))     # -> 0.5 (contradiction resolves to midpoint)
-(? ((a = a) neither (a != a)))  # -> 0   (gap: no info propagates)
+(? (both (a = a) and (a != a)))     # -> 0.5 (contradiction resolves to midpoint)
+(? (neither (a = a) nor (a != a)))  # -> 0   (gap: no info propagates)
 ```
 
 When the range changes (via `(range: ...)`), all truth constants are automatically re-initialized to their defaults for the new range.
@@ -466,20 +466,20 @@ In [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Pr
 
 ### Belnap's Four-Valued Logic
 
-See `examples/belnap-four-valued.lino` — extends classical logic with `both` (contradiction) and `neither` (gap) **operators** that alter the AND operation. This is the standard framework for reasoning about paradoxes:
+See `examples/belnap-four-valued.lino` — extends classical logic with `both...and` (contradiction) and `neither...nor` (gap) **composite natural language operators** that alter the AND operation. This is the standard framework for reasoning about paradoxes:
 
 ```lino
 (and: min)
 (or: max)
 
-(? (true both false))     # -> 0.5  (contradiction: avg of 1 and 0)
-(? (true neither false))  # -> 0    (gap: product of 1 and 0)
-(? (true both true))      # -> 1    (agree: avg of 1 and 1)
+(? (both true and false))     # -> 0.5  (contradiction: avg of 1 and 0)
+(? (neither true nor false))  # -> 0    (gap: product of 1 and 0)
+(? (both true and true))      # -> 1    (agree: avg of 1 and 1)
 
 # The liar paradox resolves naturally via "both"
 (s: s is s)
 ((s = false) has probability 0.5)
-(? (s = false))           # -> 0.5
+(? (s = false))               # -> 0.5
 ```
 
 See: [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap)
@@ -644,7 +644,7 @@ The test suites cover:
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Truth constants (`true`, `false`, `unknown`, `undefined`): defaults, redefinition, range changes, use in expressions, quantization
-- Belnap operators (`both`, `neither`): default aggregators, redefinition, prefix/infix forms, fuzzy values, range changes
+- Belnap operators (`both...and`, `neither...nor`): default aggregators, redefinition, composite/prefix/infix forms, fuzzy values, range changes
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, type queries, prefix type notation

--- a/docs/case-studies/issue-20/README.md
+++ b/docs/case-studies/issue-20/README.md
@@ -5,6 +5,7 @@
 1. **Issue opened**: User (via ChatGPT dialog) noticed that RML's `(and: avg)` semantics produce `0.5` for `(a = a) AND (a != a)`, which is non-standard — no mainstream logic assigns 0.5 to a conjunction of a tautology and contradiction.
 2. **ChatGPT analysis**: Identified that 0.5 for paradoxes is closest to [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where "both true and false" (contradiction) is a legitimate truth value.
 3. **Requirements identified**: Add standard examples first, define `both`/`neither` keywords, ensure everything is tested and configurable.
+4. **Feedback (PR #21)**: `both` and `neither` should be **operators** altering the AND operation, not truth constants. This aligns with Belnap's original framework where they represent different *conjunction strategies*.
 
 ## Root Cause Analysis
 
@@ -22,16 +23,24 @@ The liar paradox resolving to `0.5` is actually well-grounded in [Belnap's four-
 
 However, RML lacked the `both` and `neither` keywords, so users couldn't express these concepts in standard terminology.
 
-**Root cause**: The system supported the numeric values (0.5 maps to "both" in Belnap's encoding) but lacked the named constants that make the connection to standard theory explicit.
+**Root cause**: The system supported the numeric values (0.5 maps to "both" in Belnap's encoding) but lacked the operators that make the connection to standard theory explicit.
 
-## Requirements (from issue)
+### Problem 3: Constants vs Operators
+Initial implementation made `both` and `neither` truth constants (symbol probabilities). However, in Belnap's framework they represent *different ways of combining truth values* — they alter how conjunction works:
+
+- **`both`** (gullibility): combines info even when contradictory → `avg` semantics → `(true both false) = 0.5`
+- **`neither`** (consensus): only propagates agreed info → `product` semantics → `(true neither false) = 0`
+
+**Root cause**: Modeling Belnap's concepts as static values missed their dynamic, operational nature.
+
+## Requirements (from issue and PR feedback)
 
 | # | Requirement | Status |
 |---|-------------|--------|
 | 1 | Add standard/common examples first, so users aren't surprised | Done |
 | 2 | After standard examples, show non-standard ones (avg semantics, etc.) | Done |
-| 3 | Add `both` keyword for Belnap's "both true and false" | Done |
-| 4 | Add `neither` keyword for Belnap's "neither true nor false" | Done |
+| 3 | Add `both` as an operator (not constant) for Belnap's contradiction | Done |
+| 4 | Add `neither` as an operator (not constant) for Belnap's gap | Done |
 | 5 | Support paradox resolution to 0.5 within standard theory | Done |
 | 6 | Show how everything is configurable and redefinable | Done |
 | 7 | Each example tested, new tests added, code updated | Done |
@@ -39,21 +48,27 @@ However, RML lacked the `both` and `neither` keywords, so users couldn't express
 
 ## Solution
 
-### 1. New Truth Constants: `both` and `neither`
+### 1. Belnap Operators: `both` and `neither`
 
-Added two new predefined truth constants to both JS and Rust implementations:
+Added two new operators to both JS and Rust implementations:
 
 ```javascript
-// In _initTruthConstants():
-this.symbolProb.set('both', this.mid);    // midpoint of range
-this.symbolProb.set('neither', this.mid); // midpoint of range
+// In constructor ops:
+'both': (...xs) => xs.length ? decRound(xs.reduce((a,b)=>a+b,0)/xs.length) : this.lo,  // avg
+'neither': (...xs) => xs.length ? decRound(xs.reduce((a,b)=>a*b,1)) : this.lo,          // product
 ```
 
-These constants:
-- Default to the midpoint of the current range (0.5 in [0,1], 0 in [-1,1])
-- Are redefinable like all other truth constants: `(both: 0.7)`
-- Auto-update when the range changes
-- Are fixed points of negation: `not(both) = both`
+These operators:
+- Work in both infix and prefix form: `(true both false)` or `(both true false)`
+- Default to `avg` (both) and `product` (neither) aggregators
+- Are redefinable like `and` and `or`: `(both: min)`, `(neither: max)`
+- Auto-update when the range changes via `reinit_ops`
+- Support all aggregator types: avg, min, max, product, probabilistic_sum
+
+Key semantic difference from the AND operator:
+- `(true both false) = 0.5` — contradiction (avg: (1+0)/2)
+- `(true neither false) = 0` — gap (product: 1*0)
+- `(true and false) = 0.5` — default AND uses avg too, but `both`/`neither` provide explicit Belnap semantics
 
 ### 2. New Standard Examples
 
@@ -62,7 +77,7 @@ Four new example files added (in order of increasing non-standardness):
 1. **`classical-logic.lino`** — Boolean 2-valued logic with standard laws (excluded middle, non-contradiction, double negation)
 2. **`propositional-logic.lino`** — Standard probabilistic propositional logic with product/probabilistic_sum
 3. **`fuzzy-logic.lino`** — Zadeh fuzzy logic with min/max connectives
-4. **`belnap-four-valued.lino`** — Belnap's 4-valued logic demonstrating `both`/`neither` constants
+4. **`belnap-four-valued.lino`** — Belnap's 4-valued logic demonstrating `both`/`neither` operators
 
 ### 3. Reordered Documentation
 
@@ -71,18 +86,28 @@ The README Examples section was restructured to present standard examples first:
 2. Propositional Logic — standard probabilistic
 3. Fuzzy Logic — standard Zadeh
 4. Ternary Kleene — standard 3-valued
-5. Belnap Four-Valued — standard 4-valued with both/neither
+5. Belnap Four-Valued — standard 4-valued with both/neither operators
 6. Liar Paradox — natural resolution via midpoint
 7. Custom Operators — non-standard avg semantics (moved after standard)
 8. Bayesian/Markov/Self-Reasoning — advanced applications
+
+### 4. Inline Comment Fix
+
+Fixed a bug where inline `#` comments containing colons (e.g., `# -> 0.5 disagree: contradiction`) caused the LiNo parser to fail. The `run()` function now strips inline comments after closing parentheses before passing text to the parser.
 
 ## Related Work
 
 ### Belnap's Four-Valued Logic (FOUR)
 
 Proposed by Nuel Belnap in 1977 for reasoning with potentially contradictory information from multiple sources. The four values form a **bilattice** with two orderings:
-- **Truth ordering**: F < N < B < T (or F < {N,B} < T)
-- **Knowledge ordering**: N < {T,F} < B
+- **Truth ordering**: F < {N,B} < T
+- **Knowledge/Information ordering**: N < {T,F} < B
+
+The two orderings give rise to different operations:
+- **Truth lattice ops**: standard AND (∧) = glb, OR (∨) = lub
+- **Knowledge lattice ops**: consensus (⊗) = meet, gullibility (⊕) = join
+
+In RML, `both` maps to gullibility (avg) and `neither` maps to consensus (product) in the numeric [0,1] encoding.
 
 References:
 - Belnap, N.D. (1977). "A useful four-valued logic." In Modern Uses of Multiple-Valued Logic.
@@ -93,7 +118,7 @@ References:
 The standard numeric encoding maps Belnap's values to [0,1]:
 - T = 1, F = 0, B = 0.5, N = 0.5
 
-Note: B and N have the same numeric value (0.5) but different semantic meaning. In a richer implementation, they could be distinguished as separate symbols with different behaviors in certain operations. RML keeps them numerically equal for simplicity while providing distinct keywords for expressiveness.
+Note: B and N have the same numeric value (0.5) in a simple [0,1] mapping, but the *operators* that produce them differ — `both` uses avg (creating contradiction at midpoint) while `neither` uses product (creating gap at zero).
 
 ### Existing Libraries
 
@@ -103,15 +128,16 @@ Note: B and N have the same numeric value (0.5) but different semantic meaning. 
 | [belern](https://crates.io/crates/belern) | Rust | Belnap + evidence theory |
 | [four-valued](https://hackage.haskell.org/package/four-valued) | Haskell | Belnap bilattice |
 
-RML's approach differs: rather than hardcoding Belnap semantics, it provides configurable truth constants that can model Belnap's logic among many others.
+RML's approach differs: rather than hardcoding Belnap semantics, it provides configurable operators that can model Belnap's logic among many others.
 
 ## Testing
 
-- **JS**: 294 tests (199 original + 95 new), all passing
-- **Rust**: 226 tests (199 original + 27 new), all passing
-- New test categories:
-  - `both`/`neither` defaults, redefinition, range changes, expressions, fixed points
-  - Classical logic example validation
-  - Propositional logic example validation
-  - Fuzzy logic example validation
-  - Belnap four-valued logic example validation
+- **JS**: 297 tests, all passing
+- **Rust**: 230 tests, all passing
+- Test categories for both/neither:
+  - Default aggregator behavior (avg for both, product for neither)
+  - Aggregator redefinition (both: min, neither: max)
+  - Prefix and infix form support
+  - Fuzzy value computation
+  - Range change behavior
+  - Issue scenario reproduction: `(a=a) both (a!=a)` → 0.5

--- a/docs/case-studies/issue-20/README.md
+++ b/docs/case-studies/issue-20/README.md
@@ -59,15 +59,17 @@ Added two new operators to both JS and Rust implementations:
 ```
 
 These operators:
-- Work in both infix and prefix form: `(true both false)` or `(both true false)`
+- Use composite natural language syntax: `(both A and B)`, `(neither A nor B)`
+- Also support prefix form: `(both true false)` and infix form: `(true both false)` for backward compatibility
+- Support variadic form: `(both A and B and C)`, `(neither A nor B nor C)`
 - Default to `avg` (both) and `product` (neither) aggregators
 - Are redefinable like `and` and `or`: `(both: min)`, `(neither: max)`
 - Auto-update when the range changes via `reinit_ops`
 - Support all aggregator types: avg, min, max, product, probabilistic_sum
 
 Key semantic difference from the AND operator:
-- `(true both false) = 0.5` — contradiction (avg: (1+0)/2)
-- `(true neither false) = 0` — gap (product: 1*0)
+- `(both true and false) = 0.5` — contradiction (avg: (1+0)/2)
+- `(neither true nor false) = 0` — gap (product: 1*0)
 - `(true and false) = 0.5` — default AND uses avg too, but `both`/`neither` provide explicit Belnap semantics
 
 ### 2. New Standard Examples

--- a/docs/case-studies/issue-20/README.md
+++ b/docs/case-studies/issue-20/README.md
@@ -1,0 +1,117 @@
+# Case Study: Issue #20 — Standard Examples First, Belnap's Four-Valued Logic
+
+## Timeline
+
+1. **Issue opened**: User (via ChatGPT dialog) noticed that RML's `(and: avg)` semantics produce `0.5` for `(a = a) AND (a != a)`, which is non-standard — no mainstream logic assigns 0.5 to a conjunction of a tautology and contradiction.
+2. **ChatGPT analysis**: Identified that 0.5 for paradoxes is closest to [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where "both true and false" (contradiction) is a legitimate truth value.
+3. **Requirements identified**: Add standard examples first, define `both`/`neither` keywords, ensure everything is tested and configurable.
+
+## Root Cause Analysis
+
+### Problem 1: Examples surprise users
+The existing examples started with `(and: avg)` (the non-standard averaging aggregator), which produces `0.5` for `(true AND false)`. Users familiar with standard logic expect `0` (using min) or specific probabilistic rules (using product). The `avg` result is unintuitive without first showing standard alternatives.
+
+**Root cause**: Examples were added chronologically as features were developed, not ordered pedagogically.
+
+### Problem 2: No standard Belnap support
+The liar paradox resolving to `0.5` is actually well-grounded in [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap), where the four truth values are:
+- **True** (T) — known to be true
+- **False** (F) — known to be false
+- **Both** (B) — both true and false (contradiction/paradox)
+- **Neither** (N) — neither true nor false (unknown/gap)
+
+However, RML lacked the `both` and `neither` keywords, so users couldn't express these concepts in standard terminology.
+
+**Root cause**: The system supported the numeric values (0.5 maps to "both" in Belnap's encoding) but lacked the named constants that make the connection to standard theory explicit.
+
+## Requirements (from issue)
+
+| # | Requirement | Status |
+|---|-------------|--------|
+| 1 | Add standard/common examples first, so users aren't surprised | Done |
+| 2 | After standard examples, show non-standard ones (avg semantics, etc.) | Done |
+| 3 | Add `both` keyword for Belnap's "both true and false" | Done |
+| 4 | Add `neither` keyword for Belnap's "neither true nor false" | Done |
+| 5 | Support paradox resolution to 0.5 within standard theory | Done |
+| 6 | Show how everything is configurable and redefinable | Done |
+| 7 | Each example tested, new tests added, code updated | Done |
+| 8 | Case study analysis | Done |
+
+## Solution
+
+### 1. New Truth Constants: `both` and `neither`
+
+Added two new predefined truth constants to both JS and Rust implementations:
+
+```javascript
+// In _initTruthConstants():
+this.symbolProb.set('both', this.mid);    // midpoint of range
+this.symbolProb.set('neither', this.mid); // midpoint of range
+```
+
+These constants:
+- Default to the midpoint of the current range (0.5 in [0,1], 0 in [-1,1])
+- Are redefinable like all other truth constants: `(both: 0.7)`
+- Auto-update when the range changes
+- Are fixed points of negation: `not(both) = both`
+
+### 2. New Standard Examples
+
+Four new example files added (in order of increasing non-standardness):
+
+1. **`classical-logic.lino`** — Boolean 2-valued logic with standard laws (excluded middle, non-contradiction, double negation)
+2. **`propositional-logic.lino`** — Standard probabilistic propositional logic with product/probabilistic_sum
+3. **`fuzzy-logic.lino`** — Zadeh fuzzy logic with min/max connectives
+4. **`belnap-four-valued.lino`** — Belnap's 4-valued logic demonstrating `both`/`neither` constants
+
+### 3. Reordered Documentation
+
+The README Examples section was restructured to present standard examples first:
+1. Classical Logic (Boolean) — familiar to everyone
+2. Propositional Logic — standard probabilistic
+3. Fuzzy Logic — standard Zadeh
+4. Ternary Kleene — standard 3-valued
+5. Belnap Four-Valued — standard 4-valued with both/neither
+6. Liar Paradox — natural resolution via midpoint
+7. Custom Operators — non-standard avg semantics (moved after standard)
+8. Bayesian/Markov/Self-Reasoning — advanced applications
+
+## Related Work
+
+### Belnap's Four-Valued Logic (FOUR)
+
+Proposed by Nuel Belnap in 1977 for reasoning with potentially contradictory information from multiple sources. The four values form a **bilattice** with two orderings:
+- **Truth ordering**: F < N < B < T (or F < {N,B} < T)
+- **Knowledge ordering**: N < {T,F} < B
+
+References:
+- Belnap, N.D. (1977). "A useful four-valued logic." In Modern Uses of Multiple-Valued Logic.
+- [Wikipedia: Four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap)
+
+### Numeric Encoding
+
+The standard numeric encoding maps Belnap's values to [0,1]:
+- T = 1, F = 0, B = 0.5, N = 0.5
+
+Note: B and N have the same numeric value (0.5) but different semantic meaning. In a richer implementation, they could be distinguished as separate symbols with different behaviors in certain operations. RML keeps them numerically equal for simplicity while providing distinct keywords for expressiveness.
+
+### Existing Libraries
+
+| Library | Language | Belnap Support |
+|---------|----------|----------------|
+| [logic-ts](https://github.com/nicholasgasior/logic-ts) | TypeScript | 4-valued Belnap |
+| [belern](https://crates.io/crates/belern) | Rust | Belnap + evidence theory |
+| [four-valued](https://hackage.haskell.org/package/four-valued) | Haskell | Belnap bilattice |
+
+RML's approach differs: rather than hardcoding Belnap semantics, it provides configurable truth constants that can model Belnap's logic among many others.
+
+## Testing
+
+- **JS**: 294 tests (199 original + 95 new), all passing
+- **Rust**: 226 tests (199 original + 27 new), all passing
+- New test categories:
+  - `both`/`neither` defaults, redefinition, range changes, expressions, fixed points
+  - Classical logic example validation
+  - Propositional logic example validation
+  - Fuzzy logic example validation
+  - Belnap four-valued logic example validation

--- a/experiments/test-composite-operators.mjs
+++ b/experiments/test-composite-operators.mjs
@@ -1,0 +1,35 @@
+// Test composite natural language operators: (both X and Y), (neither X nor Y)
+import { run } from '../js/src/rml-links.mjs';
+
+// Test (both X and Y)
+console.log('=== both X and Y ===');
+console.log('(both true and false):', run('(? (both true and false))'));       // expect 0.5
+console.log('(both true and true):', run('(? (both true and true))'));         // expect 1
+console.log('(both false and false):', run('(? (both false and false))'));     // expect 0
+
+// Test (neither X nor Y)
+console.log('\n=== neither X nor Y ===');
+console.log('(neither true nor false):', run('(? (neither true nor false))')); // expect 0
+console.log('(neither true nor true):', run('(? (neither true nor true))'));   // expect 1
+console.log('(neither false nor false):', run('(? (neither false nor false))')); // expect 0
+
+// Test variadic: (both A and B and C)
+console.log('\n=== variadic ===');
+console.log('(both true and true and false):', run('(? (both true and true and false))')); // avg(1,1,0)=0.666...
+console.log('(neither true nor true nor false):', run('(? (neither true nor true nor false))')); // product(1,1,0)=0
+
+// Test backward compatibility: old infix form
+console.log('\n=== backward compat (old infix) ===');
+console.log('(true both false):', run('(? (true both false))'));     // expect 0.5
+console.log('(true neither false):', run('(? (true neither false))')); // expect 0
+
+// Test backward compatibility: old prefix form
+console.log('\n=== backward compat (old prefix) ===');
+console.log('(both true false):', run('(? (both true false))'));     // expect 0.5
+console.log('(neither true false):', run('(? (neither true false))')); // expect 0
+
+// Test redefinability
+console.log('\n=== redefinable ===');
+console.log('(both: min) then (both true and false):', run('(both: min)\n(? (both true and false))')); // expect 0
+
+console.log('\nAll tests passed!');

--- a/js/examples/belnap-four-valued.lino
+++ b/js/examples/belnap-four-valued.lino
@@ -6,9 +6,9 @@
 #   - both  = both true and false, contradiction/paradox (0.5)
 #   - neither = neither true nor false, unknown/gap (0)
 #
-# In RML, "both" and "neither" are operators that alter the AND operation:
-#   - "A both B" uses avg semantics: contradiction resolves to the midpoint
-#   - "A neither B" uses product semantics: gap/no info propagates as zero
+# In RML, "both" and "neither" are composite natural language operators:
+#   - "both A and B" uses avg semantics: contradiction resolves to the midpoint
+#   - "neither A nor B" uses product semantics: gap/no info propagates as zero
 # Both operators are redefinable via aggregator selection.
 #
 # This is particularly useful for:
@@ -25,8 +25,8 @@
 # The four truth values via operators
 (? true)                            # -> 1
 (? false)                           # -> 0
-(? (true both false))               # -> 0.5 contradiction
-(? (true neither false))            # -> 0 gap
+(? (both true and false))           # -> 0.5 contradiction
+(? (neither true nor false))        # -> 0 gap
 
 # NOT of standard values
 (? (not true))                      # -> 0 not true = false
@@ -40,11 +40,11 @@
 (? (not (s = false)))               # -> 0.5 negation of paradox = same
 
 # "both" operator: avg semantics
-(? (true both true))                # -> 1 both agree true
-(? (false both false))              # -> 0 both agree false
-(? (true both false))               # -> 0.5 disagree: contradiction
+(? (both true and true))            # -> 1 both agree true
+(? (both false and false))          # -> 0 both agree false
+(? (both true and false))           # -> 0.5 disagree: contradiction
 
 # "neither" operator: product semantics
-(? (true neither true))             # -> 1 both agree true
-(? (false neither false))           # -> 0 both agree false
-(? (true neither false))            # -> 0 disagree: gap, no info
+(? (neither true nor true))         # -> 1 both agree true
+(? (neither false nor false))       # -> 0 both agree false
+(? (neither true nor false))        # -> 0 disagree: gap, no info

--- a/js/examples/belnap-four-valued.lino
+++ b/js/examples/belnap-four-valued.lino
@@ -1,0 +1,52 @@
+# Belnap's Four-Valued Logic
+#
+# Belnap's logic extends classical logic with two extra truth values:
+#   - true (1)     — known to be true
+#   - false (0)    — known to be false
+#   - both (0.5)   — both true and false (contradiction/paradox)
+#   - neither (0.5) — neither true nor false (unknown/gap)
+#
+# This is particularly useful for:
+#   - Databases with contradictory information
+#   - Reasoning under incomplete knowledge
+#   - Resolving paradoxes (the liar paradox maps to "both")
+#
+# In RML, "both" and "neither" are predefined truth constants
+# that default to the midpoint of the range (0.5 in [0,1]).
+#
+# See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+#      https://en.wikipedia.org/wiki/Relevance_logic
+
+(and: min)
+(or: max)
+
+# Query the four truth values
+(? true)                      # -> 1
+(? false)                     # -> 0
+(? both)                      # -> 0.5
+(? neither)                   # -> 0.5
+
+# NOT of each value
+(? (not true))                # -> 0     (not true = false)
+(? (not false))               # -> 1     (not false = true)
+(? (not both))                # -> 0.5   (not both = both — fixed point!)
+(? (not neither))             # -> 0.5   (not neither = neither — fixed point!)
+
+# The liar paradox resolves to "both" (0.5)
+# "This statement is false" — it is both true and false
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))               # -> 0.5 (the paradox lives at the midpoint)
+(? (not (s = false)))          # -> 0.5 (negation of paradox = same value)
+
+# Conjunction and disjunction with "both"
+(? (true and both))           # -> 0.5 (true AND contradictory = contradictory)
+(? (false or both))           # -> 0.5 (false OR contradictory = contradictory)
+(? (true or both))            # -> 1   (true OR anything = true)
+(? (false and both))          # -> 0   (false AND anything = false)
+
+# === Redefinability ===
+# All truth constants are redefinable — you can customize the system
+# For example, in a custom system where "both" maps to 0.7:
+# (both: 0.7)
+# (? both)    # -> 0.7

--- a/js/examples/belnap-four-valued.lino
+++ b/js/examples/belnap-four-valued.lino
@@ -1,18 +1,20 @@
 # Belnap's Four-Valued Logic
 #
 # Belnap's logic extends classical logic with two extra truth values:
-#   - true (1)     — known to be true
-#   - false (0)    — known to be false
-#   - both (0.5)   — both true and false (contradiction/paradox)
-#   - neither (0.5) — neither true nor false (unknown/gap)
+#   - true  = known to be true (1)
+#   - false = known to be false (0)
+#   - both  = both true and false, contradiction/paradox (0.5)
+#   - neither = neither true nor false, unknown/gap (0)
+#
+# In RML, "both" and "neither" are operators that alter the AND operation:
+#   - "A both B" uses avg semantics: contradiction resolves to the midpoint
+#   - "A neither B" uses product semantics: gap/no info propagates as zero
+# Both operators are redefinable via aggregator selection.
 #
 # This is particularly useful for:
 #   - Databases with contradictory information
 #   - Reasoning under incomplete knowledge
-#   - Resolving paradoxes (the liar paradox maps to "both")
-#
-# In RML, "both" and "neither" are predefined truth constants
-# that default to the midpoint of the range (0.5 in [0,1]).
+#   - Resolving paradoxes
 #
 # See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
 #      https://en.wikipedia.org/wiki/Relevance_logic
@@ -20,33 +22,29 @@
 (and: min)
 (or: max)
 
-# Query the four truth values
-(? true)                      # -> 1
-(? false)                     # -> 0
-(? both)                      # -> 0.5
-(? neither)                   # -> 0.5
+# The four truth values via operators
+(? true)                            # -> 1
+(? false)                           # -> 0
+(? (true both false))               # -> 0.5 contradiction
+(? (true neither false))            # -> 0 gap
 
-# NOT of each value
-(? (not true))                # -> 0     (not true = false)
-(? (not false))               # -> 1     (not false = true)
-(? (not both))                # -> 0.5   (not both = both — fixed point!)
-(? (not neither))             # -> 0.5   (not neither = neither — fixed point!)
+# NOT of standard values
+(? (not true))                      # -> 0 not true = false
+(? (not false))                     # -> 1 not false = true
 
-# The liar paradox resolves to "both" (0.5)
-# "This statement is false" — it is both true and false
+# The liar paradox resolves via "both"
+# "This statement is false" is both true and false
 (s: s is s)
 ((s = false) has probability 0.5)
-(? (s = false))               # -> 0.5 (the paradox lives at the midpoint)
-(? (not (s = false)))          # -> 0.5 (negation of paradox = same value)
+(? (s = false))                     # -> 0.5 paradox lives at midpoint
+(? (not (s = false)))               # -> 0.5 negation of paradox = same
 
-# Conjunction and disjunction with "both"
-(? (true and both))           # -> 0.5 (true AND contradictory = contradictory)
-(? (false or both))           # -> 0.5 (false OR contradictory = contradictory)
-(? (true or both))            # -> 1   (true OR anything = true)
-(? (false and both))          # -> 0   (false AND anything = false)
+# "both" operator: avg semantics
+(? (true both true))                # -> 1 both agree true
+(? (false both false))              # -> 0 both agree false
+(? (true both false))               # -> 0.5 disagree: contradiction
 
-# === Redefinability ===
-# All truth constants are redefinable — you can customize the system
-# For example, in a custom system where "both" maps to 0.7:
-# (both: 0.7)
-# (? both)    # -> 0.7
+# "neither" operator: product semantics
+(? (true neither true))             # -> 1 both agree true
+(? (false neither false))           # -> 0 both agree false
+(? (true neither false))            # -> 0 disagree: gap, no info

--- a/js/examples/classical-logic.lino
+++ b/js/examples/classical-logic.lino
@@ -1,0 +1,53 @@
+# Classical Logic — Standard Boolean (2-valued)
+#
+# The most familiar logic system: every proposition is either true or false.
+# This is what most people learn in introductory logic courses.
+#
+# Key properties:
+#   - Two truth values: true (1) and false (0)
+#   - AND = min (conjunction: both must be true)
+#   - OR  = max (disjunction: at least one must be true)
+#   - NOT = 1 - x (negation: flips truth value)
+#
+# Classical laws that hold here:
+#   - Law of excluded middle: A ∨ ¬A = true
+#   - Law of non-contradiction: A ∧ ¬A = false
+#   - Double negation: ¬¬A = A
+#
+# See: https://en.wikipedia.org/wiki/Classical_logic
+#      https://en.wikipedia.org/wiki/Boolean_algebra
+
+(valence: 2)
+(and: min)
+(or: max)
+
+# Define propositions
+(p: p is p)
+(q: q is q)
+
+# Assign truth values
+((p = true) has probability 1)
+((q = true) has probability 0)
+
+# Basic queries
+(? (p = true))                          # -> 1 (true)
+(? (q = true))                          # -> 0 (false)
+
+# Negation
+(? (not (p = true)))                    # -> 0 (not true = false)
+(? (not (q = true)))                    # -> 1 (not false = true)
+
+# Conjunction (AND): both must be true
+(? ((p = true) and (q = true)))         # -> 0 (true AND false = false)
+
+# Disjunction (OR): at least one true
+(? ((p = true) or (q = true)))          # -> 1 (true OR false = true)
+
+# Law of excluded middle: p ∨ ¬p = true
+(? ((p = true) or (not (p = true))))    # -> 1
+
+# Law of non-contradiction: p ∧ ¬p = false
+(? ((p = true) and (not (p = true))))   # -> 0
+
+# Double negation: ¬¬p = p
+(? (not (not (p = true))))              # -> 1

--- a/js/examples/fuzzy-logic.lino
+++ b/js/examples/fuzzy-logic.lino
@@ -1,0 +1,43 @@
+# Fuzzy Logic — Continuous truth values in [0, 1]
+#
+# Standard fuzzy logic where truth values represent degrees of membership.
+# Unlike classical logic, propositions can be partially true.
+#
+# Standard fuzzy connectives (Zadeh):
+#   AND = min (degree of conjunction)
+#   OR  = max (degree of disjunction)
+#   NOT = 1 - x (complement)
+#
+# See: https://en.wikipedia.org/wiki/Fuzzy_logic
+#      https://en.wikipedia.org/wiki/Fuzzy_set
+
+(and: min)
+(or: max)
+
+# Define fuzzy propositions with degrees of truth
+(a: a is a)
+(b: b is b)
+(c: c is c)
+
+# "a is tall" with 80% degree of truth
+((a = tall) has probability 0.8)
+# "b is tall" with 30% degree of truth
+((b = tall) has probability 0.3)
+# "c is tall" with 60% degree of truth
+((c = tall) has probability 0.6)
+
+# Query membership degrees
+(? (a = tall))                            # -> 0.8
+(? (b = tall))                            # -> 0.3
+
+# Fuzzy AND (min): "a is tall AND b is tall"
+(? ((a = tall) and (b = tall)))           # -> 0.3
+
+# Fuzzy OR (max): "a is tall OR b is tall"
+(? ((a = tall) or (b = tall)))            # -> 0.8
+
+# Fuzzy NOT: "a is NOT tall"
+(? (not (a = tall)))                      # -> 0.2
+
+# Chained: "a is tall AND (b is tall OR c is tall)"
+(? ((a = tall) and ((b = tall) or (c = tall))))   # -> 0.6

--- a/js/examples/propositional-logic.lino
+++ b/js/examples/propositional-logic.lino
@@ -1,0 +1,40 @@
+# Propositional Logic — Multiple propositions with standard connectives
+#
+# Extends classical logic with multiple propositions to demonstrate
+# standard logical reasoning patterns that every logic textbook covers.
+#
+# Uses product aggregator for AND (standard probabilistic interpretation)
+# and probabilistic_sum for OR (inclusion-exclusion principle).
+#
+# See: https://en.wikipedia.org/wiki/Propositional_calculus
+
+(and: product)
+(or: probabilistic_sum)
+
+# Define propositions with assigned probabilities
+(rain: rain is rain)
+(umbrella: umbrella is umbrella)
+(wet: wet is wet)
+
+((rain = true) has probability 0.3)
+((umbrella = true) has probability 0.6)
+((wet = true) has probability 0.4)
+
+# Query individual probabilities
+(? (rain = true))                                    # -> 0.3
+(? (umbrella = true))                                # -> 0.6
+
+# Joint probability: P(Rain AND Umbrella) = P(Rain) * P(Umbrella)
+(? ((rain = true) and (umbrella = true)))             # -> 0.18
+
+# Union probability: P(Rain OR Umbrella) = 1 - (1-0.3)*(1-0.6)
+(? ((rain = true) or (umbrella = true)))              # -> 0.72
+
+# Complement: P(NOT Rain) = 1 - P(Rain)
+(? (not (rain = true)))                               # -> 0.7
+
+# Three-way joint: P(Rain AND Umbrella AND Wet)
+(? (and (rain = true) (umbrella = true) (wet = true)))   # -> 0.072
+
+# Three-way union: P(Rain OR Umbrella OR Wet)
+(? (or (rain = true) (umbrella = true) (wet = true)))    # -> 0.832

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -377,6 +377,26 @@ function evalNode(node, env){
     return env.clamp(op(L,R));
   }
 
+  // Composite natural language operators: (both A and B [and C ...]), (neither A nor B [nor C ...])
+  if (node.length >= 4 && typeof node[0] === 'string' && (node[0]==='both' || node[0]==='neither')) {
+    const sep = node[0]==='both' ? 'and' : 'nor';
+    // Validate pattern: operator, value, sep, value [, sep, value ...]
+    let valid = node.length % 2 === 0; // both + (n values) + (n-1 seps) = 1 + n + (n-1) = 2n, always even
+    if (valid) {
+      for (let i = 2; i < node.length; i += 2) {
+        if (node[i] !== sep) { valid = false; break; }
+      }
+    }
+    if (valid) {
+      const op = env.getOp(node[0]);
+      const vals = [];
+      for (let i = 1; i < node.length; i += 2) {
+        vals.push(evalNode(node[i], env));
+      }
+      return env.clamp(op(...vals));
+    }
+  }
+
   // Infix equality/inequality: (L = R), (L != R)
   if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='=' || node[1]==='!=')) {
     const op = env.getOp(node[1]);

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -6,7 +6,7 @@
 // - Uses official links-notation parser to parse links
 // - Terms are defined via (x: x is x)
 // - Probabilities are assigned ONLY via: ((<expr>) has probability <p>)
-// - Redefinable ops: (=: ...), (!=: not =), (and: avg|min|max|product|probabilistic_sum), (or: ...), (not: ...)
+// - Redefinable ops: (=: ...), (!=: not =), (and: avg|min|max|product|probabilistic_sum), (or: ...), (not: ...), (both: ...), (neither: ...)
 // - Range: (range: 0 1) for [0,1] or (range: -1 1) for [-1,1] (balanced/symmetric)
 // - Valence: (valence: N) to restrict truth values to N discrete levels (N=2 → Boolean, N=3 → ternary, etc.)
 // - Query: (? <expr>)
@@ -132,6 +132,11 @@ class Env {
       'not': (x)=> this.hi - (x - this.lo),  // negation: mirrors around midpoint
       'and': (...xs)=> xs.length ? xs.reduce((a,b)=>a+b,0)/xs.length : this.lo, // avg
       'or' : (...xs)=> xs.length ? Math.max(...xs) : this.lo,
+      // Belnap operators: AND-altering operators for four-valued logic
+      // "both" (gullibility): avg — contradiction resolves to midpoint
+      'both': (...xs)=> xs.length ? decRound(xs.reduce((a,b)=>a+b,0)/xs.length) : this.lo,
+      // "neither" (consensus): product — gap resolves to zero (no info propagates)
+      'neither': (...xs)=> xs.length ? decRound(xs.reduce((a,b)=>a*b,1)) : this.lo,
       '='  : (L,R,ctx)=> {
         // If assigned explicitly, use that (check both prefix and infix key forms)
         const kPrefix = keyOf(['=',L,R]);
@@ -182,12 +187,14 @@ class Env {
     this.symbolProb.set('false', this.lo);
     this.symbolProb.set('unknown', this.mid);
     this.symbolProb.set('undefined', this.mid);
-    // Belnap's four-valued logic constants:
-    // "both" = both true and false (contradiction/paradox), maps to midpoint
-    // "neither" = neither true nor false (gap/unknown), maps to midpoint
+    // Belnap's four-valued logic operators:
+    // "both" and "neither" are AND-altering operators (not constants).
+    // "both" = conjunction under contradiction (gullibility) — default: avg
+    //   (true both false) = 0.5 (both true and false → contradiction/paradox)
+    // "neither" = conjunction under gap (consensus) — default: product
+    //   (true neither false) = 0 (neither true nor false → gap/no info)
+    // Both are redefinable via (both: min), (neither: max), etc.
     // See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
-    this.symbolProb.set('both', this.mid);
-    this.symbolProb.set('neither', this.mid);
   }
 
   getOp(name){
@@ -362,8 +369,8 @@ function evalNode(node, env){
     return op(L,R);
   }
 
-  // Infix AND/OR: ((A) and (B))  /  ((A) or (B))
-  if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='and' || node[1]==='or')) {
+  // Infix AND/OR/BOTH/NEITHER: ((A) and (B))  /  ((A) or (B))  /  ((A) both (B))  /  ((A) neither (B))
+  if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='and' || node[1]==='or' || node[1]==='both' || node[1]==='neither')) {
     const op = env.getOp(node[1]);
     const L = evalNode(node[0], env);
     const R = evalNode(node[2], env);
@@ -536,6 +543,8 @@ function _reinitOps(env) {
   env.ops.set('not', (x) => env.hi - (x - env.lo));
   env.ops.set('and', (...xs) => xs.length ? xs.reduce((a,b)=>a+b,0)/xs.length : env.lo);
   env.ops.set('or', (...xs) => xs.length ? Math.max(...xs) : env.lo);
+  env.ops.set('both', (...xs) => xs.length ? decRound(xs.reduce((a,b)=>a+b,0)/xs.length) : env.lo);
+  env.ops.set('neither', (...xs) => xs.length ? decRound(xs.reduce((a,b)=>a*b,1)) : env.lo);
   env.ops.set('=', (L,R,ctx) => {
     const kPrefix = keyOf(['=',L,R]);
     if (env.assign.has(kPrefix)) return env.assign.get(kPrefix);
@@ -584,7 +593,7 @@ function defineForm(head, rhs, env){
   // Only complex expressions (arrays) are accepted as type annotations in single-element form.
   // Simple name type annotations like (x: Natural) are NOT supported — use (x: Natural x) prefix form instead.
   if (rhs.length === 1 && Array.isArray(rhs[0])) {
-    const isOp = ['=','!=','and','or','not','is','?:'].includes(head) || /[=!]/.test(head);
+    const isOp = ['=','!=','and','or','not','is','?:','both','neither'].includes(head) || /[=!]/.test(head);
     if (!isOp) {
       const typeExpr = rhs[0];
       env.terms.add(head);
@@ -616,7 +625,7 @@ function defineForm(head, rhs, env){
   }
 
   // Operator redefinitions
-  if (['=','!=','and','or','not','is','?:'].includes(head) || /[=!]/.test(head)) {
+  if (['=','!=','and','or','not','is','?:','both','neither'].includes(head) || /[=!]/.test(head)) {
 
     // Composition like: (!=: not =)   or  (=: =) (no-op)
     if (rhs.length === 2 && typeof rhs[0]==='string' && typeof rhs[1]==='string') {
@@ -627,7 +636,7 @@ function defineForm(head, rhs, env){
     }
 
     // Aggregator selection: (and: avg|min|max|product|probabilistic_sum)
-    if ((head==='and' || head==='or') && rhs.length===1 && typeof rhs[0]==='string') {
+    if ((head==='and' || head==='or' || head==='both' || head==='neither') && rhs.length===1 && typeof rhs[0]==='string') {
       const sel = rhs[0];
       const lo = env.lo;
       const agg =
@@ -677,8 +686,12 @@ function defineForm(head, rhs, env){
 // ---------- Runner ----------
 function run(text, options){
   const parser = new Parser();
-  // Strip line comments (# ...) before parsing — LiNo parser doesn't handle them
-  const stripped = text.replace(/^[ \t]*#.*$/gm, '').replace(/\n{3,}/g, '\n\n');
+  // Strip comments (# ...) before parsing — LiNo parser doesn't handle them
+  // First strip full-line comments, then strip inline comments (# after content)
+  const stripped = text
+    .replace(/^[ \t]*#.*$/gm, '')          // full-line comments
+    .replace(/(\)[ \t]+)#.*$/gm, '$1')     // inline comments after closing paren
+    .replace(/\n{3,}/g, '\n\n');
   const links = parser.parse(stripped);
 
   // Convert each top-level LiNo link to an AST by re-tokenizing that link only.

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -182,6 +182,12 @@ class Env {
     this.symbolProb.set('false', this.lo);
     this.symbolProb.set('unknown', this.mid);
     this.symbolProb.set('undefined', this.mid);
+    // Belnap's four-valued logic constants:
+    // "both" = both true and false (contradiction/paradox), maps to midpoint
+    // "neither" = neither true nor false (gap/unknown), maps to midpoint
+    // See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+    this.symbolProb.set('both', this.mid);
+    this.symbolProb.set('neither', this.mid);
   }
 
   getOp(name){

--- a/js/tests/rml-links.test.mjs
+++ b/js/tests/rml-links.test.mjs
@@ -1181,6 +1181,96 @@ describe('Truth constants: Env API', () => {
   });
 });
 
+// =============================================================================
+// Belnap's four-valued logic constants: both, neither
+// https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+// =============================================================================
+describe('Truth constants: both and neither (Belnap four-valued)', () => {
+  it('both should default to 0.5 (mid of [0,1] range)', () => {
+    const results = run('(? both)');
+    assert.strictEqual(results[0], 0.5);
+  });
+
+  it('neither should default to 0.5 (mid of [0,1] range)', () => {
+    const results = run('(? neither)');
+    assert.strictEqual(results[0], 0.5);
+  });
+
+  it('both should default to 0 (mid of [-1,1] range)', () => {
+    const results = run('(range: -1 1)\n(? both)', { lo: -1, hi: 1 });
+    assert.strictEqual(results[0], 0);
+  });
+
+  it('neither should default to 0 (mid of [-1,1] range)', () => {
+    const results = run('(range: -1 1)\n(? neither)', { lo: -1, hi: 1 });
+    assert.strictEqual(results[0], 0);
+  });
+
+  it('both and neither should be redefinable', () => {
+    const results = run(`
+(both: 0.7)
+(neither: 0.3)
+(? both)
+(? neither)
+`);
+    assert.strictEqual(results[0], 0.7);
+    assert.strictEqual(results[1], 0.3);
+  });
+
+  it('Env should have both and neither initialized', () => {
+    const env = new Env();
+    assert.strictEqual(env.getSymbolProb('both'), 0.5);
+    assert.strictEqual(env.getSymbolProb('neither'), 0.5);
+  });
+
+  it('Env with [-1,1] range should have correct both and neither', () => {
+    const env = new Env({ lo: -1, hi: 1 });
+    assert.strictEqual(env.getSymbolProb('both'), 0);
+    assert.strictEqual(env.getSymbolProb('neither'), 0);
+  });
+
+  it('both should work with 4-valued quantization', () => {
+    const results = run(`
+(valence: 4)
+(? both)
+`);
+    approx(results[0], 2/3);  // 0.5 quantized to nearest level in 4-valued: 2/3
+  });
+
+  it('both should work in expressions', () => {
+    const results = run(`
+(and: min)
+(? (true and both))
+(? (false or both))
+`);
+    assert.strictEqual(results[0], 0.5);   // min(1, 0.5)
+    assert.strictEqual(results[1], 0.5);   // max(0, 0.5)
+  });
+
+  it('not both = both, not neither = neither (fixed points)', () => {
+    const results = run(`
+(? (not both))
+(? (not neither))
+`);
+    assert.strictEqual(results[0], 0.5);   // not(0.5) = 0.5
+    assert.strictEqual(results[1], 0.5);   // not(0.5) = 0.5
+  });
+
+  it('both and neither should update when range changes', () => {
+    const results = run(`
+(? both)
+(? neither)
+(range: -1 1)
+(? both)
+(? neither)
+`);
+    assert.strictEqual(results[0], 0.5);   // both in [0,1]
+    assert.strictEqual(results[1], 0.5);   // neither in [0,1]
+    assert.strictEqual(results[2], 0);     // both in [-1,1]
+    assert.strictEqual(results[3], 0);     // neither in [-1,1]
+  });
+});
+
 describe('Truth constants: liar paradox using truth constants', () => {
   it('liar paradox with true/false constants in [0,1]', () => {
     // "This statement is false" — the classic liar paradox

--- a/js/tests/rml-links.test.mjs
+++ b/js/tests/rml-links.test.mjs
@@ -358,36 +358,32 @@ describe('Example: belnap-four-valued.lino', () => {
 (or: max)
 (? true)
 (? false)
-(? both)
-(? neither)
 (? (not true))
 (? (not false))
-(? (not both))
-(? (not neither))
 (s: s is s)
 ((s = false) has probability 0.5)
 (? (s = false))
 (? (not (s = false)))
-(? (true and both))
-(? (false or both))
-(? (true or both))
-(? (false and both))
+(? (true both false))
+(? (true neither false))
+(? (true both true))
+(? (false both false))
+(? (true neither true))
+(? (false neither false))
 `);
-    assert.strictEqual(results.length, 14);
+    assert.strictEqual(results.length, 12);
     assert.strictEqual(results[0], 1);      // true
     assert.strictEqual(results[1], 0);      // false
-    assert.strictEqual(results[2], 0.5);    // both
-    assert.strictEqual(results[3], 0.5);    // neither
-    assert.strictEqual(results[4], 0);      // not true
-    assert.strictEqual(results[5], 1);      // not false
-    assert.strictEqual(results[6], 0.5);    // not both = both
-    assert.strictEqual(results[7], 0.5);    // not neither = neither
-    assert.strictEqual(results[8], 0.5);    // liar paradox
-    assert.strictEqual(results[9], 0.5);    // not liar paradox
-    assert.strictEqual(results[10], 0.5);   // true AND both
-    assert.strictEqual(results[11], 0.5);   // false OR both
-    assert.strictEqual(results[12], 1);     // true OR both
-    assert.strictEqual(results[13], 0);     // false AND both
+    assert.strictEqual(results[2], 0);      // not true
+    assert.strictEqual(results[3], 1);      // not false
+    assert.strictEqual(results[4], 0.5);    // liar paradox
+    assert.strictEqual(results[5], 0.5);    // not liar paradox
+    assert.strictEqual(results[6], 0.5);    // true both false = 0.5 (contradiction)
+    assert.strictEqual(results[7], 0);      // true neither false = 0 (gap)
+    assert.strictEqual(results[8], 1);      // true both true = 1
+    assert.strictEqual(results[9], 0);      // false both false = 0
+    assert.strictEqual(results[10], 1);     // true neither true = 1
+    assert.strictEqual(results[11], 0);     // false neither false = 0
   });
 });
 
@@ -1316,92 +1312,120 @@ describe('Truth constants: Env API', () => {
 });
 
 // =============================================================================
-// Belnap's four-valued logic constants: both, neither
+// Belnap's four-valued logic operators: both, neither
 // https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
 // =============================================================================
-describe('Truth constants: both and neither (Belnap four-valued)', () => {
-  it('both should default to 0.5 (mid of [0,1] range)', () => {
-    const results = run('(? both)');
-    assert.strictEqual(results[0], 0.5);
+describe('Operators: both and neither (Belnap four-valued)', () => {
+  it('both should compute avg of operands (contradiction)', () => {
+    const results = run('(? (true both false))');
+    assert.strictEqual(results[0], 0.5);   // avg(1, 0) = 0.5
   });
 
-  it('neither should default to 0.5 (mid of [0,1] range)', () => {
-    const results = run('(? neither)');
-    assert.strictEqual(results[0], 0.5);
+  it('neither should compute product of operands (gap)', () => {
+    const results = run('(? (true neither false))');
+    assert.strictEqual(results[0], 0);     // product(1, 0) = 0
   });
 
-  it('both should default to 0 (mid of [-1,1] range)', () => {
-    const results = run('(range: -1 1)\n(? both)', { lo: -1, hi: 1 });
-    assert.strictEqual(results[0], 0);
-  });
-
-  it('neither should default to 0 (mid of [-1,1] range)', () => {
-    const results = run('(range: -1 1)\n(? neither)', { lo: -1, hi: 1 });
-    assert.strictEqual(results[0], 0);
-  });
-
-  it('both and neither should be redefinable', () => {
+  it('both should be redefinable via aggregator', () => {
     const results = run(`
-(both: 0.7)
-(neither: 0.3)
-(? both)
-(? neither)
+(both: min)
+(? (true both false))
 `);
-    assert.strictEqual(results[0], 0.7);
-    assert.strictEqual(results[1], 0.3);
+    assert.strictEqual(results[0], 0);     // min(1, 0) = 0
   });
 
-  it('Env should have both and neither initialized', () => {
+  it('neither should be redefinable via aggregator', () => {
+    const results = run(`
+(neither: max)
+(? (true neither false))
+`);
+    assert.strictEqual(results[0], 1);     // max(1, 0) = 1
+  });
+
+  it('Env should have both and neither as operators', () => {
     const env = new Env();
-    assert.strictEqual(env.getSymbolProb('both'), 0.5);
-    assert.strictEqual(env.getSymbolProb('neither'), 0.5);
+    assert.strictEqual(typeof env.ops.get('both'), 'function');
+    assert.strictEqual(typeof env.ops.get('neither'), 'function');
   });
 
-  it('Env with [-1,1] range should have correct both and neither', () => {
-    const env = new Env({ lo: -1, hi: 1 });
-    assert.strictEqual(env.getSymbolProb('both'), 0);
-    assert.strictEqual(env.getSymbolProb('neither'), 0);
-  });
-
-  it('both should work with 4-valued quantization', () => {
+  it('both with same values should return that value', () => {
     const results = run(`
-(valence: 4)
-(? both)
+(? (true both true))
+(? (false both false))
 `);
-    approx(results[0], 2/3);  // 0.5 quantized to nearest level in 4-valued: 2/3
+    assert.strictEqual(results[0], 1);     // avg(1, 1) = 1
+    assert.strictEqual(results[1], 0);     // avg(0, 0) = 0
   });
 
-  it('both should work in expressions', () => {
+  it('neither with same values should return that value', () => {
     const results = run(`
-(and: min)
-(? (true and both))
-(? (false or both))
+(? (true neither true))
+(? (false neither false))
 `);
-    assert.strictEqual(results[0], 0.5);   // min(1, 0.5)
-    assert.strictEqual(results[1], 0.5);   // max(0, 0.5)
+    assert.strictEqual(results[0], 1);     // product(1, 1) = 1
+    assert.strictEqual(results[1], 0);     // product(0, 0) = 0
   });
 
-  it('not both = both, not neither = neither (fixed points)', () => {
+  it('both with fuzzy values', () => {
     const results = run(`
-(? (not both))
-(? (not neither))
+(a: a is a)
+(b: b is b)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.4)
+(? ((a = tall) both (b = tall)))
 `);
-    assert.strictEqual(results[0], 0.5);   // not(0.5) = 0.5
-    assert.strictEqual(results[1], 0.5);   // not(0.5) = 0.5
+    assert.strictEqual(results[0], 0.6);   // avg(0.8, 0.4) = 0.6
   });
 
-  it('both and neither should update when range changes', () => {
+  it('neither with fuzzy values', () => {
     const results = run(`
-(? both)
-(? neither)
+(a: a is a)
+(b: b is b)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.5)
+(? ((a = tall) neither (b = tall)))
+`);
+    assert.strictEqual(results[0], 0.4);   // product(0.8, 0.5) = 0.4
+  });
+
+  it('both should work in prefix form', () => {
+    const results = run('(? (both true false))');
+    assert.strictEqual(results[0], 0.5);   // avg(1, 0) = 0.5
+  });
+
+  it('neither should work in prefix form', () => {
+    const results = run('(? (neither true false))');
+    assert.strictEqual(results[0], 0);     // product(1, 0) = 0
+  });
+
+  it('both should update behavior when range changes', () => {
+    const results = run(`
+(? (true both false))
 (range: -1 1)
-(? both)
-(? neither)
+(? (true both false))
 `);
-    assert.strictEqual(results[0], 0.5);   // both in [0,1]
-    assert.strictEqual(results[1], 0.5);   // neither in [0,1]
-    assert.strictEqual(results[2], 0);     // both in [-1,1]
-    assert.strictEqual(results[3], 0);     // neither in [-1,1]
+    assert.strictEqual(results[0], 0.5);   // avg(1, 0) = 0.5 in [0,1]
+    assert.strictEqual(results[1], 0);     // avg(1, -1) = 0 in [-1,1] (clamped to range)
+  });
+
+  it('issue scenario: (a=a) both (a!=a) gives 0.5', () => {
+    const results = run(`
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? ((a = a) both (a != a)))
+`);
+    assert.strictEqual(results[0], 0.5);
+  });
+
+  it('issue scenario: (a=a) neither (a!=a) gives 0', () => {
+    const results = run(`
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? ((a = a) neither (a != a)))
+`);
+    assert.strictEqual(results[0], 0);
   });
 });
 

--- a/js/tests/rml-links.test.mjs
+++ b/js/tests/rml-links.test.mjs
@@ -258,6 +258,140 @@ describe('run', () => {
 });
 
 // =============================================================================
+// Standard logic examples — testing the example files
+// =============================================================================
+describe('Example: classical-logic.lino', () => {
+  it('should produce correct results for classical Boolean logic', () => {
+    const results = run(`
+(valence: 2)
+(and: min)
+(or: max)
+(p: p is p)
+(q: q is q)
+((p = true) has probability 1)
+((q = true) has probability 0)
+(? (p = true))
+(? (q = true))
+(? (not (p = true)))
+(? (not (q = true)))
+(? ((p = true) and (q = true)))
+(? ((p = true) or (q = true)))
+(? ((p = true) or (not (p = true))))
+(? ((p = true) and (not (p = true))))
+(? (not (not (p = true))))
+`);
+    assert.strictEqual(results.length, 9);
+    assert.strictEqual(results[0], 1);    // p = true
+    assert.strictEqual(results[1], 0);    // q = false
+    assert.strictEqual(results[2], 0);    // not p = false
+    assert.strictEqual(results[3], 1);    // not q = true
+    assert.strictEqual(results[4], 0);    // p AND q = false
+    assert.strictEqual(results[5], 1);    // p OR q = true
+    assert.strictEqual(results[6], 1);    // excluded middle
+    assert.strictEqual(results[7], 0);    // non-contradiction
+    assert.strictEqual(results[8], 1);    // double negation
+  });
+});
+
+describe('Example: propositional-logic.lino', () => {
+  it('should produce correct results for probabilistic propositional logic', () => {
+    const results = run(`
+(and: product)
+(or: probabilistic_sum)
+(rain: rain is rain)
+(umbrella: umbrella is umbrella)
+(wet: wet is wet)
+((rain = true) has probability 0.3)
+((umbrella = true) has probability 0.6)
+((wet = true) has probability 0.4)
+(? (rain = true))
+(? (umbrella = true))
+(? ((rain = true) and (umbrella = true)))
+(? ((rain = true) or (umbrella = true)))
+(? (not (rain = true)))
+(? (and (rain = true) (umbrella = true) (wet = true)))
+(? (or (rain = true) (umbrella = true) (wet = true)))
+`);
+    assert.strictEqual(results.length, 7);
+    approx(results[0], 0.3);
+    approx(results[1], 0.6);
+    approx(results[2], 0.18);
+    approx(results[3], 0.72);
+    approx(results[4], 0.7);
+    approx(results[5], 0.072);
+    approx(results[6], 0.832);
+  });
+});
+
+describe('Example: fuzzy-logic.lino', () => {
+  it('should produce correct results for fuzzy logic (Zadeh)', () => {
+    const results = run(`
+(and: min)
+(or: max)
+(a: a is a)
+(b: b is b)
+(c: c is c)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.3)
+((c = tall) has probability 0.6)
+(? (a = tall))
+(? (b = tall))
+(? ((a = tall) and (b = tall)))
+(? ((a = tall) or (b = tall)))
+(? (not (a = tall)))
+(? ((a = tall) and ((b = tall) or (c = tall))))
+`);
+    assert.strictEqual(results.length, 6);
+    approx(results[0], 0.8);
+    approx(results[1], 0.3);
+    approx(results[2], 0.3);   // min(0.8, 0.3)
+    approx(results[3], 0.8);   // max(0.8, 0.3)
+    approx(results[4], 0.2);   // 1 - 0.8
+    approx(results[5], 0.6);   // min(0.8, max(0.3, 0.6))
+  });
+});
+
+describe('Example: belnap-four-valued.lino', () => {
+  it('should produce correct results for Belnap four-valued logic', () => {
+    const results = run(`
+(and: min)
+(or: max)
+(? true)
+(? false)
+(? both)
+(? neither)
+(? (not true))
+(? (not false))
+(? (not both))
+(? (not neither))
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))
+(? (not (s = false)))
+(? (true and both))
+(? (false or both))
+(? (true or both))
+(? (false and both))
+`);
+    assert.strictEqual(results.length, 14);
+    assert.strictEqual(results[0], 1);      // true
+    assert.strictEqual(results[1], 0);      // false
+    assert.strictEqual(results[2], 0.5);    // both
+    assert.strictEqual(results[3], 0.5);    // neither
+    assert.strictEqual(results[4], 0);      // not true
+    assert.strictEqual(results[5], 1);      // not false
+    assert.strictEqual(results[6], 0.5);    // not both = both
+    assert.strictEqual(results[7], 0.5);    // not neither = neither
+    assert.strictEqual(results[8], 0.5);    // liar paradox
+    assert.strictEqual(results[9], 0.5);    // not liar paradox
+    assert.strictEqual(results[10], 0.5);   // true AND both
+    assert.strictEqual(results[11], 0.5);   // false OR both
+    assert.strictEqual(results[12], 1);     // true OR both
+    assert.strictEqual(results[13], 0);     // false AND both
+  });
+});
+
+// =============================================================================
 // Quantization helper
 // See: https://en.wikipedia.org/wiki/Many-valued_logic
 // =============================================================================

--- a/js/tests/rml-links.test.mjs
+++ b/js/tests/rml-links.test.mjs
@@ -1398,6 +1398,54 @@ describe('Operators: both and neither (Belnap four-valued)', () => {
     assert.strictEqual(results[0], 0);     // product(1, 0) = 0
   });
 
+  it('both should work in composite natural language form: (both A and B)', () => {
+    const results = run(`
+(? (both true and false))
+(? (both true and true))
+(? (both false and false))
+`);
+    assert.strictEqual(results[0], 0.5);   // avg(1, 0) = 0.5
+    assert.strictEqual(results[1], 1);     // avg(1, 1) = 1
+    assert.strictEqual(results[2], 0);     // avg(0, 0) = 0
+  });
+
+  it('neither should work in composite natural language form: (neither A nor B)', () => {
+    const results = run(`
+(? (neither true nor false))
+(? (neither true nor true))
+(? (neither false nor false))
+`);
+    assert.strictEqual(results[0], 0);     // product(1, 0) = 0
+    assert.strictEqual(results[1], 1);     // product(1, 1) = 1
+    assert.strictEqual(results[2], 0);     // product(0, 0) = 0
+  });
+
+  it('composite both should work with variadic form: (both A and B and C)', () => {
+    const results = run('(? (both true and true and false))');
+    assert.ok(Math.abs(results[0] - 0.666666666667) < 0.0001); // avg(1, 1, 0)
+  });
+
+  it('composite neither should work with variadic form: (neither A nor B nor C)', () => {
+    const results = run('(? (neither true nor true nor false))');
+    assert.strictEqual(results[0], 0);     // product(1, 1, 0) = 0
+  });
+
+  it('composite both should be redefinable', () => {
+    const results = run(`
+(both: min)
+(? (both true and false))
+`);
+    assert.strictEqual(results[0], 0);     // min(1, 0) = 0
+  });
+
+  it('composite neither should be redefinable', () => {
+    const results = run(`
+(neither: max)
+(? (neither true nor false))
+`);
+    assert.strictEqual(results[0], 1);     // max(1, 0) = 1
+  });
+
   it('both should update behavior when range changes', () => {
     const results = run(`
 (? (true both false))
@@ -1408,7 +1456,27 @@ describe('Operators: both and neither (Belnap four-valued)', () => {
     assert.strictEqual(results[1], 0);     // avg(1, -1) = 0 in [-1,1] (clamped to range)
   });
 
-  it('issue scenario: (a=a) both (a!=a) gives 0.5', () => {
+  it('issue scenario: both (a=a) and (a!=a) gives 0.5', () => {
+    const results = run(`
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? (both (a = a) and (a != a)))
+`);
+    assert.strictEqual(results[0], 0.5);
+  });
+
+  it('issue scenario: neither (a=a) nor (a!=a) gives 0', () => {
+    const results = run(`
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? (neither (a = a) nor (a != a)))
+`);
+    assert.strictEqual(results[0], 0);
+  });
+
+  it('issue scenario: infix backward compat (a=a) both (a!=a) gives 0.5', () => {
     const results = run(`
 (a: a is a)
 ((a = a) has probability 1)
@@ -1416,16 +1484,6 @@ describe('Operators: both and neither (Belnap four-valued)', () => {
 (? ((a = a) both (a != a)))
 `);
     assert.strictEqual(results[0], 0.5);
-  });
-
-  it('issue scenario: (a=a) neither (a!=a) gives 0', () => {
-    const results = run(`
-(a: a is a)
-((a = a) has probability 1)
-((a != a) has probability 0)
-(? ((a = a) neither (a != a)))
-`);
-    assert.strictEqual(results[0], 0);
   });
 });
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/examples/belnap-four-valued.lino
+++ b/rust/examples/belnap-four-valued.lino
@@ -6,9 +6,9 @@
 #   - both  = both true and false, contradiction/paradox (0.5)
 #   - neither = neither true nor false, unknown/gap (0)
 #
-# In RML, "both" and "neither" are operators that alter the AND operation:
-#   - "A both B" uses avg semantics: contradiction resolves to the midpoint
-#   - "A neither B" uses product semantics: gap/no info propagates as zero
+# In RML, "both" and "neither" are composite natural language operators:
+#   - "both A and B" uses avg semantics: contradiction resolves to the midpoint
+#   - "neither A nor B" uses product semantics: gap/no info propagates as zero
 # Both operators are redefinable via aggregator selection.
 #
 # This is particularly useful for:
@@ -25,8 +25,8 @@
 # The four truth values via operators
 (? true)                            # -> 1
 (? false)                           # -> 0
-(? (true both false))               # -> 0.5 contradiction
-(? (true neither false))            # -> 0 gap
+(? (both true and false))           # -> 0.5 contradiction
+(? (neither true nor false))        # -> 0 gap
 
 # NOT of standard values
 (? (not true))                      # -> 0 not true = false
@@ -40,11 +40,11 @@
 (? (not (s = false)))               # -> 0.5 negation of paradox = same
 
 # "both" operator: avg semantics
-(? (true both true))                # -> 1 both agree true
-(? (false both false))              # -> 0 both agree false
-(? (true both false))               # -> 0.5 disagree: contradiction
+(? (both true and true))            # -> 1 both agree true
+(? (both false and false))          # -> 0 both agree false
+(? (both true and false))           # -> 0.5 disagree: contradiction
 
 # "neither" operator: product semantics
-(? (true neither true))             # -> 1 both agree true
-(? (false neither false))           # -> 0 both agree false
-(? (true neither false))            # -> 0 disagree: gap, no info
+(? (neither true nor true))         # -> 1 both agree true
+(? (neither false nor false))       # -> 0 both agree false
+(? (neither true nor false))        # -> 0 disagree: gap, no info

--- a/rust/examples/belnap-four-valued.lino
+++ b/rust/examples/belnap-four-valued.lino
@@ -1,0 +1,52 @@
+# Belnap's Four-Valued Logic
+#
+# Belnap's logic extends classical logic with two extra truth values:
+#   - true (1)     — known to be true
+#   - false (0)    — known to be false
+#   - both (0.5)   — both true and false (contradiction/paradox)
+#   - neither (0.5) — neither true nor false (unknown/gap)
+#
+# This is particularly useful for:
+#   - Databases with contradictory information
+#   - Reasoning under incomplete knowledge
+#   - Resolving paradoxes (the liar paradox maps to "both")
+#
+# In RML, "both" and "neither" are predefined truth constants
+# that default to the midpoint of the range (0.5 in [0,1]).
+#
+# See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+#      https://en.wikipedia.org/wiki/Relevance_logic
+
+(and: min)
+(or: max)
+
+# Query the four truth values
+(? true)                      # -> 1
+(? false)                     # -> 0
+(? both)                      # -> 0.5
+(? neither)                   # -> 0.5
+
+# NOT of each value
+(? (not true))                # -> 0     (not true = false)
+(? (not false))               # -> 1     (not false = true)
+(? (not both))                # -> 0.5   (not both = both — fixed point!)
+(? (not neither))             # -> 0.5   (not neither = neither — fixed point!)
+
+# The liar paradox resolves to "both" (0.5)
+# "This statement is false" — it is both true and false
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))               # -> 0.5 (the paradox lives at the midpoint)
+(? (not (s = false)))          # -> 0.5 (negation of paradox = same value)
+
+# Conjunction and disjunction with "both"
+(? (true and both))           # -> 0.5 (true AND contradictory = contradictory)
+(? (false or both))           # -> 0.5 (false OR contradictory = contradictory)
+(? (true or both))            # -> 1   (true OR anything = true)
+(? (false and both))          # -> 0   (false AND anything = false)
+
+# === Redefinability ===
+# All truth constants are redefinable — you can customize the system
+# For example, in a custom system where "both" maps to 0.7:
+# (both: 0.7)
+# (? both)    # -> 0.7

--- a/rust/examples/belnap-four-valued.lino
+++ b/rust/examples/belnap-four-valued.lino
@@ -1,18 +1,20 @@
 # Belnap's Four-Valued Logic
 #
 # Belnap's logic extends classical logic with two extra truth values:
-#   - true (1)     — known to be true
-#   - false (0)    — known to be false
-#   - both (0.5)   — both true and false (contradiction/paradox)
-#   - neither (0.5) — neither true nor false (unknown/gap)
+#   - true  = known to be true (1)
+#   - false = known to be false (0)
+#   - both  = both true and false, contradiction/paradox (0.5)
+#   - neither = neither true nor false, unknown/gap (0)
+#
+# In RML, "both" and "neither" are operators that alter the AND operation:
+#   - "A both B" uses avg semantics: contradiction resolves to the midpoint
+#   - "A neither B" uses product semantics: gap/no info propagates as zero
+# Both operators are redefinable via aggregator selection.
 #
 # This is particularly useful for:
 #   - Databases with contradictory information
 #   - Reasoning under incomplete knowledge
-#   - Resolving paradoxes (the liar paradox maps to "both")
-#
-# In RML, "both" and "neither" are predefined truth constants
-# that default to the midpoint of the range (0.5 in [0,1]).
+#   - Resolving paradoxes
 #
 # See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
 #      https://en.wikipedia.org/wiki/Relevance_logic
@@ -20,33 +22,29 @@
 (and: min)
 (or: max)
 
-# Query the four truth values
-(? true)                      # -> 1
-(? false)                     # -> 0
-(? both)                      # -> 0.5
-(? neither)                   # -> 0.5
+# The four truth values via operators
+(? true)                            # -> 1
+(? false)                           # -> 0
+(? (true both false))               # -> 0.5 contradiction
+(? (true neither false))            # -> 0 gap
 
-# NOT of each value
-(? (not true))                # -> 0     (not true = false)
-(? (not false))               # -> 1     (not false = true)
-(? (not both))                # -> 0.5   (not both = both — fixed point!)
-(? (not neither))             # -> 0.5   (not neither = neither — fixed point!)
+# NOT of standard values
+(? (not true))                      # -> 0 not true = false
+(? (not false))                     # -> 1 not false = true
 
-# The liar paradox resolves to "both" (0.5)
-# "This statement is false" — it is both true and false
+# The liar paradox resolves via "both"
+# "This statement is false" is both true and false
 (s: s is s)
 ((s = false) has probability 0.5)
-(? (s = false))               # -> 0.5 (the paradox lives at the midpoint)
-(? (not (s = false)))          # -> 0.5 (negation of paradox = same value)
+(? (s = false))                     # -> 0.5 paradox lives at midpoint
+(? (not (s = false)))               # -> 0.5 negation of paradox = same
 
-# Conjunction and disjunction with "both"
-(? (true and both))           # -> 0.5 (true AND contradictory = contradictory)
-(? (false or both))           # -> 0.5 (false OR contradictory = contradictory)
-(? (true or both))            # -> 1   (true OR anything = true)
-(? (false and both))          # -> 0   (false AND anything = false)
+# "both" operator: avg semantics
+(? (true both true))                # -> 1 both agree true
+(? (false both false))              # -> 0 both agree false
+(? (true both false))               # -> 0.5 disagree: contradiction
 
-# === Redefinability ===
-# All truth constants are redefinable — you can customize the system
-# For example, in a custom system where "both" maps to 0.7:
-# (both: 0.7)
-# (? both)    # -> 0.7
+# "neither" operator: product semantics
+(? (true neither true))             # -> 1 both agree true
+(? (false neither false))           # -> 0 both agree false
+(? (true neither false))            # -> 0 disagree: gap, no info

--- a/rust/examples/classical-logic.lino
+++ b/rust/examples/classical-logic.lino
@@ -1,0 +1,53 @@
+# Classical Logic — Standard Boolean (2-valued)
+#
+# The most familiar logic system: every proposition is either true or false.
+# This is what most people learn in introductory logic courses.
+#
+# Key properties:
+#   - Two truth values: true (1) and false (0)
+#   - AND = min (conjunction: both must be true)
+#   - OR  = max (disjunction: at least one must be true)
+#   - NOT = 1 - x (negation: flips truth value)
+#
+# Classical laws that hold here:
+#   - Law of excluded middle: A ∨ ¬A = true
+#   - Law of non-contradiction: A ∧ ¬A = false
+#   - Double negation: ¬¬A = A
+#
+# See: https://en.wikipedia.org/wiki/Classical_logic
+#      https://en.wikipedia.org/wiki/Boolean_algebra
+
+(valence: 2)
+(and: min)
+(or: max)
+
+# Define propositions
+(p: p is p)
+(q: q is q)
+
+# Assign truth values
+((p = true) has probability 1)
+((q = true) has probability 0)
+
+# Basic queries
+(? (p = true))                          # -> 1 (true)
+(? (q = true))                          # -> 0 (false)
+
+# Negation
+(? (not (p = true)))                    # -> 0 (not true = false)
+(? (not (q = true)))                    # -> 1 (not false = true)
+
+# Conjunction (AND): both must be true
+(? ((p = true) and (q = true)))         # -> 0 (true AND false = false)
+
+# Disjunction (OR): at least one true
+(? ((p = true) or (q = true)))          # -> 1 (true OR false = true)
+
+# Law of excluded middle: p ∨ ¬p = true
+(? ((p = true) or (not (p = true))))    # -> 1
+
+# Law of non-contradiction: p ∧ ¬p = false
+(? ((p = true) and (not (p = true))))   # -> 0
+
+# Double negation: ¬¬p = p
+(? (not (not (p = true))))              # -> 1

--- a/rust/examples/fuzzy-logic.lino
+++ b/rust/examples/fuzzy-logic.lino
@@ -1,0 +1,43 @@
+# Fuzzy Logic — Continuous truth values in [0, 1]
+#
+# Standard fuzzy logic where truth values represent degrees of membership.
+# Unlike classical logic, propositions can be partially true.
+#
+# Standard fuzzy connectives (Zadeh):
+#   AND = min (degree of conjunction)
+#   OR  = max (degree of disjunction)
+#   NOT = 1 - x (complement)
+#
+# See: https://en.wikipedia.org/wiki/Fuzzy_logic
+#      https://en.wikipedia.org/wiki/Fuzzy_set
+
+(and: min)
+(or: max)
+
+# Define fuzzy propositions with degrees of truth
+(a: a is a)
+(b: b is b)
+(c: c is c)
+
+# "a is tall" with 80% degree of truth
+((a = tall) has probability 0.8)
+# "b is tall" with 30% degree of truth
+((b = tall) has probability 0.3)
+# "c is tall" with 60% degree of truth
+((c = tall) has probability 0.6)
+
+# Query membership degrees
+(? (a = tall))                            # -> 0.8
+(? (b = tall))                            # -> 0.3
+
+# Fuzzy AND (min): "a is tall AND b is tall"
+(? ((a = tall) and (b = tall)))           # -> 0.3
+
+# Fuzzy OR (max): "a is tall OR b is tall"
+(? ((a = tall) or (b = tall)))            # -> 0.8
+
+# Fuzzy NOT: "a is NOT tall"
+(? (not (a = tall)))                      # -> 0.2
+
+# Chained: "a is tall AND (b is tall OR c is tall)"
+(? ((a = tall) and ((b = tall) or (c = tall))))   # -> 0.6

--- a/rust/examples/propositional-logic.lino
+++ b/rust/examples/propositional-logic.lino
@@ -1,0 +1,40 @@
+# Propositional Logic — Multiple propositions with standard connectives
+#
+# Extends classical logic with multiple propositions to demonstrate
+# standard logical reasoning patterns that every logic textbook covers.
+#
+# Uses product aggregator for AND (standard probabilistic interpretation)
+# and probabilistic_sum for OR (inclusion-exclusion principle).
+#
+# See: https://en.wikipedia.org/wiki/Propositional_calculus
+
+(and: product)
+(or: probabilistic_sum)
+
+# Define propositions with assigned probabilities
+(rain: rain is rain)
+(umbrella: umbrella is umbrella)
+(wet: wet is wet)
+
+((rain = true) has probability 0.3)
+((umbrella = true) has probability 0.6)
+((wet = true) has probability 0.4)
+
+# Query individual probabilities
+(? (rain = true))                                    # -> 0.3
+(? (umbrella = true))                                # -> 0.6
+
+# Joint probability: P(Rain AND Umbrella) = P(Rain) * P(Umbrella)
+(? ((rain = true) and (umbrella = true)))             # -> 0.18
+
+# Union probability: P(Rain OR Umbrella) = 1 - (1-0.3)*(1-0.6)
+(? ((rain = true) or (umbrella = true)))              # -> 0.72
+
+# Complement: P(NOT Rain) = 1 - P(Rain)
+(? (not (rain = true)))                               # -> 0.7
+
+# Three-way joint: P(Rain AND Umbrella AND Wet)
+(? (and (rain = true) (umbrella = true) (wet = true)))   # -> 0.072
+
+# Three-way union: P(Rain OR Umbrella OR Wet)
+(? (or (rain = true) (umbrella = true) (wet = true)))    # -> 0.832

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,7 +5,7 @@
 // - Uses official links-notation crate to parse LiNo text into links
 // - Terms are defined via (x: x is x)
 // - Probabilities are assigned ONLY via: ((<expr>) has probability <p>)
-// - Redefinable ops: (=: ...), (!=: not =), (and: avg|min|max|product|probabilistic_sum), (or: ...), (not: ...)
+// - Redefinable ops: (=: ...), (!=: not =), (and: avg|min|max|product|probabilistic_sum), (or: ...), (not: ...), (both: ...), (neither: ...)
 // - Range: (range: 0 1) for [0,1] or (range: -1 1) for [-1,1] (balanced/symmetric)
 // - Valence: (valence: N) to restrict truth values to N discrete levels (N=2 → Boolean, N=3 → ternary, etc.)
 // - Query: (? <expr>)
@@ -352,6 +352,12 @@ impl Env {
         ops.insert("not".to_string(), Op::Not);
         ops.insert("and".to_string(), Op::Agg(Aggregator::Avg));
         ops.insert("or".to_string(), Op::Agg(Aggregator::Max));
+        // Belnap operators: AND-altering operators for four-valued logic
+        // "both" (gullibility): avg — contradiction resolves to midpoint
+        // "neither" (consensus): product — gap resolves to zero (no info propagates)
+        // See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+        ops.insert("both".to_string(), Op::Agg(Aggregator::Avg));
+        ops.insert("neither".to_string(), Op::Agg(Aggregator::Prod));
         ops.insert("=".to_string(), Op::Eq);
         ops.insert("!=".to_string(), Op::Neq);
         ops.insert("+".to_string(), Op::Add);
@@ -394,12 +400,8 @@ impl Env {
         let mid = self.mid();
         self.symbol_prob.insert("unknown".to_string(), mid);
         self.symbol_prob.insert("undefined".to_string(), mid);
-        // Belnap's four-valued logic constants:
-        // "both" = both true and false (contradiction/paradox), maps to midpoint
-        // "neither" = neither true nor false (gap/unknown), maps to midpoint
+        // Note: "both" and "neither" are operators (not constants) — see Env::new()
         // See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
-        self.symbol_prob.insert("both".to_string(), mid);
-        self.symbol_prob.insert("neither".to_string(), mid);
     }
 
     /// Clamp and optionally quantize a value to the valid range.
@@ -470,7 +472,7 @@ impl Env {
                     self.hi - (vals[0] - self.lo)
                 }
             }
-            Op::Agg(agg) => agg.apply(vals, self.lo),
+            Op::Agg(agg) => dec_round(agg.apply(vals, self.lo)),
             Op::Eq | Op::Neq => self.lo,
             Op::Compose {
                 ref outer,
@@ -549,6 +551,8 @@ impl Env {
         self.ops.insert("not".to_string(), Op::Not);
         self.ops.insert("and".to_string(), Op::Agg(Aggregator::Avg));
         self.ops.insert("or".to_string(), Op::Agg(Aggregator::Max));
+        self.ops.insert("both".to_string(), Op::Agg(Aggregator::Avg));
+        self.ops.insert("neither".to_string(), Op::Agg(Aggregator::Prod));
         self.ops.insert("=".to_string(), Op::Eq);
         self.ops.insert("!=".to_string(), Op::Neq);
         self.ops.insert("+".to_string(), Op::Add);
@@ -813,10 +817,10 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                 }
             }
 
-            // Infix AND/OR: ((A) and (B)) / ((A) or (B))
+            // Infix AND/OR/BOTH/NEITHER: ((A) and (B)) / ((A) or (B)) / ((A) both (B)) / ((A) neither (B))
             if children.len() == 3 {
                 if let Node::Leaf(ref op_name) = children[1] {
-                    if op_name == "and" || op_name == "or" {
+                    if op_name == "and" || op_name == "or" || op_name == "both" || op_name == "neither" {
                         let l = eval_node(&children[0], env).as_f64();
                         let r = eval_node(&children[2], env).as_f64();
                         return EvalResult::Value(env.clamp(env.apply_op(op_name, &[l, r])));
@@ -1172,6 +1176,8 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         || head == "!="
         || head == "and"
         || head == "or"
+        || head == "both"
+        || head == "neither"
         || head == "not"
         || head == "is"
         || head == "?:"
@@ -1196,7 +1202,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         }
 
         // Aggregator selection: (and: avg|min|max|product|probabilistic_sum)
-        if (head == "and" || head == "or") && rhs.len() == 1 {
+        if (head == "and" || head == "or" || head == "both" || head == "neither") && rhs.len() == 1 {
             if let Node::Leaf(ref sel) = rhs[0] {
                 if let Some(agg) = Aggregator::from_name(sel) {
                     env.define_op(head, Op::Agg(agg));
@@ -1238,6 +1244,8 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
             || head == "!="
             || head == "and"
             || head == "or"
+            || head == "both"
+            || head == "neither"
             || head == "not"
             || head == "is"
             || head == "?:"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -394,6 +394,12 @@ impl Env {
         let mid = self.mid();
         self.symbol_prob.insert("unknown".to_string(), mid);
         self.symbol_prob.insert("undefined".to_string(), mid);
+        // Belnap's four-valued logic constants:
+        // "both" = both true and false (contradiction/paradox), maps to midpoint
+        // "neither" = neither true nor false (gap/unknown), maps to midpoint
+        // See: https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+        self.symbol_prob.insert("both".to_string(), mid);
+        self.symbol_prob.insert("neither".to_string(), mid);
     }
 
     /// Clamp and optionally quantize a value to the valid range.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -828,6 +828,28 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                 }
             }
 
+            // Composite natural language operators: (both A and B [and C ...]), (neither A nor B [nor C ...])
+            if children.len() >= 4 && children.len() % 2 == 0 {
+                if let Node::Leaf(ref head) = children[0] {
+                    if head == "both" || head == "neither" {
+                        let sep = if head == "both" { "and" } else { "nor" };
+                        let mut valid = true;
+                        for i in (2..children.len()).step_by(2) {
+                            if let Node::Leaf(ref s) = children[i] {
+                                if s != sep { valid = false; break; }
+                            } else { valid = false; break; }
+                        }
+                        if valid {
+                            let head_str = head.clone();
+                            let vals: Vec<f64> = (1..children.len()).step_by(2)
+                                .map(|i| eval_node(&children[i], env).as_f64())
+                                .collect();
+                            return EvalResult::Value(env.clamp(env.apply_op(&head_str, &vals)));
+                        }
+                    }
+                }
+            }
+
             // Infix equality/inequality: (L = R), (L != R)
             if children.len() == 3 {
                 if let Node::Leaf(ref op_name) = children[1] {

--- a/rust/tests/rml_tests.rs
+++ b/rust/tests/rml_tests.rs
@@ -1545,6 +1545,266 @@ fn truth_const_liar_paradox_balanced() {
     assert_eq!(results[0], 0.0);
 }
 
+// ===== Belnap's four-valued logic constants: both, neither =====
+// https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
+
+#[test]
+fn truth_const_both_default_01() {
+    let results = run("(? both)", None);
+    assert_eq!(results[0], 0.5);
+}
+
+#[test]
+fn truth_const_neither_default_01() {
+    let results = run("(? neither)", None);
+    assert_eq!(results[0], 0.5);
+}
+
+#[test]
+fn truth_const_both_default_balanced() {
+    let results = run(
+        "(range: -1 1)\n(? both)",
+        Some(EnvOptions {
+            lo: -1.0,
+            hi: 1.0,
+            valence: 0,
+        }),
+    );
+    assert_eq!(results[0], 0.0);
+}
+
+#[test]
+fn truth_const_neither_default_balanced() {
+    let results = run(
+        "(range: -1 1)\n(? neither)",
+        Some(EnvOptions {
+            lo: -1.0,
+            hi: 1.0,
+            valence: 0,
+        }),
+    );
+    assert_eq!(results[0], 0.0);
+}
+
+#[test]
+fn truth_const_both_redefine() {
+    let results = run(
+        r#"
+(both: 0.7)
+(neither: 0.3)
+(? both)
+(? neither)
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.7);
+    assert_eq!(results[1], 0.3);
+}
+
+#[test]
+fn truth_const_both_env_api_01() {
+    let env = Env::new(None);
+    assert_eq!(env.get_symbol_prob("both"), 0.5);
+    assert_eq!(env.get_symbol_prob("neither"), 0.5);
+}
+
+#[test]
+fn truth_const_both_env_api_balanced() {
+    let env = Env::new(Some(EnvOptions {
+        lo: -1.0,
+        hi: 1.0,
+        valence: 0,
+    }));
+    assert_eq!(env.get_symbol_prob("both"), 0.0);
+    assert_eq!(env.get_symbol_prob("neither"), 0.0);
+}
+
+#[test]
+fn truth_const_both_in_expressions() {
+    let results = run(
+        r#"
+(and: min)
+(? (true and both))
+(? (false or both))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5); // min(1, 0.5)
+    assert_eq!(results[1], 0.5); // max(0, 0.5)
+}
+
+#[test]
+fn truth_const_not_both_fixed_point() {
+    let results = run(
+        r#"
+(? (not both))
+(? (not neither))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5); // not(0.5) = 0.5
+    assert_eq!(results[1], 0.5); // not(0.5) = 0.5
+}
+
+#[test]
+fn truth_const_both_range_change() {
+    let results = run(
+        r#"
+(? both)
+(? neither)
+(range: -1 1)
+(? both)
+(? neither)
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5); // both in [0,1]
+    assert_eq!(results[1], 0.5); // neither in [0,1]
+    assert_eq!(results[2], 0.0); // both in [-1,1]
+    assert_eq!(results[3], 0.0); // neither in [-1,1]
+}
+
+// ===== Standard logic examples =====
+
+#[test]
+fn example_classical_logic() {
+    let results = run(
+        r#"
+(valence: 2)
+(and: min)
+(or: max)
+(p: p is p)
+(q: q is q)
+((p = true) has probability 1)
+((q = true) has probability 0)
+(? (p = true))
+(? (q = true))
+(? (not (p = true)))
+(? (not (q = true)))
+(? ((p = true) and (q = true)))
+(? ((p = true) or (q = true)))
+(? ((p = true) or (not (p = true))))
+(? ((p = true) and (not (p = true))))
+(? (not (not (p = true))))
+"#,
+        None,
+    );
+    assert_eq!(results.len(), 9);
+    assert_eq!(results[0], 1.0);
+    assert_eq!(results[1], 0.0);
+    assert_eq!(results[2], 0.0);
+    assert_eq!(results[3], 1.0);
+    assert_eq!(results[4], 0.0);
+    assert_eq!(results[5], 1.0);
+    assert_eq!(results[6], 1.0);
+    assert_eq!(results[7], 0.0);
+    assert_eq!(results[8], 1.0);
+}
+
+#[test]
+fn example_propositional_logic() {
+    let results = run(
+        r#"
+(and: product)
+(or: probabilistic_sum)
+(rain: rain is rain)
+(umbrella: umbrella is umbrella)
+(wet: wet is wet)
+((rain = true) has probability 0.3)
+((umbrella = true) has probability 0.6)
+((wet = true) has probability 0.4)
+(? (rain = true))
+(? (umbrella = true))
+(? ((rain = true) and (umbrella = true)))
+(? ((rain = true) or (umbrella = true)))
+(? (not (rain = true)))
+(? (and (rain = true) (umbrella = true) (wet = true)))
+(? (or (rain = true) (umbrella = true) (wet = true)))
+"#,
+        None,
+    );
+    assert_eq!(results.len(), 7);
+    approx(results[0], 0.3);
+    approx(results[1], 0.6);
+    approx(results[2], 0.18);
+    approx(results[3], 0.72);
+    approx(results[4], 0.7);
+    approx(results[5], 0.072);
+    approx(results[6], 0.832);
+}
+
+#[test]
+fn example_fuzzy_logic() {
+    let results = run(
+        r#"
+(and: min)
+(or: max)
+(a: a is a)
+(b: b is b)
+(c: c is c)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.3)
+((c = tall) has probability 0.6)
+(? (a = tall))
+(? (b = tall))
+(? ((a = tall) and (b = tall)))
+(? ((a = tall) or (b = tall)))
+(? (not (a = tall)))
+(? ((a = tall) and ((b = tall) or (c = tall))))
+"#,
+        None,
+    );
+    assert_eq!(results.len(), 6);
+    approx(results[0], 0.8);
+    approx(results[1], 0.3);
+    approx(results[2], 0.3);
+    approx(results[3], 0.8);
+    approx(results[4], 0.2);
+    approx(results[5], 0.6);
+}
+
+#[test]
+fn example_belnap_four_valued() {
+    let results = run(
+        r#"
+(and: min)
+(or: max)
+(? true)
+(? false)
+(? both)
+(? neither)
+(? (not true))
+(? (not false))
+(? (not both))
+(? (not neither))
+(s: s is s)
+((s = false) has probability 0.5)
+(? (s = false))
+(? (not (s = false)))
+(? (true and both))
+(? (false or both))
+(? (true or both))
+(? (false and both))
+"#,
+        None,
+    );
+    assert_eq!(results.len(), 14);
+    assert_eq!(results[0], 1.0);
+    assert_eq!(results[1], 0.0);
+    assert_eq!(results[2], 0.5);
+    assert_eq!(results[3], 0.5);
+    assert_eq!(results[4], 0.0);
+    assert_eq!(results[5], 1.0);
+    assert_eq!(results[6], 0.5);
+    assert_eq!(results[7], 0.5);
+    assert_eq!(results[8], 0.5);
+    assert_eq!(results[9], 0.5);
+    assert_eq!(results[10], 0.5);
+    assert_eq!(results[11], 0.5);
+    assert_eq!(results[12], 1.0);
+    assert_eq!(results[13], 0.0);
+}
+
 // ===== Type System: "everything is a link" =====
 // Dependent types as links: types are stored as associations in the link network.
 // See: https://github.com/link-foundation/associative-dependent-logic/issues/13

--- a/rust/tests/rml_tests.rs
+++ b/rust/tests/rml_tests.rs
@@ -1545,123 +1545,160 @@ fn truth_const_liar_paradox_balanced() {
     assert_eq!(results[0], 0.0);
 }
 
-// ===== Belnap's four-valued logic constants: both, neither =====
+// ===== Belnap's four-valued logic operators: both, neither =====
 // https://en.wikipedia.org/wiki/Four-valued_logic#Belnap
 
 #[test]
-fn truth_const_both_default_01() {
-    let results = run("(? both)", None);
-    assert_eq!(results[0], 0.5);
+fn operator_both_default_avg() {
+    let results = run("(? (true both false))", None);
+    assert_eq!(results[0], 0.5); // avg(1, 0) = 0.5
 }
 
 #[test]
-fn truth_const_neither_default_01() {
-    let results = run("(? neither)", None);
-    assert_eq!(results[0], 0.5);
+fn operator_neither_default_product() {
+    let results = run("(? (true neither false))", None);
+    assert_eq!(results[0], 0.0); // product(1, 0) = 0
 }
 
 #[test]
-fn truth_const_both_default_balanced() {
-    let results = run(
-        "(range: -1 1)\n(? both)",
-        Some(EnvOptions {
-            lo: -1.0,
-            hi: 1.0,
-            valence: 0,
-        }),
-    );
-    assert_eq!(results[0], 0.0);
-}
-
-#[test]
-fn truth_const_neither_default_balanced() {
-    let results = run(
-        "(range: -1 1)\n(? neither)",
-        Some(EnvOptions {
-            lo: -1.0,
-            hi: 1.0,
-            valence: 0,
-        }),
-    );
-    assert_eq!(results[0], 0.0);
-}
-
-#[test]
-fn truth_const_both_redefine() {
+fn operator_both_redefine_aggregator() {
     let results = run(
         r#"
-(both: 0.7)
-(neither: 0.3)
-(? both)
-(? neither)
+(both: min)
+(? (true both false))
 "#,
         None,
     );
-    assert_eq!(results[0], 0.7);
-    assert_eq!(results[1], 0.3);
+    assert_eq!(results[0], 0.0); // min(1, 0) = 0
 }
 
 #[test]
-fn truth_const_both_env_api_01() {
+fn operator_neither_redefine_aggregator() {
+    let results = run(
+        r#"
+(neither: max)
+(? (true neither false))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 1.0); // max(1, 0) = 1
+}
+
+#[test]
+fn operator_both_env_has_op() {
     let env = Env::new(None);
-    assert_eq!(env.get_symbol_prob("both"), 0.5);
-    assert_eq!(env.get_symbol_prob("neither"), 0.5);
+    assert!(env.ops.contains_key("both"));
+    assert!(env.ops.contains_key("neither"));
 }
 
 #[test]
-fn truth_const_both_env_api_balanced() {
-    let env = Env::new(Some(EnvOptions {
-        lo: -1.0,
-        hi: 1.0,
-        valence: 0,
-    }));
-    assert_eq!(env.get_symbol_prob("both"), 0.0);
-    assert_eq!(env.get_symbol_prob("neither"), 0.0);
-}
-
-#[test]
-fn truth_const_both_in_expressions() {
+fn operator_both_same_values() {
     let results = run(
         r#"
-(and: min)
-(? (true and both))
-(? (false or both))
+(? (true both true))
+(? (false both false))
 "#,
         None,
     );
-    assert_eq!(results[0], 0.5); // min(1, 0.5)
-    assert_eq!(results[1], 0.5); // max(0, 0.5)
+    assert_eq!(results[0], 1.0); // avg(1, 1) = 1
+    assert_eq!(results[1], 0.0); // avg(0, 0) = 0
 }
 
 #[test]
-fn truth_const_not_both_fixed_point() {
+fn operator_neither_same_values() {
     let results = run(
         r#"
-(? (not both))
-(? (not neither))
+(? (true neither true))
+(? (false neither false))
 "#,
         None,
     );
-    assert_eq!(results[0], 0.5); // not(0.5) = 0.5
-    assert_eq!(results[1], 0.5); // not(0.5) = 0.5
+    assert_eq!(results[0], 1.0); // product(1, 1) = 1
+    assert_eq!(results[1], 0.0); // product(0, 0) = 0
 }
 
 #[test]
-fn truth_const_both_range_change() {
+fn operator_both_fuzzy_values() {
     let results = run(
         r#"
-(? both)
-(? neither)
+(a: a is a)
+(b: b is b)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.4)
+(? ((a = tall) both (b = tall)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.6); // avg(0.8, 0.4) = 0.6
+}
+
+#[test]
+fn operator_neither_fuzzy_values() {
+    let results = run(
+        r#"
+(a: a is a)
+(b: b is b)
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.5)
+(? ((a = tall) neither (b = tall)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.4); // product(0.8, 0.5) = 0.4
+}
+
+#[test]
+fn operator_both_prefix_form() {
+    let results = run("(? (both true false))", None);
+    assert_eq!(results[0], 0.5); // avg(1, 0) = 0.5
+}
+
+#[test]
+fn operator_neither_prefix_form() {
+    let results = run("(? (neither true false))", None);
+    assert_eq!(results[0], 0.0); // product(1, 0) = 0
+}
+
+#[test]
+fn operator_both_range_change() {
+    let results = run(
+        r#"
+(? (true both false))
 (range: -1 1)
-(? both)
-(? neither)
+(? (true both false))
 "#,
         None,
     );
-    assert_eq!(results[0], 0.5); // both in [0,1]
-    assert_eq!(results[1], 0.5); // neither in [0,1]
-    assert_eq!(results[2], 0.0); // both in [-1,1]
-    assert_eq!(results[3], 0.0); // neither in [-1,1]
+    assert_eq!(results[0], 0.5); // avg(1, 0) = 0.5 in [0,1]
+    assert_eq!(results[1], 0.0); // avg(1, -1) = 0 in [-1,1]
+}
+
+#[test]
+fn operator_both_issue_scenario() {
+    let results = run(
+        r#"
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? ((a = a) both (a != a)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5);
+}
+
+#[test]
+fn operator_neither_issue_scenario() {
+    let results = run(
+        r#"
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? ((a = a) neither (a != a)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.0);
 }
 
 // ===== Standard logic examples =====
@@ -1771,38 +1808,34 @@ fn example_belnap_four_valued() {
 (or: max)
 (? true)
 (? false)
-(? both)
-(? neither)
 (? (not true))
 (? (not false))
-(? (not both))
-(? (not neither))
 (s: s is s)
 ((s = false) has probability 0.5)
 (? (s = false))
 (? (not (s = false)))
-(? (true and both))
-(? (false or both))
-(? (true or both))
-(? (false and both))
+(? (true both false))
+(? (true neither false))
+(? (true both true))
+(? (false both false))
+(? (true neither true))
+(? (false neither false))
 "#,
         None,
     );
-    assert_eq!(results.len(), 14);
-    assert_eq!(results[0], 1.0);
-    assert_eq!(results[1], 0.0);
-    assert_eq!(results[2], 0.5);
-    assert_eq!(results[3], 0.5);
-    assert_eq!(results[4], 0.0);
-    assert_eq!(results[5], 1.0);
-    assert_eq!(results[6], 0.5);
-    assert_eq!(results[7], 0.5);
-    assert_eq!(results[8], 0.5);
-    assert_eq!(results[9], 0.5);
-    assert_eq!(results[10], 0.5);
-    assert_eq!(results[11], 0.5);
-    assert_eq!(results[12], 1.0);
-    assert_eq!(results[13], 0.0);
+    assert_eq!(results.len(), 12);
+    assert_eq!(results[0], 1.0);    // true
+    assert_eq!(results[1], 0.0);    // false
+    assert_eq!(results[2], 0.0);    // not true
+    assert_eq!(results[3], 1.0);    // not false
+    assert_eq!(results[4], 0.5);    // liar paradox
+    assert_eq!(results[5], 0.5);    // not liar paradox
+    assert_eq!(results[6], 0.5);    // true both false = 0.5 (contradiction)
+    assert_eq!(results[7], 0.0);    // true neither false = 0 (gap)
+    assert_eq!(results[8], 1.0);    // true both true = 1
+    assert_eq!(results[9], 0.0);    // false both false = 0
+    assert_eq!(results[10], 1.0);   // true neither true = 1
+    assert_eq!(results[11], 0.0);   // false neither false = 0
 }
 
 // ===== Type System: "everything is a link" =====

--- a/rust/tests/rml_tests.rs
+++ b/rust/tests/rml_tests.rs
@@ -1660,6 +1660,100 @@ fn operator_neither_prefix_form() {
 }
 
 #[test]
+fn operator_both_composite_natural_language() {
+    let results = run(
+        r#"
+(? (both true and false))
+(? (both true and true))
+(? (both false and false))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5); // avg(1, 0) = 0.5
+    assert_eq!(results[1], 1.0); // avg(1, 1) = 1
+    assert_eq!(results[2], 0.0); // avg(0, 0) = 0
+}
+
+#[test]
+fn operator_neither_composite_natural_language() {
+    let results = run(
+        r#"
+(? (neither true nor false))
+(? (neither true nor true))
+(? (neither false nor false))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.0); // product(1, 0) = 0
+    assert_eq!(results[1], 1.0); // product(1, 1) = 1
+    assert_eq!(results[2], 0.0); // product(0, 0) = 0
+}
+
+#[test]
+fn operator_both_composite_variadic() {
+    let results = run("(? (both true and true and false))", None);
+    assert!((results[0] - 0.666666666667).abs() < 0.0001); // avg(1, 1, 0)
+}
+
+#[test]
+fn operator_neither_composite_variadic() {
+    let results = run("(? (neither true nor true nor false))", None);
+    assert_eq!(results[0], 0.0); // product(1, 1, 0) = 0
+}
+
+#[test]
+fn operator_both_composite_redefinable() {
+    let results = run(
+        r#"
+(both: min)
+(? (both true and false))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.0); // min(1, 0) = 0
+}
+
+#[test]
+fn operator_neither_composite_redefinable() {
+    let results = run(
+        r#"
+(neither: max)
+(? (neither true nor false))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 1.0); // max(1, 0) = 1
+}
+
+#[test]
+fn operator_both_composite_issue_scenario() {
+    let results = run(
+        r#"
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? (both (a = a) and (a != a)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.5);
+}
+
+#[test]
+fn operator_neither_composite_issue_scenario() {
+    let results = run(
+        r#"
+(a: a is a)
+((a = a) has probability 1)
+((a != a) has probability 0)
+(? (neither (a = a) nor (a != a)))
+"#,
+        None,
+    );
+    assert_eq!(results[0], 0.0);
+}
+
+#[test]
 fn operator_both_range_change() {
     let results = run(
         r#"


### PR DESCRIPTION
## Summary

Fixes #20

### Composite Natural Language Operators (latest change)

Changed `both` and `neither` to use **composite natural language syntax** that reads like English:

```lino
# Before (infix):
(? (true both false))           # -> 0.5
(? (true neither false))        # -> 0

# After (natural language):
(? (both true and false))       # -> 0.5  "both true and false"
(? (neither true nor false))    # -> 0    "neither true nor false"
```

- **Variadic support**: `(both A and B and C)`, `(neither A nor B nor C)`
- **Backward compatible**: Old infix `(A both B)` and prefix `(both A B)` forms still work
- **Redefinable**: `(both: min)`, `(neither: max)` — just like `and` and `or`

### Previous Changes

- **Change `both` and `neither` from truth constants to operators** — They are now AND-altering operators that alter conjunction strategy (avg for contradiction, product for gap).
- **Add 4 new standard example files** — `classical-logic.lino`, `propositional-logic.lino`, `fuzzy-logic.lino`, `belnap-four-valued.lino`
- **Reorder README examples** from standard to non-standard
- **Update Quick Start** to use classical Boolean logic
- **Fix inline comment parsing** — Comments containing colons after closing parentheses no longer crash the parser
- **Both JS and Rust implementations updated** with matching behavior and tests
- **Version bumped to 0.9.0**

## Key Change: Natural Language Operators

```lino
# Contradiction — reads naturally as "both true and false"
(? (both true and false))       # -> 0.5 (avg)

# Gap — reads naturally as "neither true nor false"
(? (neither true nor false))    # -> 0   (product)

# Variadic
(? (both A and B and C))        # avg(A, B, C)

# Redefinable
(both: min)
(? (both true and false))       # -> 0   (min semantics)

# Paradox resolution
(? (both (a = a) and (a != a))) # -> 0.5 (contradiction at midpoint)
```

## Test plan

- [x] All 304 JS tests pass (`cd js && npm test`)
- [x] All 238 Rust tests pass (`cd rust && cargo test`)
- [x] All example .lino files run correctly
- [x] `(both true and false)` = 0.5 (composite natural language)
- [x] `(neither true nor false)` = 0 (composite natural language)
- [x] Variadic: `(both A and B and C)` works
- [x] Old infix `(A both B)` and prefix `(both A B)` still work (backward compat)
- [x] `both`/`neither` are redefinable via aggregator selection
- [x] Operators auto-update when range changes
- [x] Working tree is clean with no uncommitted changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)