### PR TITLE
Add competitor concept and feature comparison docs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T08:35:33.797Z for PR creation at branch issue-22-7b369df07ffd for issue https://github.com/link-foundation/relative-meta-logic/issues/22

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T08:35:33.797Z for PR creation at branch issue-22-7b369df07ffd for issue https://github.com/link-foundation/relative-meta-logic/issues/22

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Both implementations pass the same comprehensive test suites and produce identic
 
 For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 
+## Comparisons
+
+- [Core concept comparison](./docs/CONCEPTS-COMPARISION.md) - RML vs Twelf, LF, HELF, Isabelle, Coq/Rocq, Lean, Foundation, AFP, Abella, lambda Prolog, and Pecan by logical/metatheoretic concepts.
+- [Product feature comparison](./docs/FEATURE-COMPARISION.md) - RML vs the same systems by authoring workflow, automation, libraries, tooling, and distribution.
+
 ## Overview
 
 RML (Relative Meta-Logic, formerly Associative-Dependent Logic / ADL) is a minimal probabilistic logic system built on top of [LiNo (Links Notation)](https://github.com/link-foundation/links-notation). It supports [many-valued logics](https://en.wikipedia.org/wiki/Many-valued_logic) from unary (1-valued) through continuous probabilistic ([fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic)), allowing you to:

--- a/docs/CONCEPTS-COMPARISION.md
+++ b/docs/CONCEPTS-COMPARISION.md
@@ -1,0 +1,160 @@
+# Core Concept Comparison
+
+This document compares Relative Meta-Logic (RML) with the systems named in
+[issue #22](https://github.com/link-foundation/relative-meta-logic/issues/22)
+by core logical and metatheoretic concepts. Product and workflow capabilities
+are compared separately in [FEATURE-COMPARISION.md](./FEATURE-COMPARISION.md).
+
+The goal is positioning, not a claim that every system has the same design
+target. Several entries are logical frameworks, some are full proof assistants,
+some are libraries inside a host prover, and Pecan is a domain-specific
+automated prover.
+
+## Legend
+
+| Mark | Meaning |
+|------|---------|
+| Yes | First-class or central capability |
+| Part | Partial, prototype, limited, indirect, or available by encoding |
+| Host | Inherited from the host proof assistant rather than implemented by the project itself |
+| Theory | Theoretical framework rather than a standalone product implementation |
+| N/A | Not applicable to the system's role |
+| No | No evidence of support or outside the system's design goal |
+
+## Systems
+
+| System | Primary role |
+|--------|--------------|
+| RML | Link-based probabilistic and many-valued meta-logic with JS and Rust implementations |
+| Twelf | LF implementation with type checking, logic programming, and metatheorem checking |
+| Edinburgh LF | Dependently typed logical framework for representing deductive systems |
+| HELF | Haskell implementation of an LF/Twelf subset for parsing and type checking `.elf` files |
+| Isabelle | Generic interactive theorem prover, especially Isabelle/Pure and Isabelle/HOL |
+| Coq/Rocq | Interactive theorem prover based on the Calculus of Inductive Constructions |
+| Lean | Interactive theorem prover and programming language based on dependent type theory |
+| Foundation | Lean 4 library formalizing mathematical logic |
+| AFP | Isabelle Archive of Formal Proofs, a checked archive of Isabelle developments |
+| Abella | Interactive prover for lambda-tree syntax and two-level logic reasoning |
+| lambda Prolog | Higher-order hereditary Harrop logic programming language |
+| Pecan | Automated theorem prover for automatic sequences and Buchi automata |
+
+## Foundations and Representation
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| General meta-logic for object logics | Yes: link substrate can encode many logics | Yes | Yes | Part | Yes: Pure framework | Part: can encode logics in CIC | Part: can encode logics in DTT | Yes: logic formalizations in Lean | Host: Isabelle entries | Yes | Part: specification language | No |
+| Uniform representation of syntax and judgments | Yes: links | Yes: LF terms | Yes: LF terms | Yes: LF terms | Part: Pure/HOL terms | Yes: CIC terms | Yes: dependent terms | Host | Host | Yes: two-level terms | Yes: lambda terms | Part: formulas and automata |
+| One syntactic category for terms/propositions/proofs | Part: links are uniform; proof terms are prototype only | Yes in LF style | Yes in LF style | Yes in LF subset | Part: terms/propositions distinct in HOL layer | Yes | Yes | Host | Host | Part | Part | No |
+| Explicit object-language encodings | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Part |
+| Adequacy-oriented encodings | Part | Yes | Yes | Part | Yes by proof development | Yes by proof development | Yes by proof development | Host | Host | Yes | Part | No |
+| Links or tuples as primitive notation | Yes | No | No | No | No | No | No | No | No | No | No | No |
+| Named constants and declarations | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes |
+| Definitions as first-class source entries | Yes | Yes | Theory | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes |
+| Structural equality over expressions | Yes | Yes: type theory equality/convertibility | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Part | Domain-specific equality |
+| Numeric truth values in the core | Yes | No | No | No | No | No | No | No | No | No | No | Part: arithmetic domains |
+| Configurable semantic range | Yes: `[0,1]` or `[-1,1]` | No | No | No | No | No | No | No | No | No | No | No |
+| Configurable valence | Yes: unary, Boolean, N-valued, continuous | No | No | No | No | No | No | No | No | No | No | No |
+| Self-reference accepted by default | Yes: midpoint/paradox-tolerant evaluation | No | No | No | No | No | No | Host constraints | Host constraints | Part: coinductive reasoning only | No | No |
+| Circular definitions as ordinary data | Part | No | No | No | Guarded/fixed-point mechanisms | Guarded/termination rules | Guarded/termination rules | Host | Host | Coinductive predicates | Recursive programs with restrictions | Automata fixed points |
+
+## Type Theory and Binding
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Dependent types | Part: prototype type layer | Yes | Yes | Yes | No: HOL is simply typed; Pure is higher-order | Yes | Yes | Host | Host | No: simply typed reasoning/spec logics | No: polymorphic/simple typed | No |
+| Dependent products / Pi-types | Part | Yes | Yes | Yes | Part: meta-level universal quantification | Yes | Yes | Host | Host | No | No | No |
+| Lambda abstraction | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
+| Function application | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
+| Beta reduction | Part: beta for link lambdas | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Yes | No |
+| Definitional equality / conversion | Part | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Part: beta conversion | No |
+| Full normalization | No: evaluator is not a normalizer | Yes for LF canonical forms | Yes in theory | Part | Yes where defined by logic/tools | Yes | Yes | Host | Host | Part | Part | No |
+| Universe hierarchy | Part: `(Type 0)`, `(Type 1)` | No: LF has kinds/types | No | No | No in HOL; object theories possible | Yes | Yes | Host | Host | No | No | No |
+| Sorts / kinds | Part | Yes | Yes | Yes | Yes: types/classes/logics | Yes | Yes | Host | Host | Yes: type declarations | Yes | Domain sorts |
+| Type annotations | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes: domain declarations |
+| Type inference | Part | Part: reconstruction | Theory | No reconstruction | Yes | Yes | Yes | Host | Host | Part | Yes | Part |
+| Type checking | Part | Yes | Theory | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes: domain/formula checking |
+| Higher-order abstract syntax | Part: encodable as links | Yes | Yes | Yes | Part | Part | Part | Host | Host | Yes | Yes | No |
+| Lambda-tree syntax | Part | Yes/related | Yes/related | Yes/related | Encodable | Encodable | Encodable | Host | Host | Yes | Yes | No |
+| Binding-aware substitution | Part | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
+| Variable freshness support | Part | Part | Part | Part | Yes by libraries/packages | Yes by libraries/packages | Yes by libraries/packages | Host/libraries | Host/libraries | Yes: nabla/generic judgments | Part | No |
+| Polymorphism | No dedicated system | Part | Part | Part | Yes | Yes | Yes | Host | Host | Schematic polymorphism | Yes | Domain-specific |
+| Type classes | No | No | No | No | Yes | Yes | Yes | Host | Host | No | No | No |
+| Inductive families | Part: encodable only | Encoded as LF families | Encodable | Encodable | Yes | Yes | Yes | Host | Host | Yes: inductive definitions | Encodable | No |
+| Coinductive types/predicates | Part: encodable only | Limited/encoded | No | No | Yes | Yes | Yes | Host | Host | Yes: coinductive predicates | Encodable | Automata over infinite words |
+
+## Logic and Semantics
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Classical logic | Yes | Encodable | Encodable | Encodable | Yes: HOL/FOL libraries | Yes | Yes | Yes | Yes | Encodable | Encodable | Part: decidable fragments |
+| Intuitionistic logic | Part | Yes: LF foundation | Yes | Yes | Encodable / FOL library | Yes | Yes | Yes | Yes | Yes | Yes | No |
+| Constructive type theory | Part | LF-style | LF-style | LF-style | Object theories possible | Yes | Yes | Host | Host | No | No | No |
+| Higher-order logic | Part | Encodable | Encodable | Encodable | Yes | Encodable in CIC | Encodable in DTT | Host/encodable | Host | Part | Yes: higher-order programming logic | No |
+| First-order logic | Part | Encodable | Encodable | Encodable | Yes | Encodable | Encodable | Yes | Yes | Encodable | Encodable | Part: arithmetic/word formulas |
+| Modal logic | Part: link encoding | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Provability logic | Part: encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Interpretability logic | Part: encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Set theory | Part: encodable | Encodable | Encodable | Encodable | Yes: ZF object logic | Encodable/libraries | Encodable/libraries | Yes | Yes | Encodable | Encodable | No |
+| Many-valued logic | Yes: native valence/range | No | No | No | Encodable | Encodable | Encodable | Part | Part | Encodable | Encodable | No |
+| Fuzzy logic | Yes: continuous truth values and aggregators | No | No | No | Encodable | Encodable | Encodable | No | Part | Encodable | No | No |
+| Probabilistic truth values | Yes: native probabilities | No | No | No | Encodable | Encodable | Encodable | No | Part | Encodable | No | No |
+| Probabilistic operators | Yes: product/probabilistic sum | No | No | No | Encodable | Encodable | Encodable | No | Part | Encodable | No | No |
+| Redefinable logical operators | Yes | Part: notation and constants | Theory | Limited | Yes | Yes | Yes | Host | Host | Part | Yes | Part |
+| Paraconsistent semantics | Yes: paradox-tolerant midpoint behavior | No | No | No | Encodable | Encodable with axioms/libraries | Encodable with axioms/libraries | Part: logic zoo focus | Part | Encodable | No | No |
+| Liar/self-reference examples | Yes | No | No | No | Encodable with care | Encodable with restrictions | Encodable with restrictions | Part | Part | Part | No | No |
+| Arithmetic reasoning | Part: decimal arithmetic in evaluator | Constraint domains possible | Encodable | Encodable | Yes | Yes | Yes | Yes | Yes | Encodable | Encodable | Yes: numeration systems |
+| Automated sequence reasoning | No | No | No | No | Encodable with effort | Encodable with effort | Encodable with effort | No | Some entries possible | No | No | Yes |
+| Automata-theoretic semantics | No | No | No | No | External/libraries possible | External/libraries possible | External/libraries possible | No | Part | No | No | Yes |
+| Decidable complete target fragment | No: general meta-logic evaluator | No | No | No | Some procedures | Some procedures/tactics | Some procedures/tactics | Host | Host | No | No | Yes |
+
+## Metatheory and Proof Objects
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Machine-checked proof terms | Part: not yet first-class derivation objects | Yes | Theory | Yes: LF type checking | Yes | Yes | Yes | Host | Host | Yes | Part: proof/search witnesses | No general proof terms |
+| Small trusted kernel/checker | Part: small evaluator, prototype type layer | Yes: LF checker | Theory | Yes: LF checker | Yes: LCF-style kernel | Yes | Yes | Host | Host | Yes | No: language implementation | Domain-specific automata checker |
+| Metatheorem checking about encoded systems | Part | Yes | Theory goal | No | Yes | Yes | Yes | Yes | Yes | Yes | Part | No |
+| Totality checking | No | Yes | No | No | Part: function package/tools | Yes | Yes | Host | Host | Part | No | N/A |
+| Termination checking | No | Yes | No | No | Yes for recursive definitions/tools | Yes | Yes | Host | Host | Part | No | N/A |
+| Coverage checking | No | Yes | No | No | Part | Yes | Yes | Host | Host | Part | No | N/A |
+| Mode checking | No | Yes | No | No | No direct equivalent | Tactic/program mechanisms | Tactic/program mechanisms | Host | Host | Part | Modes in implementations/ecosystem | N/A |
+| World declarations / regular worlds | No | Yes | No | No | No | No | No | No | No | No | No | N/A |
+| Proof search | Part: query evaluation | Yes | No | No | Yes | Yes via tactics/plugins | Yes via tactics | Host | Host | Yes | Yes | Yes: decision procedure |
+| Tactic-level proof construction | No | Part: theorem prover/proof search | No | No | Yes | Yes | Yes | Host | Host | Yes | Logic programming search | No |
+| Rewriting as proof principle | Part: operators/evaluator | Encodable | Encodable | Encodable | Yes | Yes | Yes | Host | Host | Part | Part | No |
+| Countermodel/counterexample support | No | No | No | No | Yes: tools such as Nitpick/Quickcheck | Plugins/tools | Ecosystem/tools | Host | Host | No | No | Automata emptiness gives domain feedback |
+| Executable specifications | Yes | Yes | No | Part: typecheck examples | Part | Yes: Gallina programs | Yes: functional programs | Host | Host | Yes: executable specification logic | Yes | Yes |
+| Proof-producing evaluator | No | Yes for logic programming/type checking | Theory | Type-checking only | Yes | Yes | Yes | Host | Host | Yes | Part | No general derivation object |
+| Independent proof replay | No | Yes via LF checking | Theory | Yes for LF terms | Yes | Yes | Yes | Host | Host | Yes | No standard independent replay | Domain-specific rerun |
+| Library-scale theorem reuse | No | Examples only | Theory | No | Yes | Yes | Yes | Yes | Yes | Examples | Examples | Domain libraries |
+| Soundness story documented | Part | Yes through LF/Twelf literature | Yes | Part | Yes | Yes | Yes | Host | Host | Yes | Yes | Domain-specific/paper |
+| Proof irrelevance / propositions | No dedicated support | No general universe feature | No | No | Logic-dependent | Yes | Yes | Host | Host | No | No | No |
+| Reflection/metatheory inside the system | Part: links can encode rules | Part | Theory | No | Isabelle/ML and object encodings | Ltac/MetaCoq/plugins | Lean metaprogramming | Host | Host | Part | Program-level | No |
+| External certification bridge | No | No | N/A | No | Can import/export through ecosystem | Plugins/tools | Ecosystem/tools | Host | Host | No | No | No |
+
+## RML Positioning From the Concept Matrix
+
+| Area | RML advantage | RML gap |
+|------|---------------|---------|
+| Semantic flexibility | Native many-valued, probabilistic, fuzzy, and paradox-tolerant evaluation | No mature proof-producing semantics or independent proof replay |
+| Representation | Links give one low-friction substrate for terms, propositions, probabilities, graph structures, and prototype type constructs | No mature elaborator, module system, or binding discipline comparable to LF/DTT systems |
+| Logic diversity | Operators and truth ranges can be changed at runtime | Encoded object logics lack machine-checked metatheory infrastructure |
+| Type theory | Universe, Pi, lambda, application, and type-query experiments exist | No full normalization, inductive families, totality, termination, or coverage checking |
+| Automation | Query evaluation is small and easy to inspect | No tactic language, simplifier, SMT/ATP bridge, or complete domain decision procedure |
+| Ecosystem | JS/Rust parity and concise implementation surface | No large library corpus comparable to AFP, mathlib, Rocq libraries, or Foundation |
+
+## Source Notes
+
+| System | Source notes |
+|--------|--------------|
+| RML | This repository's [README.md](../README.md) and [ARCHITECTURE.md](../ARCHITECTURE.md) describe the current syntax, evaluator, truth ranges, valence, operators, type features, examples, and tests. |
+| Twelf and LF | The Twelf LF page describes LF as a dependently typed lambda calculus for representing deductive systems and lists Twelf's LF checker, logic programming language, and metatheorem checker: <https://twelf.org/wiki/lf/>. The Twelf logic programming page describes `%solve`, `%query`, tabled queries, and dependently typed higher-order logic programming: <https://twelf.org/wiki/logic-programming/>. The Twelf guide lists reconstruction, modes, termination, coverage, totality, theorem prover, ML interface, server, and Emacs interface chapters: <https://www.cs.cmu.edu/~twelf/guide-1-4/twelf_toc.html>. |
+| HELF | Hackage describes HELF as a Haskell implementation of LF that parses and typechecks Twelf-style `.elf` files, implements a subset of Twelf, and omits type reconstruction/unification: <https://hackage.haskell.org/package/helf>. |
+| Isabelle | The Isabelle documentation index lists Isabelle2025-2 manuals for locales, classes, datatypes, functions, code generation, Nitpick, Sledgehammer, Eisbach, Isabelle/Isar, implementation, system, and jEdit: <https://isabelle.in.tum.de/documentation.html>. |
+| Coq/Rocq | The Rocq reference manual documents core language constructs, conversion, typing rules, inductive/coinductive types, modules, universes, proof mode, tactics, and extraction-related material: <https://docs.rocq-prover.org/master/refman/>. |
+| Lean | The Lean reference describes Lean as an interactive theorem prover based on dependent type theory with a minimal kernel, tactics, simplifier, macros, modules, and build tools: <https://lean-lang.org/doc/reference/latest/>. |
+| Foundation | The Foundation README describes a Lean 4 mathematical logic library covering propositional, first-order, modal, provability, interpretability, arithmetic, set theory, proof automation, and logic zoo material: <https://github.com/FormalizedFormalLogic/Foundation>. |
+| AFP | The Archive of Formal Proofs describes itself as proof libraries, examples, and larger scientific developments mechanically checked by Isabelle and organized like a scientific journal: <https://www.isa-afp.org/>. |
+| Abella | The Abella site describes an interactive theorem prover based on lambda-tree syntax and two-level logic for reasoning about specifications with binding: <https://abella-prover.org/index.html>. The reference guide documents induction, coinduction, search, apply, and other tactics: <https://abella-prover.org/reference-guide.html>. |
+| lambda Prolog | The Teyjus documentation describes lambda Prolog as a higher-order hereditary Harrop logic programming language with higher-order programming, polymorphic typing, scoping, modules, abstract data types, and lambda terms as data: <https://teyjus.cs.umn.edu/old/language/teyjus_1.html>. |
+| Pecan | The Pecan repository describes it as an automated theorem prover for Buchi automata, numeration systems, and automatic words, with batch and interactive modes: <https://github.com/ReedOei/Pecan>. The Pecan paper describes automated theorem proving for automatic sequences using Buchi automata: <https://arxiv.org/abs/2102.01727>. |

--- a/docs/FEATURE-COMPARISION.md
+++ b/docs/FEATURE-COMPARISION.md
@@ -1,0 +1,127 @@
+# Product Feature Comparison
+
+This document compares user-visible product, tooling, automation, and library
+features for Relative Meta-Logic (RML) and the systems named in
+[issue #22](https://github.com/link-foundation/relative-meta-logic/issues/22).
+Core logical concepts are compared separately in
+[CONCEPTS-COMPARISION.md](./CONCEPTS-COMPARISION.md).
+
+## Legend
+
+| Mark | Meaning |
+|------|---------|
+| Yes | First-class or central capability |
+| Part | Partial, prototype, limited, indirect, or available by encoding |
+| Host | Inherited from the host proof assistant rather than implemented by the project itself |
+| N/A | Not applicable to the system's role |
+| No | No evidence of support or outside the system's design goal |
+
+## Authoring and Checking Workflow
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Batch file checking | Yes: JS/Rust CLIs run `.lino` files | Yes | N/A | Yes: `helf file.elf` | Yes | Yes | Yes | Host | Yes: Isabelle sessions | Yes | Yes | Yes |
+| Interactive REPL/top-level | Part: CLI queries only | Yes | N/A | No | Yes | Yes | Yes | Host | N/A | Yes | Yes | Yes: interactive mode |
+| Query commands | Yes: `(? expr)` | Yes: `%query`, `%solve` | N/A | No | Yes | Yes | Yes | Host | Host | Yes: `search`, commands | Yes | Yes: theorem/prove commands |
+| Incremental proof state | No | Part | N/A | No | Yes | Yes | Yes | Host | Host | Yes | Logic-programming goal state | No |
+| Dedicated IDE/editor support | No | Emacs mode | N/A | No | Isabelle/jEdit and PIDE | CoqIDE, Proof General, VS Code ecosystem | VS Code/LSP ecosystem | Host | Host | Emacs/Proof General style support | Teyjus tooling | Vim syntax; online demo |
+| Language server protocol support | No | No | N/A | No | PIDE rather than plain LSP | Ecosystem support | Yes: Lean language server | Host | Host | No standard LSP | No standard LSP | No |
+| Structured diagnostics | Part: parser/evaluator errors | Part | N/A | No: package notes poor errors | Yes | Yes | Yes | Host | Host | Part | Part | Part |
+| Module/import system | Part: file-level examples | Yes | N/A | Part | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes |
+| Namespaces | No dedicated feature | Part | N/A | Part | Yes | Yes | Yes | Host | Host | Part | Part | Part |
+| Package/build ecosystem | Part: npm/cargo packages | Part | N/A | Cabal/Hackage | Isabelle sessions | Dune/opam/coq_makefile ecosystem | Lake | Lake | Isabelle releases/sessions | OPAM/source distribution | Teyjus/ELPI ecosystems | Python scripts/Docker |
+| Versioned package distribution | Yes: npm/cargo project layout | Releases/source | N/A | Hackage | Isabelle releases | OPAM/packages | Lake/GitHub | GitHub/Lake | AFP releases | OPAM/source | Source/packages vary | Source/Docker |
+| Documentation generation | Markdown docs | Part | N/A | Hackage README | Yes | Yes | Yes | Yes: generated docs/catalogue | Yes | Yes: `abella_doc` | Part | Manual/README |
+| Literate proof documents | No | Part | N/A | No | Yes | Yes, via ecosystem | Yes, via ecosystem | Host | Host | Part | No | No |
+| Online/browser use | No | No | N/A | No | Limited ecosystem demos | jsCoq exists | Web examples exist | Host | Website docs | No | No | Yes: online demo referenced |
+| Multi-implementation parity | Yes: JS and Rust | No | N/A | No: Haskell only | No | No | No | Host | Host | No | Multiple implementations exist | No |
+| Example command-line demos | Yes | Yes | N/A | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes |
+
+## Proof Engineering and Automation
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Tactic language | No | Part: theorem prover/proof search | N/A | No | Yes: Isar/Eisbach/tools | Yes | Yes | Host | Host | Yes | Logic programming search | No tactics; automated proving |
+| Simplifier | Part: evaluator and operators | Part | N/A | No | Yes | Yes | Yes | Host | Host | Part | Part | No |
+| Rewriting automation | Part | Part | N/A | No | Yes | Yes | Yes | Host | Host | Part | Part | No |
+| Built-in proof search | Part: query evaluation | Yes | N/A | No | Yes | Yes via tactics/plugins | Yes via tactics | Host | Host | Yes | Yes | Yes: automata decision procedure |
+| Search depth controls | No | Yes | N/A | No | Tool-dependent | Tactic-dependent | Tactic-dependent | Host | Host | Yes | Yes | Domain-dependent |
+| External ATP integration | No | No | N/A | No | Yes: Sledgehammer/ATPs/SMT | Plugins/tools | Ecosystem tools | Host | Host | No | No | No |
+| SMT integration | No | No | N/A | No | Yes | Plugins/tools | Ecosystem tools | Host | Host | No | No | No |
+| Model/counterexample finding | No | No | N/A | No | Yes: Nitpick/Quickcheck | Plugins/tools | Ecosystem/tools | Host | Host | No | No | Automata emptiness/domain feedback |
+| Totality automation | No | Yes | N/A | No | Yes for recursive definitions | Yes | Yes | Host | Host | Part | No | N/A |
+| Termination automation | No | Yes | N/A | No | Yes | Yes | Yes | Host | Host | Part | No | N/A |
+| Coverage/productivity checks | No | Yes | N/A | No | Yes for datatypes/functions | Yes | Yes | Host | Host | Part | No | N/A |
+| Program extraction | No | No | N/A | No | Yes: code generator | Yes: extraction | Yes: compiler/code generation | Host | Host | No | Logic programs execute | No general extraction |
+| Native executable programs | Yes: evaluator executes `.lino` queries | Logic programs | N/A | No | Generated code | Gallina extraction | Lean compiler | Host | Host | Specification logic execution | Yes | Yes |
+| Reflection/metaprogramming | Part: links can encode rules | Part | N/A | No | Isabelle/ML | Ltac/ML/plugins | Lean metaprogramming/macros | Host | Host | Part | Program-level | No |
+| Custom syntax/macros | Part: grammar-light links | Fixity/operators | N/A | Limited Twelf subset | Yes | Yes | Yes | Host | Host | Part | Yes | Yes: language syntax |
+| Proof repair/refactoring tools | No | No | N/A | No | Ecosystem/editor support | Ecosystem support | Ecosystem support | Host | Host | No | No | No |
+| Generated proof/checking artifacts | No | Yes | N/A | LF checking result | Yes | Yes | Yes | Host | Host | Yes | Part | Domain result |
+| Replayable derivation trace | No | Yes for LF/proof terms | N/A | Part | Yes | Yes | Yes | Host | Host | Yes | Part | Rerun script/procedure |
+
+## Library and Domain Coverage
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Stable large standard library | No | Examples/case studies | N/A | No | Yes | Yes | Yes plus mathlib | Yes: project library | Yes: archive | Examples | Examples | Domain libraries |
+| Mathematics library | No | No | N/A | No | Yes | Yes | Yes: mathlib | Part: mathematical logic | Yes | No | No | No |
+| Formalized logic library | Part: examples/case studies | Examples | N/A | Examples | Yes | Yes | Yes | Yes | Yes | Examples | Examples | Domain-specific formulas |
+| Programming language metatheory examples | Part | Yes | Encodable | Yes: examples | Yes | Yes | Yes | Part | Yes | Yes | Yes | No |
+| Lambda calculus examples | Yes: dependent type examples | Yes | Encodable | Yes | Yes | Yes | Yes | Host/libraries | Entries | Yes | Yes | No |
+| Modal logic corpus | Part: encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Provability/interpretability logic corpus | Part: encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Set theory corpus | Part: encodable | Encodable | Encodable | Encodable | Yes | Libraries | Libraries | Yes | Yes | Encodable | Encodable | No |
+| Arithmetic corpus | Part: evaluator arithmetic | Constraints/examples | Encodable | Encodable | Yes | Yes | Yes | Yes | Yes | Encodable | Encodable | Yes |
+| Probabilistic examples | Yes | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | No |
+| Fuzzy logic examples | Yes | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | No |
+| Graphical model examples | Yes: Bayesian/Markov examples | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | No |
+| Paradox/self-reference examples | Yes: liar paradox examples | No | No | No | Encodable with restrictions | Encodable with restrictions | Encodable with restrictions | Part | Part | Part | No | No |
+| Automatic sequences/numeration systems | No | No | No | No | Encodable with effort | Encodable with effort | Encodable with effort | No | Some entries possible | No | No | Yes |
+| Automata libraries | No | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | Yes |
+| Scientific archive model | Part: case studies | Wiki/case studies | Papers | No | Yes | Yes | Yes | Docs/catalogue | Yes: journal-like archive | Examples/publications | Examples/book | Paper/manual |
+
+## Distribution, Maintenance, and Integration
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Public source repository | Yes | Yes | N/A/theory | Yes | Yes | Yes | Yes | Yes | Yes/downloads | Yes | Yes | Yes |
+| Active language/runtime ecosystem | Node.js/Rust | Standard ML legacy | N/A | Haskell/Cabal | Isabelle/ML | OCaml/opam | Lean/Lake | Lean/Lake | Isabelle | OCaml/opam | Teyjus/OCaml ecosystem | Python/Docker |
+| CI-friendly batch mode | Yes | Yes | N/A | Yes | Yes | Yes | Yes | Host | Yes | Yes | Yes | Yes |
+| Docker support | No repository-level Docker | No | N/A | No | Ecosystem possible | Ecosystem possible | Ecosystem possible | No | No | No | No | Yes |
+| Package manager install | npm/cargo layout; package release dependent | Source/distribution | N/A | Hackage/Cabal | Isabelle distribution | OPAM/packages | Lake/elan | Lake/GitHub | AFP download/releases | OPAM | Depends on implementation | pip requirements/manual |
+| Generated API/reference docs | Part | Part | N/A | Hackage page | Yes | Yes | Yes | Yes | Yes | Part | Part | Manual |
+| Tutorials/walkthroughs | README/examples | Yes | Papers/docs | README/examples | Yes | Yes | Yes | Catalogue/docs | Entry docs | Yes | Manuals/examples | README/manual |
+| Backward compatibility story | Part | Historical Twelf docs | Theory | Hackage package | Release-managed | Release-managed | Release-managed | Host constraints | Isabelle release coupling | Versioned releases | Implementation-dependent | Source-level |
+| Human-readable examples | Yes: `.lino` examples | Yes | Papers | Yes | Yes | Yes | Yes | Host | Yes | Yes | Yes | Yes |
+| Machine-readable examples/tests | Yes | Yes | N/A | Yes | Yes | Yes | Yes | Host | Yes | Yes | Yes | Yes |
+| Cross-language implementation parity | Yes: JS/Rust implementations share behavior | No | N/A | No | No | No | No | Host | Host | No | Multiple implementations differ | No |
+
+## RML Product Roadmap Suggested by the Feature Matrix
+
+| Priority | Gap | Why it matters | Candidate next step |
+|----------|-----|----------------|---------------------|
+| 1 | Discoverable user docs | Users should see positioning without reading issue case studies | Keep these top-level concept/feature comparison docs linked from README |
+| 2 | Structured diagnostics | Failed queries and type checks need actionable explanations | Add opt-in trace output for parsing, assignment lookup, operator resolution, and type inference |
+| 3 | Proof artifacts | RML currently evaluates truth values but does not emit replayable derivations | Add a derivation trace format for equality, probability lookup, and operator application |
+| 4 | Module/import system | Larger examples need reusable files and namespaces | Add imports with cycle detection and explicit module names |
+| 5 | Inductive definitions | Mature proof assistants rely on constructors, eliminators, recursion, and induction principles | Prototype inductive families encoded as links with generated query rules |
+| 6 | Automation | Competitors provide tactics, simplifiers, ATP/SMT bridges, or domain procedures | Start with a small query/tactic language over existing evaluator operations |
+| 7 | Editor integration | Proof assistants win productivity through live feedback | Add JSON diagnostics first, then an LSP/VS Code extension |
+| 8 | Library ecosystem | Users need reusable logic fragments, not only demos | Split examples into reusable libraries for classical, fuzzy, probabilistic, type-theoretic, and graph-model reasoning |
+
+## Source Notes
+
+| System | Source notes |
+|--------|--------------|
+| RML | This repository's [README.md](../README.md), [ARCHITECTURE.md](../ARCHITECTURE.md), JavaScript examples, Rust examples, and test suites describe the current user-facing behavior. |
+| Twelf and LF | Twelf LF, logic programming, and guide pages document LF representation, type checking, `%solve`, `%query`, modes, termination, coverage, totality, theorem proving, server, and Emacs support: <https://twelf.org/wiki/lf/>, <https://twelf.org/wiki/logic-programming/>, <https://www.cs.cmu.edu/~twelf/guide-1-4/twelf_toc.html>. |
+| HELF | The Hackage package documents the `.elf` parser/typechecker, Twelf subset, Cabal installation, limitations, and examples: <https://hackage.haskell.org/package/helf>. |
+| Isabelle | The official documentation index lists manuals and tooling for Isabelle2025-2, including datatypes, functions, code generation, Nitpick, Sledgehammer, Eisbach, Isabelle/Isar, system, and jEdit: <https://isabelle.in.tum.de/documentation.html>. |
+| Coq/Rocq | The Rocq reference manual documents the core language, modules, universes, proof mode, tactics, inductives/coinductives, and related commands: <https://docs.rocq-prover.org/master/refman/>. |
+| Lean | The Lean reference documents dependent type theory, kernel checking, tactics, simplifier, macros, modules, source files, and build tools: <https://lean-lang.org/doc/reference/latest/>. |
+| Foundation | The Foundation README describes its Lean 4 mathematical logic library, generated catalogue/docs, logic zoo diagrams, and proof automation area: <https://github.com/FormalizedFormalLogic/Foundation>. |
+| AFP | The AFP home page describes proof libraries, examples, larger developments, Isabelle checking, journal-style organization, and releases: <https://www.isa-afp.org/>. |
+| Abella | The Abella site and reference guide document lambda-tree syntax, two-level logic, examples, OPAM/source installation, induction, coinduction, search, and tactics: <https://abella-prover.org/index.html>, <https://abella-prover.org/reference-guide.html>. |
+| lambda Prolog | The Teyjus documentation describes lambda Prolog's higher-order hereditary Harrop foundation, higher-order programming, polymorphic typing, scoping, modules, abstract data types, and lambda terms as data: <https://teyjus.cs.umn.edu/old/language/teyjus_1.html>. |
+| Pecan | The Pecan repository documents batch and interactive modes, Docker support, numeration systems, automatic words, Buchi automata, examples, and Vim syntax support: <https://github.com/ReedOei/Pecan>. The paper gives the automatic-sequence theorem-proving context: <https://arxiv.org/abs/2102.01727>. |

--- a/docs/case-studies/issue-22/README.md
+++ b/docs/case-studies/issue-22/README.md
@@ -6,6 +6,11 @@
 
 Relative Meta-Logic (RML) is currently strongest as a small, executable, probabilistic meta-logic over LiNo links. Its distinctive capabilities are configurable truth ranges, N-valued and continuous truth values, probabilistic and fuzzy operators, paradox-tolerant midpoint semantics, and a uniform link notation that can encode terms, propositions, probabilities, and a prototype dependent type layer.
 
+User-facing standalone comparison tables are available in:
+
+- [Core Concept Comparison](../../CONCEPTS-COMPARISION.md)
+- [Product Feature Comparison](../../FEATURE-COMPARISION.md)
+
 The compared systems cluster into five groups:
 
 1. **LF-family logical frameworks:** Edinburgh LF, Twelf, and HELF focus on representing deductive systems with dependent typed lambda terms. Twelf adds logic programming and metatheorem checking around totality, modes, worlds, termination, and coverage.

--- a/docs/case-studies/issue-22/README.md
+++ b/docs/case-studies/issue-22/README.md
@@ -1,0 +1,207 @@
+# Case Study: Competitor Concepts and Feature Comparison
+
+**Issue:** [#22 - Create a list of all core concepts and features that competitors support, with comparison tables by concepts and features separately](https://github.com/link-foundation/relative-meta-logic/issues/22)
+
+## Executive Summary
+
+Relative Meta-Logic (RML) is currently strongest as a small, executable, probabilistic meta-logic over LiNo links. Its distinctive capabilities are configurable truth ranges, N-valued and continuous truth values, probabilistic and fuzzy operators, paradox-tolerant midpoint semantics, and a uniform link notation that can encode terms, propositions, probabilities, and a prototype dependent type layer.
+
+The compared systems cluster into five groups:
+
+1. **LF-family logical frameworks:** Edinburgh LF, Twelf, and HELF focus on representing deductive systems with dependent typed lambda terms. Twelf adds logic programming and metatheorem checking around totality, modes, worlds, termination, and coverage.
+2. **Large proof assistants:** Isabelle, Coq/Rocq, and Lean provide mature kernels, libraries, automation, tactics, module systems, and proof engineering workflows.
+3. **Formalized logic libraries:** FormalizedFormalLogic/Foundation and Isabelle AFP are not independent provers; they are large proof developments built on Lean and Isabelle respectively.
+4. **Higher-order specification/proof systems:** Abella and lambda Prolog focus on lambda-tree syntax, higher-order abstract syntax, and relational specifications with binders.
+5. **Domain-specific automated provers:** Pecan is specialized for automatic sequences, numeration systems, and Buchi automata.
+
+The main competitive gap for RML is not expressiveness of its notation. It is the product layer around the notation: proof automation, robust type checking, inductive/coinductive definitions, tactics, libraries, editor integration, module/package systems, and large proof corpora.
+
+## Scope
+
+This document compares the systems explicitly named in issue #22:
+
+| System | Role in this comparison |
+|--------|-------------------------|
+| RML | This repository: probabilistic, many-valued, link-based meta-logic |
+| Twelf | LF implementation with logic programming and metatheorem checking |
+| Edinburgh LF | Core logical framework theory behind Twelf and HELF |
+| HELF | Haskell implementation of a Twelf/LF subset |
+| Isabelle | Generic interactive theorem prover, especially Isabelle/Pure and Isabelle/HOL |
+| Coq/Rocq | Interactive theorem prover based on the Calculus of Inductive Constructions |
+| Lean | Interactive theorem prover and programming language based on dependent type theory |
+| FormalizedFormalLogic/Foundation | Lean 4 library formalizing mathematical logic |
+| Isabelle AFP | Archive of formal proof developments checked by Isabelle |
+| Abella | Interactive theorem prover for lambda-tree syntax and two-level logic reasoning |
+| lambda Prolog | Higher-order logic programming language |
+| Pecan | Automated theorem prover based on Buchi automata |
+
+## Legend
+
+| Mark | Meaning |
+|------|---------|
+| Yes | First-class or central capability |
+| Part | Partial, prototype, limited, or indirect support |
+| Host | Inherited from the host proof assistant rather than provided by the project itself |
+| N/A | Not an independent prover or not applicable |
+| No | No evidence of support or outside the system's design goal |
+
+## Core Concept Comparison
+
+### Foundations and Representation
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| General meta-logic for object logics | Yes | Yes | Yes | Part | Yes | Part | Part | Yes | Host | Yes | Part | No |
+| Uniform representation of syntax and judgments | Yes: links | Yes: LF terms | Yes: LF terms | Yes: LF terms | Part: Pure/HOL terms | Yes: CIC terms | Yes: dependent terms | Host | Host | Yes: two-level terms | Yes: lambda terms | Part: formulas/automata |
+| Dependent types | Part | Yes | Yes | Yes | No: HOL is simply typed; Pure is higher-order meta-logic | Yes | Yes | Host | Host | No: simply typed core | No: simply typed | No |
+| Dependent products / Pi-types | Part | Yes | Yes | Yes | Part: meta-level universal quantification | Yes | Yes | Host | Host | No | No | No |
+| Lambda abstraction and application | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
+| Higher-order abstract syntax / lambda-tree syntax | Part | Yes | Yes | Yes | Part | Part | Part | Host | Host | Yes | Yes | No |
+| Judgments-as-types | Part | Yes | Yes | Yes | Part | Yes via Curry-Howard | Yes via propositions-as-types | Host | Host | Part | Part | No |
+| Propositions-as-types / proofs-as-terms | Part | Yes in LF style | Yes | Yes | Part: proof terms exist, HOL propositions are bool-like formulas | Yes | Yes | Host | Host | Part | Part | No |
+| Universe hierarchy | Part | No: LF has kinds/types, not Lean-style universes | No | No | No | Yes | Yes | Host | Host | No | No | No |
+| Self-reference / circularity tolerated | Yes | No | No | No | No | No | No | Host constraints | Host constraints | Part: coinductive reasoning | No | No |
+
+### Logic and Semantics
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Classical logic | Yes | Encodable | Encodable | Encodable | Yes | Yes | Yes | Yes | Yes | Encodable | Encodable | Part: decidable fragments |
+| Intuitionistic / constructive logic | Part | Yes: LF foundation | Yes | Yes | Encodable | Yes | Yes | Yes | Yes | Yes | Yes | No |
+| Higher-order logic | Part | Encodable | Encodable | Encodable | Yes | Encodable in CIC | Encodable in DTT | Host | Host | Part | Yes as programming logic fragment | No |
+| First-order logic | Part | Encodable | Encodable | Encodable | Yes | Encodable | Encodable | Yes | Yes | Encodable | Encodable | Part: arithmetic formulas |
+| Modal logic | Part: encodable as links | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Many-valued logic | Yes | No | No | No | Encodable | Encodable | Encodable | Part | Part | Encodable | Encodable | No |
+| Probabilistic truth values | Yes | No | No | No | Encodable | Encodable | Encodable | No | Part | Encodable | No | No |
+| Fuzzy operators | Yes | No | No | No | Encodable | Encodable | Encodable | No | Part | Encodable | No | No |
+| Paraconsistent / paradox-tolerant semantics | Yes | No | No | No | Encodable | Encodable with axioms/libraries | Encodable with axioms/libraries | Part: logic zoo focus | Part | Encodable | No | No |
+| Automata-theoretic decision procedures | No | No | No | No | External/tools possible | Tactics/libraries possible | Tactics/libraries possible | No | Part | No | No | Yes |
+
+### Metatheory and Proof Objects
+
+| Core concept | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|--------------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Machine-checked proof terms | Part | Yes | Theory only | Yes: LF type checking | Yes | Yes | Yes | Host | Host | Yes | Part: proof search terms | No: automata decision result |
+| Small trusted kernel | Part: small evaluator, prototype type layer | Yes: LF checker | Theory only | Yes: LF checker | Yes: LCF-style kernel | Yes | Yes | Host | Host | Yes | No: language implementation | Domain-specific checker |
+| Inductive definitions | Part | Encoded as LF families | Encodable | Encodable | Yes | Yes | Yes | Host | Host | Yes | Encodable | No |
+| Coinductive definitions | Part | Limited/encoded | No | No | Yes | Yes | Yes | Host | Host | Yes | Encodable | Automata over infinite words |
+| Termination / totality checking | No | Yes | No | No | Part: function package and tools | Yes | Yes | Host | Host | Part: stratification/productivity constraints | No | N/A |
+| Coverage checking | No | Yes | No | No | Part | Yes | Yes | Host | Host | Part | No | N/A |
+| Definitional equality / normalization | Part | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Yes: beta conversion for lambda terms | No |
+| Metatheorem checking about encoded systems | Part | Yes | Theory goal | No | Yes | Yes | Yes | Yes | Yes | Yes | Part | No |
+| Executable specifications | Yes | Yes | No | Part: typecheck only | Part | Yes: programs in Gallina | Yes: functional programs | Host | Host | Yes: specification logic | Yes | Yes: automated proving scripts |
+| Decidable complete domain fragment | No: general evaluator | No | No | No | Some procedures | Some tactics/procedures | Some tactics/procedures | Host | Host | No | No | Yes: Buchi/automatic structures |
+
+## Product Feature Comparison
+
+### Authoring and Checking Workflow
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Batch file checking | Yes | Yes | N/A | Yes | Yes | Yes | Yes | Host | Yes | Yes | Yes | Yes |
+| Interactive REPL / top-level | Part: CLI queries | Yes | N/A | No | Yes | Yes | Yes | Host | N/A | Yes | Yes | Yes |
+| IDE/editor support | No dedicated IDE | Emacs mode | N/A | No | Isabelle/jEdit and PIDE | CoqIDE, Proof General, VS Code ecosystem | VS Code/LSP ecosystem | Host | Host | Emacs/Proof General style support | Teyjus tooling | Vim syntax; online demo |
+| Module/import system | Part: file-level examples | Yes | N/A | Part | Yes | Yes | Yes | Host | Host | Yes | Yes | Yes |
+| Package/build ecosystem | Part: npm/cargo package | Part | N/A | Cabal/Hackage | Isabelle sessions | Dune/opam/coq_makefile ecosystem | Lake | Lake | Isabelle sessions/releases | Source distribution | Teyjus/ELPI ecosystems | Python scripts/Docker |
+| Documentation generation | Markdown docs | Part | N/A | Hackage README | Yes | Yes | Yes | Yes | Yes | Yes: abella_doc | Part | Manual/README |
+| Stable large standard library | No | Examples/case studies | N/A | No | Yes | Yes | Yes plus mathlib | Yes: library itself | Yes: archive | Examples | Examples | Domain libraries |
+
+### Proof Engineering
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Tactic language | No | Part: theorem prover/proof search | N/A | No | Yes | Yes | Yes | Host | Host | Yes | Logic programming search | No tactics; automated proving |
+| Simplifier / rewriting automation | Part: operators/evaluator | Part | N/A | No | Yes | Yes | Yes | Host | Host | Part | Part | No |
+| External ATP/SMT integration | No | No | N/A | No | Yes: Sledgehammer/SMT/ATPs | Plugins/tools | Ecosystem tools | Host | Host | No | No | No |
+| Built-in proof search | Part: query evaluation | Yes | N/A | No | Yes | Yes via tactics/plugins | Yes via tactics | Host | Host | Yes | Yes | Yes: decision procedure |
+| Counterexample/model finding | No | No | N/A | No | Yes: Nitpick/Quickcheck | Plugins/tools | Ecosystem/tools | Host | Host | No | No | Yes/No by automata emptiness |
+| Totality/termination automation | No | Yes | N/A | No | Yes for recursive definitions | Yes | Yes | Host | Host | Part | No | N/A |
+| Coverage/productivity checks | No | Yes | N/A | No | Yes for datatypes/functions | Yes | Yes | Host | Host | Part | No | N/A |
+| Program extraction / compilation | No | No | N/A | No | Yes: code generator | Yes: extraction | Yes: compiler/code gen | Host | Host | No | Logic programs execute | No general extraction |
+| Reflection/metaprogramming | Part: links can encode rules | Part | N/A | No | Isabelle/ML | Ltac/ML/plugins | Yes: Lean metaprogramming/macros | Host | Host | Part | Program-level | No |
+| Custom syntax/macros | Part: LiNo links are grammar-light | Fixity/operators | N/A | Limited Twelf subset | Yes | Yes | Yes | Host | Host | Part | Yes | Yes: language-specific syntax |
+
+### Domain and Library Coverage
+
+| Feature | RML | Twelf | Edinburgh LF | HELF | Isabelle | Coq/Rocq | Lean | Foundation | AFP | Abella | lambda Prolog | Pecan |
+|---------|-----|-------|--------------|------|----------|----------|------|------------|-----|--------|---------------|-------|
+| Programming language metatheory examples | Part | Yes | Encodable | Yes: examples | Yes | Yes | Yes | Part | Yes | Yes | Yes | No |
+| Mathematics library | No | No | N/A | No | Yes | Yes | Yes: mathlib | Yes: mathematical logic | Yes | No | No | No |
+| Formalized logic library | Part | Examples | N/A | Examples | Yes | Yes | Yes | Yes | Yes | Examples | Examples | Domain-specific formulas |
+| Modal/provability/interpretablity logic corpus | Part | Encodable | Encodable | Encodable | Encodable | Encodable | Encodable | Yes | Yes | Encodable | Encodable | No |
+| Probabilistic examples | Yes | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | No |
+| Graphical model examples | Yes | No | No | No | Libraries possible | Libraries possible | Libraries possible | No | Some entries possible | No | No | No |
+| Automatic sequences / numeration systems | No | No | No | No | Encodable with effort | Encodable with effort | Encodable with effort | No | Some entries possible | No | No | Yes |
+| Browser/online use | No | No | N/A | No | Limited ecosystem demos | jsCoq exists | Web-based examples exist | Host | Website archive | No | No | Yes: online demo referenced |
+| Multi-language implementation parity | Yes: JS and Rust | No | N/A | No: Haskell only | No | No | No | Host | Host | No | Multiple implementations exist | No |
+| Human-readable research archive model | Part: case studies | Wiki/case studies | Papers | No | Yes | Yes | Yes | Book/docs | Yes: journal-like archive | Examples/publications | Examples/book | Paper/manual |
+
+## Main RML Advantages
+
+1. **Probabilistic and many-valued semantics are native.** RML supports configurable truth ranges, valence, continuous fuzzy values, probabilistic aggregators, and truth constants directly in the evaluator.
+2. **Operators are redefinable at runtime.** The same file can switch between classical, fuzzy, probabilistic, Belnap-style, or custom semantics.
+3. **Links provide a low-friction representation substrate.** RML can encode terms, propositions, probabilities, type declarations, graph structures, and self-reference with one parenthesized notation.
+4. **Paradox tolerance is a deliberate semantic choice.** RML resolves several self-referential cases to the midpoint rather than rejecting them by stratification.
+5. **Implementation surface is small.** The JavaScript and Rust implementations are compact enough to audit and keep behaviorally aligned.
+
+## Main RML Gaps
+
+1. **Proof assistant maturity.** Isabelle, Coq/Rocq, and Lean provide kernels, tactics, libraries, modules, and IDE workflows that RML does not yet have.
+2. **LF-family metatheory support.** Twelf has mature support for modes, worlds, totality, termination, coverage, and logic programming around LF signatures.
+3. **Inductive and coinductive infrastructure.** RML can encode many patterns as links, but it lacks first-class inductive families, eliminators, recursors, and productivity checks.
+4. **Automation.** RML has query evaluation but no comparable Sledgehammer, simplifier, SMT bridge, tactic language, or domain decision procedure.
+5. **Library ecosystem.** RML has examples and case studies, while Lean/mathlib, Isabelle/AFP, Rocq libraries, and Foundation provide large reusable formal corpora.
+6. **Tooling.** RML lacks dedicated editor integration, language server support, structured diagnostics, proof state visualization, and generated reference docs.
+7. **Explicit proof artifacts.** RML evaluates expressions and stores probabilities, but it does not yet produce independently checkable proof terms for derivations.
+
+## Recommended Roadmap
+
+### Near Term
+
+1. **Make this comparison part of the docs index.** Link this case study from the root README or a docs index so users can find the positioning work.
+2. **State RML's niche explicitly.** Position RML as a probabilistic many-valued meta-logic and executable link notation, not yet as a replacement for mature proof assistants.
+3. **Add proof-state diagnostics before tactics.** Better explanations for failed type queries, missing assignments, and operator resolution would give immediate value.
+4. **Add an explicit proof object experiment.** A small derivation trace for equality, probability assignment lookup, and operator application would move RML toward auditable proofs.
+
+### Medium Term
+
+1. **Inductive definitions as links.** Add a minimal representation for constructors, eliminators, and recursion over link-defined datatypes.
+2. **Twelf-inspired totality checks.** Start with modes and termination for a small class of relation-like link families.
+3. **A small tactic/query language.** Provide named proof/search steps before attempting full automation.
+4. **A documentation generator for examples.** Convert `.lino` examples into rendered docs with inputs, outputs, and explanations.
+
+### Long Term
+
+1. **Proof-producing evaluator.** Make every query optionally return a derivation object that can be replayed by a smaller checker.
+2. **Library organization.** Establish reusable libraries for classical logic, fuzzy logic, probabilistic reasoning, type theory, and graph models.
+3. **Editor integration.** Provide an LSP or VS Code extension with parse errors, query outputs, and hover documentation.
+4. **Bridge to mature provers.** Export selected RML fragments to Lean, Isabelle, or Rocq for external certification when a classical proof is desired.
+
+## Source Notes
+
+Primary sources consulted:
+
+| System | Source notes |
+|--------|--------------|
+| RML | This repository's [README.md](../../../README.md) and [ARCHITECTURE.md](../../../ARCHITECTURE.md) describe the current syntax, evaluator, operators, type features, examples, and tests. |
+| Twelf and LF | The Twelf LF page describes LF as a dependently typed lambda calculus for representing deductive systems, and lists Twelf's LF checker, logic programming language, and metatheorem checker: <https://twelf.org/wiki/lf/>. The Twelf logic programming page describes dependently typed higher-order logic programming and `%solve`/`%query`: <https://twelf.org/wiki/logic-programming/>. The Twelf guide lists syntax, reconstruction, logic programming, modes, termination, coverage, totality, theorem prover, ML interface, server, and Emacs interface chapters: <https://www.cs.cmu.edu/~twelf/guide-1-4/twelf_toc.html>. |
+| Twelf totality | The Twelf totality tutorial describes `%mode`, `%worlds`, `%total`, and the checks for mode, worlds, termination, input coverage, and output coverage: <https://twelf.org/wiki/proving-metatheorems-proving-totality-assertions-about-the-natural-numbers/>. |
+| HELF | The Hackage package states that HELF is a Haskell implementation of LF, parses and typechecks Twelf-style `.elf` files, and only implements a subset of Twelf without type reconstruction or unification: <https://hackage.haskell.org/package/helf>. |
+| Isabelle | Official Isabelle documentation and generated docs cover Isabelle/Isar, locales, type classes, datatypes, Sledgehammer, code generation, and related manuals from the documentation index: <https://isabelle.in.tum.de/dist/library/Doc/>. |
+| Coq/Rocq | The Coq/Rocq reference manual describes Gallina, the Calculus of Inductive Constructions, Curry-Howard, tactics, interactive and compiled modes: <https://docs.rocq-prover.org/V8.11.1/refman/>. The current Rocq docs cover inductive/coinductive reasoning and extraction: <https://docs.rocq-prover.org/master/refman/proofs/writing-proofs/reasoning-inductives.html> and <https://docs.rocq-prover.org/master/refman/addendum/extraction.html>. |
+| Lean | The Lean language reference describes Lean as an interactive theorem prover based on dependent type theory with a minimal kernel, tactic language, functional programming, modules, type classes, macros, and build tools: <https://lean-lang.org/doc/reference/latest/>. The type system docs cover dependent terms, definitional equality, universes, and inductive types: <https://lean-lang.org/doc/reference/latest/The-Type-System/>. |
+| FormalizedFormalLogic/Foundation | The Foundation README describes a Lean 4 library for propositional, first-order, modal, provability, interpretability, arithmetic, set theory, proof automation, and logic zoo developments: <https://github.com/FormalizedFormalLogic/Foundation>. |
+| Isabelle AFP | The Archive of Formal Proofs describes itself as proof libraries, examples, and larger scientific developments mechanically checked by Isabelle and organized like a scientific journal: <https://www.isa-afp.org/>. |
+| Abella | The Abella site describes an interactive theorem prover based on lambda-tree syntax, two-level logic, hereditary Harrop specifications, and reasoning over specifications: <https://abella-prover.org/index.html>. The reference guide documents simply typed specification and reasoning logics: <https://abella-prover.org/reference-guide.html>. |
+| lambda Prolog | The Teyjus documentation describes lambda Prolog as a higher-order hereditary Harrop logic programming language with higher-order programming, polymorphic typing, scoping, modules, abstract data types, and lambda terms as data: <https://teyjus.cs.umn.edu/old/language/teyjus_1.html>. The lambda Prolog home page summarizes the same foundations and lambda-tree syntax focus: <https://www.lix.polytechnique.fr/Labo/Dale.Miller/lProlog/>. |
+| Pecan | The Pecan repository describes it as an automated theorem prover for Buchi automata with support for numeration systems and automatic words: <https://github.com/ReedOei/Pecan>. The Pecan paper describes the automated theorem prover for automatic sequences using Buchi automata: <https://arxiv.org/abs/2102.01727>. |
+
+## Acceptance Checklist
+
+| Requirement | Status |
+|-------------|--------|
+| Include all competitors named in issue #22 | Done |
+| Separate core concept comparison from feature comparison | Done |
+| Compare RML against each alternative | Done |
+| Capture RML advantages and gaps | Done |
+| Include source links for follow-up research | Done |


### PR DESCRIPTION
## Summary
- Adds `docs/CONCEPTS-COMPARISION.md` with detailed user-facing concept matrices comparing RML against Twelf, Edinburgh LF, HELF, Isabelle, Coq/Rocq, Lean, Foundation, AFP, Abella, lambda Prolog, and Pecan.
- Adds `docs/FEATURE-COMPARISION.md` with detailed product/workflow, proof-engineering, library, distribution, and roadmap tables for the same systems.
- Links the standalone comparison docs from the root `README.md` and the issue #22 case study so users can find them without reading case-study-only material.

Fixes #22

## Verification
- Markdown table-shape validator: 8 concept tables and 7 feature tables validated.
- `git diff --check`
- `cd js && npm ci && npm test` - 304 tests passed.
- `cd rust && cargo test` - 238 tests passed, doc-tests passed.
- GitHub Actions: no runs returned for this branch (`gh run list --repo link-foundation/relative-meta-logic --branch issue-22-7b369df07ffd --limit 5 --json databaseId,conclusion,createdAt,headSha,name,status,url` returned `[]`).
