### PR TITLE
[A1] Structured diagnostics with source spans

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T14:46:29.034Z for PR creation at branch issue-28-0975c695fe7a for issue https://github.com/link-foundation/relative-meta-logic/issues/28

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T14:46:29.034Z for PR creation at branch issue-28-0975c695fe7a for issue https://github.com/link-foundation/relative-meta-logic/issues/28

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -114,6 +114,32 @@ For consumers that start from a selected natural-language interpretation rather 
 
 The adapter currently supports explicit arithmetic equality and arithmetic value questions, plus direct LiNo/RML expressions. Real-world claims such as `moon orbits the Sun` remain non-computable until a caller provides selected entities, relations, evidence sources, and a formal shape.
 
+### Structured Diagnostics
+
+The `evaluate()` entry point in both implementations returns a structured
+result instead of throwing or panicking:
+
+| JavaScript | Rust |
+|------------|------|
+| `evaluate(code, options?)` → `{ results, diagnostics }` | `evaluate(text, file, options)` → `EvaluateResult { results, diagnostics }` |
+
+Each `Diagnostic` carries a stable error code (`E001`, `E002`, …), a
+human-readable message, and a 1-based source span (`{ file, line, col, length }`).
+Errors do not abort evaluation: independent forms continue to be processed
+after a failing one, so a single bad line does not silence valid queries
+elsewhere in the input.
+
+The Rust implementation bridges internal `panic!`s into diagnostics via
+`std::panic::catch_unwind`, with the default panic hook silenced for the
+duration of the call so stack traces never leak to stderr.
+
+The CLIs format diagnostics as `<file>:<line>:<col>: <CODE>: <message>`
+with the source line and a caret beneath the offending column, and exit
+non-zero whenever any diagnostic is emitted.
+
+See [docs/DIAGNOSTICS.md](./docs/DIAGNOSTICS.md) for the complete code
+table and instructions for adding new codes.
+
 ## Environment (`Env`)
 
 The environment holds all mutable state during evaluation:

--- a/README.md
+++ b/README.md
@@ -672,6 +672,15 @@ See language-specific documentation:
 - [JavaScript API](./js/README.md#api)
 - [Rust API](./rust/README.md#api)
 
+## Diagnostics
+
+Both implementations expose an `evaluate()` entry point that returns a list
+of results plus structured diagnostics — every parser, evaluator, and type
+checker error carries a stable code (`E001`, …), a message, and a 1-based
+source span. The CLIs print them as `file:line:col: Exxx: message` with a
+caret under the offending token. See [docs/DIAGNOSTICS.md](./docs/DIAGNOSTICS.md)
+for the full code list and usage examples.
+
 ## References
 
 - [Many-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic) — overview of logics with more than two truth values

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -1,0 +1,99 @@
+# Diagnostics
+
+RML reports every parser, evaluator, and type-checker error as a structured
+**Diagnostic** value rather than throwing or panicking. This makes failures
+easy to consume programmatically (an editor, a test runner, a tool that
+reports errors in a UI) and gives the CLI everything it needs to print a
+familiar `file:line:col` message with a caret under the offending token.
+
+The two reference implementations (`js/src/rml-links.mjs` and
+`rust/src/lib.rs`) share the same diagnostic shape, error-code table, and
+formatting rules so output stays consistent across runtimes.
+
+## Diagnostic shape
+
+```
+Diagnostic {
+  code:    "Exxx",            // see the table below
+  message: "human-readable summary",
+  span: {
+    file:   "kb.lino" | null, // input file, when known
+    line:   1,                // 1-based line of the offending form
+    col:    1,                // 1-based column
+    length: 1,                // length used to render carets ("^^^")
+  }
+}
+```
+
+### JavaScript
+
+```js
+import { evaluate, formatDiagnostic } from 'relative-meta-logic';
+
+const { results, diagnostics } = evaluate(source, { file: 'kb.lino' });
+
+for (const d of diagnostics) {
+  console.error(formatDiagnostic(d, source));
+}
+```
+
+`evaluate(code, options?)` never throws. Successful queries appear in
+`results`; everything else is a `Diagnostic` in `diagnostics`.
+
+### Rust
+
+```rust
+use rml::{evaluate, format_diagnostic};
+
+let evaluation = evaluate(&source, Some("kb.lino"), None);
+for diag in &evaluation.diagnostics {
+    eprintln!("{}", format_diagnostic(diag, Some(&source)));
+}
+```
+
+`evaluate` returns an `EvaluateResult { results, diagnostics }`. Internal
+panics raised by the evaluator are caught and converted into diagnostics —
+the panic hook is silenced for the duration of the call so a stack trace
+never leaks to stderr.
+
+## CLI output
+
+Both CLIs (`node js/src/rml-links.mjs <file>` and `rml <file>`) print
+diagnostics in this format:
+
+```
+kb.lino:3:1: E001: Unknown op: foo
+(=: foo bar)
+^
+```
+
+The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
+
+## Error codes
+
+| Code | When it fires |
+|------|----------------------------------------------------------------|
+| `E000` | Generic / unclassified error fallback. |
+| `E001` | Reference to an undefined operator (`Unknown op: <name>`). Triggered, for example, by composing one operator from an unknown one: `(=: foo bar)`. |
+| `E002` | Token-level parse error inside a single link (missing `)`, extra tokens, etc.). |
+| `E003` | An operator definition has the right head but the wrong shape, e.g. `(=: a b c)` — the operator is real but the body is unsupported. |
+| `E004` | Unknown aggregator selector, e.g. `(and: bogus_agg)`. Valid selectors are `avg`, `min`, `max`, `product`/`prod`, `probabilistic_sum`/`ps`. |
+| `E005` | Empty meta-expression passed to a formalization helper. |
+| `E006` | LiNo top-level parse failure, e.g. unclosed paren in the whole file. |
+
+Codes are stable identifiers — they do not change between releases unless we
+explicitly note a breaking change in the changelog. The accompanying
+`message` field is free-form and may be improved at any time.
+
+## Adding a new code
+
+1. Add a new row to the table above with a brief trigger description.
+2. In both implementations, throw/panic with the new code so the existing
+   diagnostic dispatch picks it up:
+   - JavaScript: `throw new RmlError('Eyyy', 'message');`
+   - Rust: `panic!("recognisable prefix: …")` and extend
+     `decode_panic_payload` in `rust/src/lib.rs` to map the prefix to
+     `Eyyy`.
+3. Add a test in `js/tests/diagnostics.test.mjs` and a mirrored test in
+   `rust/tests/diagnostics_tests.rs` so drift between the two
+   implementations fails CI.

--- a/js/README.md
+++ b/js/README.md
@@ -55,6 +55,10 @@ npm run demo
 ```javascript
 import {
   run,
+  evaluate,
+  formatDiagnostic,
+  Diagnostic,
+  RmlError,
   parseLino,
   tokenizeOne,
   parseOne,
@@ -76,6 +80,13 @@ const results = run(linoText);
 
 // Run with custom range and valence
 const results2 = run(linoText, { lo: -1, hi: 1, valence: 3 });
+
+// Structured evaluation: never throws, returns diagnostics for every error.
+// See ../docs/DIAGNOSTICS.md for the error-code table.
+const { results: out, diagnostics } = evaluate(linoText, { file: 'kb.lino' });
+for (const d of diagnostics) {
+  console.error(formatDiagnostic(d, linoText));
+}
 
 // Parse and evaluate individual expressions
 const env = new Env({ lo: 0, hi: 1, valence: 3 });

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -14,6 +14,49 @@
 import fs from 'node:fs';
 import { Parser } from 'links-notation';
 
+// ---------- Structured Diagnostics ----------
+// Every parser/evaluator error is reported as a `Diagnostic` with an error
+// code, human-readable message, and source span (file/line/col, 1-based).
+// See `docs/DIAGNOSTICS.md` for the full code list.
+class Diagnostic {
+  constructor({ code, message, span }) {
+    this.code = code;
+    this.message = message;
+    this.span = span || { file: null, line: 1, col: 1, length: 0 };
+  }
+}
+
+// Internal error class used to carry a code + span across throw sites so the
+// outer `evaluate()` boundary can convert them into Diagnostics.
+class RmlError extends Error {
+  constructor(code, message, span) {
+    super(message);
+    this.name = 'RmlError';
+    this.code = code;
+    this.span = span || null;
+  }
+}
+
+// Format a diagnostic for human-readable CLI output:
+//   <file>:<line>:<col>: <CODE>: <message>
+//       <source line>
+//       ^
+function formatDiagnostic(diag, sourceText) {
+  const span = diag.span || { file: null, line: 1, col: 1, length: 0 };
+  const file = span.file || '<input>';
+  const lines = [`${file}:${span.line}:${span.col}: ${diag.code}: ${diag.message}`];
+  if (typeof sourceText === 'string') {
+    const srcLines = sourceText.split('\n');
+    const lineText = srcLines[span.line - 1];
+    if (lineText !== undefined) {
+      lines.push(lineText);
+      const caretCount = Math.max(1, span.length || 1);
+      lines.push(' '.repeat(Math.max(0, span.col - 1)) + '^'.repeat(caretCount));
+    }
+  }
+  return lines.join('\n');
+}
+
 // ---------- helpers: canonical keys & tokenization of a single link string ----------
 function tokenizeOne(s) {
   // s is a single-link string like "( (a = a) has probability 1 )"
@@ -51,19 +94,19 @@ function tokenizeOne(s) {
 function parseOne(tokens) {
   let i = 0;
   function read() {
-    if (tokens[i] !== '(') throw new Error('expected "("');
+    if (tokens[i] !== '(') throw new RmlError('E002', 'expected "("');
     i++;
     const arr = [];
     while (i < tokens.length && tokens[i] !== ')') {
       if (tokens[i] === '(') arr.push(read());
       else { arr.push(tokens[i]); i++; }
     }
-    if (tokens[i] !== ')') throw new Error('expected ")"');
+    if (tokens[i] !== ')') throw new RmlError('E002', 'expected ")"');
     i++;
     return arr;
   }
   const ast = read();
-  if (i !== tokens.length) throw new Error('extra tokens after link');
+  if (i !== tokens.length) throw new RmlError('E002', 'extra tokens after link');
   return ast;
 }
 const isNum = s => /^-?(\d+(\.\d+)?|\.\d+)$/.test(s);
@@ -198,7 +241,7 @@ class Env {
   }
 
   getOp(name){
-    if (!this.ops.has(name)) throw new Error(`Unknown op: ${name}`);
+    if (!this.ops.has(name)) throw new RmlError('E001', `Unknown op: ${name}`);
     return this.ops.get(name);
   }
   defineOp(name, fn){ this.ops.set(name, fn); }
@@ -665,12 +708,12 @@ function defineForm(head, rhs, env){
         sel==='max' ? xs=>xs.length? Math.max(...xs) : lo :
         sel==='product' || sel==='prod' ? xs=>xs.reduce((a,b)=>a*b,1) :
         sel==='probabilistic_sum' || sel==='ps' ? xs=> 1 - xs.reduce((a,b)=>a*(1-b),1) : null;
-      if (!agg) throw new Error(`Unknown aggregator "${sel}"`);
+      if (!agg) throw new RmlError('E004', `Unknown aggregator "${sel}"`);
       env.defineOp(head, (...xs)=> xs.length? agg(xs) : lo);
       return 1;
     }
 
-    throw new Error(`Unsupported operator definition for "${head}"`);
+    throw new RmlError('E003', `Unsupported operator definition for "${head}"`);
   }
 
   // Lambda definition: (name: lambda (A x) body)
@@ -729,6 +772,103 @@ function parseLinoForms(text) {
     });
 }
 
+// Compute (line, col) source positions for every top-level link in `text`.
+// A "top-level link" is a parenthesized form that is not nested inside another;
+// position is reported as 1-based line and column of its opening `(`.
+// Lines starting with `#` are treated as full-line comments and ignored, just
+// like `stripLinoComments` does.
+function computeFormSpans(text, file) {
+  const spans = [];
+  const lines = text.split('\n');
+  // Track parenthesis depth across the whole text (top-level links never nest).
+  let depth = 0;
+  let lineNum = 1;
+  let colNum = 1;
+  let pendingStart = null; // {line, col, offset} for the next top-level link
+  let inLineComment = false;
+  for (let off = 0; off < text.length; off++) {
+    const ch = text[off];
+    if (ch === '\n') {
+      inLineComment = false;
+      lineNum++;
+      colNum = 1;
+      continue;
+    }
+    if (inLineComment) { colNum++; continue; }
+    // Detect a full-line comment (line begins with optional whitespace + #).
+    if (ch === '#' && depth === 0) {
+      // Check if the line so far contains only whitespace.
+      const lineSoFar = lines[lineNum - 1].slice(0, colNum - 1);
+      if (/^[ \t]*$/.test(lineSoFar)) {
+        inLineComment = true;
+        colNum++;
+        continue;
+      }
+    }
+    if (ch === '(') {
+      if (depth === 0) {
+        pendingStart = { line: lineNum, col: colNum };
+      }
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+      if (depth === 0 && pendingStart) {
+        spans.push({ file: file || null, line: pendingStart.line, col: pendingStart.col, length: 1 });
+        pendingStart = null;
+      }
+    }
+    colNum++;
+  }
+  return spans;
+}
+
+// New structured evaluator: returns { results, diagnostics }. Existing
+// callers can keep using `run`, which now delegates to this and surfaces only
+// the result list (preserving its previous signature for tests/CLI consumers).
+function evaluate(code, options) {
+  const opts = options || {};
+  const file = opts.file || null;
+  const sourceText = String(code);
+  const env = new Env(opts.env || opts);
+  const results = [];
+  const diagnostics = [];
+
+  // Pre-compute spans for each top-level form so error reporting can attach
+  // a real source location even when the parser/evaluator throw deep inside.
+  const formSpans = computeFormSpans(sourceText, file);
+
+  let forms;
+  try {
+    forms = parseLinoForms(sourceText);
+  } catch (err) {
+    const diag = err && err.code
+      ? new Diagnostic({ code: err.code, message: err.message, span: { file, line: 1, col: 1, length: 0 } })
+      : new Diagnostic({ code: 'E006', message: `LiNo parse failure: ${err && err.message ? err.message : String(err)}`, span: { file, line: 1, col: 1, length: 0 } });
+    diagnostics.push(diag);
+    return { results, diagnostics };
+  }
+
+  for (let idx = 0; idx < forms.length; idx++) {
+    let form = forms[idx];
+    while (Array.isArray(form) && form.length === 1 && Array.isArray(form[0])) {
+      form = form[0];
+    }
+    const span = formSpans[idx] || { file, line: 1, col: 1, length: 0 };
+    try {
+      const res = evalNode(form, env);
+      if (res && res.query) {
+        results.push(res.value);
+      }
+    } catch (err) {
+      const diagSpan = (err && err.span) || span;
+      const code = (err && err.code) || 'E000';
+      const message = err && err.message ? err.message : String(err);
+      diagnostics.push(new Diagnostic({ code, message, span: diagSpan }));
+    }
+  }
+  return { results, diagnostics };
+}
+
 // ---------- Meta-expression adapter ----------
 function normalizeInterpretation(interpretation) {
   if (!interpretation) return {};
@@ -761,7 +901,7 @@ function splitTopLevelEquals(expression) {
 
 function parseExpressionShape(expression, options = {}) {
   const trimmed = String(expression || '').trim();
-  if (!trimmed) throw new Error('empty expression');
+  if (!trimmed) throw new RmlError('E005', 'empty expression');
   const source = trimmed.startsWith('(') && trimmed.endsWith(')') ? trimmed : `(${trimmed})`;
   let ast = parseOne(tokenizeOne(source));
   while (
@@ -933,18 +1073,27 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     process.exit(1);
   }
   const text = fs.readFileSync(file, 'utf8');
-  const outs = run(text);
-  for (const v of outs) {
+  const { results, diagnostics } = evaluate(text, { file });
+  for (const v of results) {
     if (typeof v === 'string') {
       console.log(v);
     } else {
       console.log(String(+v.toFixed(6)).replace(/\.0+$/,''));
     }
   }
+  for (const diag of diagnostics) {
+    console.error(formatDiagnostic(diag, text));
+  }
+  if (diagnostics.length > 0) process.exit(1);
 }
 
 export {
   run,
+  evaluate,
+  Diagnostic,
+  RmlError,
+  formatDiagnostic,
+  computeFormSpans,
   parseLino,
   tokenizeOne,
   parseOne,

--- a/js/tests/diagnostics.test.mjs
+++ b/js/tests/diagnostics.test.mjs
@@ -1,0 +1,137 @@
+// Tests for structured diagnostics (issue #28).
+// Covers the evaluate() API, error codes, source spans, and CLI-style
+// formatting. The Rust suite mirrors these cases in
+// rust/tests/diagnostics_tests.rs to keep the two implementations in lock-step.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  evaluate,
+  formatDiagnostic,
+  Diagnostic,
+  RmlError,
+  computeFormSpans,
+} from '../src/rml-links.mjs';
+
+describe('evaluate() returns a structured result', () => {
+  it('produces results and an empty diagnostics array on a clean input', () => {
+    const out = evaluate('(valence: 2)\n(p has probability 1)\n(? p)');
+    assert.ok(Array.isArray(out.results));
+    assert.ok(Array.isArray(out.diagnostics));
+    assert.strictEqual(out.diagnostics.length, 0);
+    assert.strictEqual(out.results.length, 1);
+    assert.strictEqual(out.results[0], 1);
+  });
+
+  it('does not throw on bad input — returns a Diagnostic instead', () => {
+    let threw = false;
+    let out;
+    try {
+      out = evaluate('(=: missing_op identity)');
+    } catch (_) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'evaluate() must not throw');
+    assert.ok(out.diagnostics.length >= 1);
+  });
+});
+
+describe('Diagnostic shape and error codes', () => {
+  it('E001 — unknown op surfaces with file/line/col span', () => {
+    const out = evaluate('(=: missing_op identity)', { file: 'inline.lino' });
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.ok(d instanceof Diagnostic);
+    assert.strictEqual(d.code, 'E001');
+    assert.match(d.message, /Unknown op/);
+    assert.strictEqual(d.span.file, 'inline.lino');
+    assert.strictEqual(d.span.line, 1);
+    assert.strictEqual(d.span.col, 1);
+  });
+
+  it('E006 — LiNo parse error is reported as a diagnostic, not thrown', () => {
+    const out = evaluate('(=: foo bar', { file: 'inline.lino' });
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E006');
+    assert.strictEqual(d.span.file, 'inline.lino');
+    assert.strictEqual(d.span.line, 1);
+  });
+
+  it('E004 — unknown aggregator surfaces', () => {
+    const out = evaluate('(and: bogus_agg)', { file: 'agg.lino' });
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E004');
+    assert.match(d.message, /aggregator/i);
+    assert.strictEqual(d.span.line, 1);
+  });
+
+  it('E001 — span tracks line for forms that follow blank lines', () => {
+    const src = '(valence: 2)\n\n(=: missing identity)';
+    const out = evaluate(src, { file: 'multi.lino' });
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E001');
+    assert.strictEqual(out.diagnostics[0].span.line, 3);
+    assert.strictEqual(out.diagnostics[0].span.col, 1);
+  });
+
+  it('keeps good results even when a later form errors', () => {
+    const src = '(valence: 2)\n(p has probability 1)\n(? p)\n(=: missing identity)';
+    const out = evaluate(src, { file: 'mix.lino' });
+    assert.strictEqual(out.results.length, 1);
+    assert.strictEqual(out.results[0], 1);
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E001');
+    assert.strictEqual(out.diagnostics[0].span.line, 4);
+  });
+});
+
+describe('formatDiagnostic()', () => {
+  it('prints "<file>:<line>:<col>: <CODE>: <message>" plus a caret line', () => {
+    const src = '(=: missing_op identity)';
+    const out = evaluate(src, { file: 'demo.lino' });
+    const text = formatDiagnostic(out.diagnostics[0], src);
+    const lines = text.split('\n');
+    assert.match(lines[0], /^demo\.lino:1:1: E001: Unknown op/);
+    assert.strictEqual(lines[1], '(=: missing_op identity)');
+    assert.strictEqual(lines[2], '^');
+  });
+
+  it('points the caret at the second form on a later line', () => {
+    const src = '(valence: 2)\n(=: missing_op identity)';
+    const out = evaluate(src, { file: 'caret.lino' });
+    assert.strictEqual(out.diagnostics.length, 1);
+    const text = formatDiagnostic(out.diagnostics[0], src);
+    const lines = text.split('\n');
+    assert.match(lines[0], /^caret\.lino:2:1:/);
+    assert.strictEqual(lines[1], '(=: missing_op identity)');
+    assert.strictEqual(lines[2], '^');
+  });
+});
+
+describe('RmlError', () => {
+  it('carries code and span attributes', () => {
+    const err = new RmlError('E001', 'Unknown op: foo', { line: 1, col: 1 });
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.code, 'E001');
+    assert.deepStrictEqual(err.span, { line: 1, col: 1 });
+  });
+});
+
+describe('computeFormSpans()', () => {
+  it('returns one span per top-level form with 1-based line/col', () => {
+    const text = '(a)\n  (b)\n\n(c)';
+    const spans = computeFormSpans(text, 'spans.lino');
+    assert.strictEqual(spans.length, 3);
+    assert.deepStrictEqual(
+      spans.map((s) => [s.line, s.col]),
+      [
+        [1, 1],
+        [2, 3],
+        [4, 1],
+      ],
+    );
+    for (const s of spans) assert.strictEqual(s.file, 'spans.lino');
+  });
+});

--- a/rust/README.md
+++ b/rust/README.md
@@ -54,7 +54,8 @@ Or after building:
 
 ```rust
 use rml::{
-    run, tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round,
+    run, evaluate, format_diagnostic, Diagnostic, EvaluateResult, RunResult, Span,
+    tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round,
     formalize_selected_interpretation, evaluate_formalization,
     FormalizationRequest, Interpretation,
 };
@@ -64,6 +65,13 @@ let results = run(lino_text, None);
 
 // Run with custom range and valence
 let results2 = run(lino_text, Some(EnvOptions { lo: -1.0, hi: 1.0, valence: 3 }));
+
+// Structured evaluation: never panics, returns diagnostics for every error.
+// See ../docs/DIAGNOSTICS.md for the error-code table.
+let evaluation = evaluate(lino_text, Some("kb.lino"), None);
+for diag in &evaluation.diagnostics {
+    eprintln!("{}", format_diagnostic(diag, Some(lino_text)));
+}
 
 // Parse and evaluate individual expressions
 let mut env = Env::new(Some(EnvOptions { lo: 0.0, hi: 1.0, valence: 3 }));

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,6 +12,145 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+// ========== Structured Diagnostics ==========
+// Every parser/evaluator error is reported as a `Diagnostic` with an error
+// code, human-readable message, and source span (file/line/col, 1-based).
+// See `docs/DIAGNOSTICS.md` for the full code list.
+
+/// A source span: 1-based `line`/`col`, optional file path, and a `length`
+/// of the offending region (used to render carets in the CLI).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Span {
+    pub file: Option<String>,
+    pub line: usize,
+    pub col: usize,
+    pub length: usize,
+}
+
+impl Span {
+    pub fn new(file: Option<String>, line: usize, col: usize, length: usize) -> Self {
+        Self {
+            file,
+            line,
+            col,
+            length,
+        }
+    }
+
+    pub fn unknown() -> Self {
+        Self {
+            file: None,
+            line: 1,
+            col: 1,
+            length: 0,
+        }
+    }
+}
+
+/// A single diagnostic emitted by parser, evaluator, or type checker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Diagnostic {
+    pub code: String,
+    pub message: String,
+    pub span: Span,
+}
+
+impl Diagnostic {
+    pub fn new(code: &str, message: impl Into<String>, span: Span) -> Self {
+        Self {
+            code: code.to_string(),
+            message: message.into(),
+            span,
+        }
+    }
+}
+
+/// Result of `evaluate(src)`: a list of query results (numeric or type) plus
+/// any diagnostics emitted while parsing/evaluating.
+#[derive(Debug, Clone, Default)]
+pub struct EvaluateResult {
+    pub results: Vec<RunResult>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Format a diagnostic for human-readable CLI output:
+///     `<file>:<line>:<col>: <CODE>: <message>`
+///         `<source line>`
+///         `^`
+pub fn format_diagnostic(diag: &Diagnostic, source: Option<&str>) -> String {
+    let file = diag.span.file.as_deref().unwrap_or("<input>");
+    let mut out = format!(
+        "{}:{}:{}: {}: {}",
+        file, diag.span.line, diag.span.col, diag.code, diag.message
+    );
+    if let Some(src) = source {
+        let lines: Vec<&str> = src.split('\n').collect();
+        if diag.span.line >= 1 && diag.span.line <= lines.len() {
+            let line_text = lines[diag.span.line - 1];
+            out.push('\n');
+            out.push_str(line_text);
+            out.push('\n');
+            let pad = diag.span.col.saturating_sub(1);
+            let caret_count = diag.span.length.max(1);
+            out.push_str(&" ".repeat(pad));
+            out.push_str(&"^".repeat(caret_count));
+        }
+    }
+    out
+}
+
+/// Compute (line, col) source positions for every top-level link in `text`.
+/// Mirrors `compute_form_spans` in the JavaScript implementation.
+pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let mut depth: i32 = 0;
+    let mut line: usize = 1;
+    let mut col: usize = 1;
+    let mut pending_start: Option<(usize, usize)> = None;
+    let mut in_line_comment = false;
+    let mut line_start_idx: usize = 0;
+    let bytes = text.as_bytes();
+    for (off, &b) in bytes.iter().enumerate() {
+        let ch = b as char;
+        if ch == '\n' {
+            in_line_comment = false;
+            line += 1;
+            col = 1;
+            line_start_idx = off + 1;
+            continue;
+        }
+        if in_line_comment {
+            col += 1;
+            continue;
+        }
+        if ch == '#' && depth == 0 {
+            // Determine if the line so far contains only whitespace.
+            let line_so_far = &text[line_start_idx..off];
+            if line_so_far.chars().all(|c| c == ' ' || c == '\t') {
+                in_line_comment = true;
+                col += 1;
+                continue;
+            }
+        }
+        if ch == '(' {
+            if depth == 0 {
+                pending_start = Some((line, col));
+            }
+            depth += 1;
+        } else if ch == ')' {
+            depth -= 1;
+            if depth == 0 {
+                if let Some((sl, sc)) = pending_start.take() {
+                    spans.push(Span::new(file.map(|s| s.to_string()), sl, sc, 1));
+                }
+            }
+        }
+        col += 1;
+    }
+    spans
+}
 
 // ========== LiNo Parser ==========
 // Uses the official links-notation crate for parsing LiNo text.
@@ -1288,6 +1427,13 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
                     );
                     return EvalResult::Value(1.0);
                 }
+                // Mirror JS behavior: surface a diagnostic for the missing op.
+                if !env.ops.contains_key(outer.as_str()) {
+                    panic!("Unknown op: {}", outer);
+                }
+                if !env.ops.contains_key(inner.as_str()) {
+                    panic!("Unknown op: {}", inner);
+                }
             }
         }
 
@@ -1727,6 +1873,106 @@ pub fn evaluate_formalization(formalization: &Formalization) -> FormalizationEva
 pub enum RunResult {
     Num(f64),
     Type(String),
+}
+
+/// Evaluate a complete LiNo knowledge base and return both results and any
+/// diagnostics emitted by the parser, evaluator, or type checker.
+///
+/// Each diagnostic carries a code (`E001`, `E002`, ...), a message, and a
+/// source span (1-based line/col).  See `docs/DIAGNOSTICS.md` for the
+/// full code list.  Errors do not abort evaluation: independent forms
+/// continue to be processed after a failing one.
+pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> EvaluateResult {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let spans = compute_form_spans(text, file);
+
+    let links = parse_lino(text);
+    let forms: Vec<Node> = links
+        .iter()
+        .filter(|link_str| {
+            let s = link_str.trim();
+            !(s.starts_with("(#") && s.chars().nth(2).map_or(false, |c| c.is_whitespace()))
+        })
+        .filter_map(|link_str| {
+            let toks = tokenize_one(link_str);
+            match parse_one(&toks) {
+                Ok(node) => Some(node),
+                Err(msg) => {
+                    diagnostics.push(Diagnostic::new(
+                        "E002",
+                        msg,
+                        Span::new(file.map(|s| s.to_string()), 1, 1, 0),
+                    ));
+                    None
+                }
+            }
+        })
+        .collect();
+
+    let mut env = Env::new(options);
+    let mut results: Vec<RunResult> = Vec::new();
+
+    // Silence the default panic hook while we deliberately catch evaluator
+    // panics — otherwise they'd leak to stderr alongside the diagnostics.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+
+    for (idx, form) in forms.into_iter().enumerate() {
+        let mut form = form;
+        loop {
+            match form {
+                Node::List(ref children) if children.len() == 1 => {
+                    if let Node::List(_) = &children[0] {
+                        form = children[0].clone();
+                    } else {
+                        break;
+                    }
+                }
+                _ => break,
+            }
+        }
+        let span = spans
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| Span::new(file.map(|s| s.to_string()), 1, 1, 0));
+        let result = catch_unwind(AssertUnwindSafe(|| eval_node(&form, &mut env)));
+        match result {
+            Ok(EvalResult::Query(v)) => results.push(RunResult::Num(v)),
+            Ok(EvalResult::TypeQuery(s)) => results.push(RunResult::Type(s)),
+            Ok(_) => {}
+            Err(payload) => {
+                let (code, message) = decode_panic_payload(&payload);
+                diagnostics.push(Diagnostic::new(&code, message, span));
+            }
+        }
+    }
+
+    std::panic::set_hook(prev_hook);
+
+    EvaluateResult {
+        results,
+        diagnostics,
+    }
+}
+
+/// Map a panic payload to a diagnostic `(code, message)` pair.  Known panic
+/// messages emitted by the evaluator are mapped to the canonical `E001`/etc.
+/// codes; anything else falls back to `E000`.
+fn decode_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> (String, String) {
+    let raw_msg: String = if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "evaluation panicked".to_string()
+    };
+    if raw_msg.starts_with("Unknown op:") {
+        ("E001".to_string(), raw_msg)
+    } else if raw_msg.starts_with("Unknown aggregator") {
+        ("E004".to_string(), raw_msg)
+    } else {
+        ("E000".to_string(), raw_msg)
+    }
 }
 
 /// Run a complete LiNo knowledge base and return query results (including type queries).

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,21 +1,25 @@
 // RML CLI — run a LiNo knowledge base and print query results
-use rml::{run_typed, RunResult};
+use rml::{evaluate, format_diagnostic, RunResult};
 use std::env;
 use std::fs;
+use std::process::ExitCode;
 
-fn main() {
+fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: rml <kb.lino>");
-        std::process::exit(1);
+        return ExitCode::from(1);
     }
     let file = &args[1];
-    let text = fs::read_to_string(file).unwrap_or_else(|e| {
-        eprintln!("Error reading {}: {}", file, e);
-        std::process::exit(1);
-    });
-    let outs = run_typed(&text, None);
-    for v in outs {
+    let text = match fs::read_to_string(file) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error reading {}: {}", file, e);
+            return ExitCode::from(1);
+        }
+    };
+    let evaluation = evaluate(&text, Some(file), None);
+    for v in evaluation.results {
         match v {
             RunResult::Num(n) => {
                 let formatted = format!("{:.6}", n);
@@ -24,5 +28,14 @@ fn main() {
             }
             RunResult::Type(s) => println!("{}", s),
         }
+    }
+    let has_diagnostics = !evaluation.diagnostics.is_empty();
+    for diag in &evaluation.diagnostics {
+        eprintln!("{}", format_diagnostic(diag, Some(&text)));
+    }
+    if has_diagnostics {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
     }
 }

--- a/rust/tests/diagnostics_tests.rs
+++ b/rust/tests/diagnostics_tests.rs
@@ -1,0 +1,127 @@
+// Tests for structured diagnostics (issue #28).
+// Mirrors js/tests/diagnostics.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{
+    compute_form_spans, evaluate, format_diagnostic, Diagnostic, RunResult, Span,
+};
+
+#[test]
+fn evaluate_clean_input_returns_results_and_no_diagnostics() {
+    let out = evaluate("(valence: 2)\n(p has probability 1)\n(? p)", None, None);
+    assert_eq!(out.diagnostics.len(), 0);
+    assert_eq!(out.results.len(), 1);
+    match &out.results[0] {
+        RunResult::Num(n) => assert!((*n - 1.0).abs() < 1e-9),
+        other => panic!("expected numeric result, got {:?}", other),
+    }
+}
+
+#[test]
+fn evaluate_does_not_panic_on_unknown_op() {
+    let out = evaluate("(=: missing_op identity)", Some("inline.lino"), None);
+    assert!(out.diagnostics.len() >= 1);
+}
+
+#[test]
+fn unknown_op_surfaces_as_e001_with_span() {
+    let out = evaluate("(=: missing_op identity)", Some("inline.lino"), None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E001");
+    assert!(d.message.contains("Unknown op"), "msg was: {}", d.message);
+    assert_eq!(d.span.file.as_deref(), Some("inline.lino"));
+    assert_eq!(d.span.line, 1);
+    assert_eq!(d.span.col, 1);
+}
+
+#[test]
+fn unknown_aggregator_surfaces_as_e004() {
+    let out = evaluate("(and: bogus_agg)", Some("agg.lino"), None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E004");
+    assert!(
+        d.message.to_lowercase().contains("aggregator"),
+        "msg was: {}",
+        d.message
+    );
+    assert_eq!(d.span.line, 1);
+}
+
+#[test]
+fn span_tracks_line_for_form_after_blank_lines() {
+    let src = "(valence: 2)\n\n(=: missing identity)";
+    let out = evaluate(src, Some("multi.lino"), None);
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E001");
+    assert_eq!(out.diagnostics[0].span.line, 3);
+    assert_eq!(out.diagnostics[0].span.col, 1);
+}
+
+#[test]
+fn good_results_are_kept_when_a_later_form_errors() {
+    let src = "(valence: 2)\n(p has probability 1)\n(? p)\n(=: missing identity)";
+    let out = evaluate(src, Some("mix.lino"), None);
+    assert_eq!(out.results.len(), 1);
+    match &out.results[0] {
+        RunResult::Num(n) => assert!((*n - 1.0).abs() < 1e-9),
+        other => panic!("expected numeric result, got {:?}", other),
+    }
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E001");
+    assert_eq!(out.diagnostics[0].span.line, 4);
+}
+
+#[test]
+fn format_diagnostic_renders_caret_under_offending_token() {
+    let src = "(=: missing_op identity)";
+    let out = evaluate(src, Some("demo.lino"), None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let text = format_diagnostic(&out.diagnostics[0], Some(src));
+    let lines: Vec<&str> = text.split('\n').collect();
+    assert!(
+        lines[0].starts_with("demo.lino:1:1: E001:"),
+        "line[0] was: {}",
+        lines[0]
+    );
+    assert_eq!(lines[1], "(=: missing_op identity)");
+    assert_eq!(lines[2], "^");
+}
+
+#[test]
+fn format_diagnostic_for_second_line() {
+    let src = "(valence: 2)\n(=: missing_op identity)";
+    let out = evaluate(src, Some("caret.lino"), None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let text = format_diagnostic(&out.diagnostics[0], Some(src));
+    let lines: Vec<&str> = text.split('\n').collect();
+    assert!(
+        lines[0].starts_with("caret.lino:2:1:"),
+        "line[0] was: {}",
+        lines[0]
+    );
+    assert_eq!(lines[1], "(=: missing_op identity)");
+    assert_eq!(lines[2], "^");
+}
+
+#[test]
+fn diagnostic_struct_carries_code_message_span() {
+    let span = Span::new(Some("x.lino".to_string()), 2, 3, 1);
+    let diag = Diagnostic::new("E001", "Unknown op: foo", span.clone());
+    assert_eq!(diag.code, "E001");
+    assert_eq!(diag.message, "Unknown op: foo");
+    assert_eq!(diag.span, span);
+}
+
+#[test]
+fn compute_form_spans_returns_one_span_per_top_level_form() {
+    let text = "(a)\n  (b)\n\n(c)";
+    let spans = compute_form_spans(text, Some("spans.lino"));
+    assert_eq!(spans.len(), 3);
+    let lc: Vec<(usize, usize)> = spans.iter().map(|s| (s.line, s.col)).collect();
+    assert_eq!(lc, vec![(1, 1), (2, 3), (4, 1)]);
+    for s in &spans {
+        assert_eq!(s.file.as_deref(), Some("spans.lino"));
+    }
+}


### PR DESCRIPTION
Fixes #28.

Replaces ad-hoc `throw`/`panic` error reporting with a structured
`Diagnostic` value across both implementations, gives both CLIs the
familiar `file:line:col` + caret output, and is fully additive — the
existing `run()` entry point and all 657 pre-existing tests stay
unchanged.

## What changed

### New API: `evaluate()` returns structured diagnostics

| Language | Signature |
|----------|-----------|
| JavaScript | `evaluate(code, options?) -> { results, diagnostics }` |
| Rust | `evaluate(text, file, options) -> EvaluateResult { results, diagnostics }` |

Each `Diagnostic` carries a stable error code (`E001`, `E002`, …), a
human-readable message, and a 1-based source span
(`{ file, line, col, length }`). `evaluate()` never throws and never
panics: errors do not abort evaluation, so independent forms continue to
be processed after a failing one.

The Rust implementation bridges internal `panic!`s into diagnostics via
`std::panic::catch_unwind`, with the default panic hook silenced for the
duration of the call so stack traces never leak to stderr.

### CLI output

Both CLIs (`node js/src/rml-links.mjs <file>` and `rml <file>`) now
print:

```
kb.lino:1:1: E001: Unknown op: foo
(=: foo bar)
^
```

…and exit non-zero whenever any diagnostic is emitted.

### Error codes

| Code | When it fires |
|------|---------------|
| `E000` | Generic / unclassified fallback. |
| `E001` | Reference to an undefined operator. |
| `E002` | Token-level parse error inside a single link. |
| `E003` | Operator definition with the right head but unsupported body. |
| `E004` | Unknown aggregator selector. |
| `E005` | Empty meta-expression passed to a formalization helper. |
| `E006` | LiNo top-level parse failure. |

The full table with triggers and "how to add a new code" instructions
lives in [`docs/DIAGNOSTICS.md`](./docs/DIAGNOSTICS.md).

## Files

- `js/src/rml-links.mjs` — `Diagnostic`, `RmlError`, `formatDiagnostic`,
  `computeFormSpans`, `evaluate` exports; existing throw sites replaced
  with `RmlError` carrying an error code.
- `rust/src/lib.rs` — `Span`, `Diagnostic`, `EvaluateResult`,
  `format_diagnostic`, `compute_form_spans`, `evaluate` exports; panic
  payload decoder; panic-hook silencing.
- `js/src/rml-links.mjs` (CLI block) and `rust/src/main.rs` rewired to
  use `evaluate()` and `formatDiagnostic`/`format_diagnostic`.
- `js/tests/diagnostics.test.mjs` (11 cases) and
  `rust/tests/diagnostics_tests.rs` (10 cases) cover E001/E002/E004/E006
  triggers, span correctness across blank lines, formatter output, and
  the "good results survive a later error" guarantee.
- `docs/DIAGNOSTICS.md` — new doc.
- `README.md`, `ARCHITECTURE.md`, `js/README.md`, `rust/README.md` —
  cross-link to `docs/DIAGNOSTICS.md` and document the new entry point.

## Test plan

- [x] `cd js && npm test` — 424 tests pass (413 pre-existing + 11 new).
- [x] `cd rust && cargo test` — 254 tests pass (242 lib + 2 shared
      examples + 10 new diagnostics).
- [x] CLI parity: `(=: foo bar)` produces identical
      `file:line:col: E001: Unknown op: foo` + caret + exit code 1 in
      both implementations.

## How to reproduce the issue (before this PR)

```bash
$ echo '(=: foo bar)' > /tmp/t.lino
$ node js/src/rml-links.mjs /tmp/t.lino
# crashed with an unstructured "Error: Unknown op: foo" stack trace,
# no file/line/col, exit code unstable.
```

After this PR:

```
$ node js/src/rml-links.mjs /tmp/t.lino
/tmp/t.lino:1:1: E001: Unknown op: foo
(=: foo bar)
^
$ echo $?
1
```

…with byte-identical output from `cargo run --bin rml /tmp/t.lino`.