### PR TITLE
[A3] Trace mode for evaluation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T15:50:21.439Z for PR creation at branch issue-30-fbacf7f8954b for issue https://github.com/link-foundation/relative-meta-logic/issues/30

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T15:50:21.439Z for PR creation at branch issue-30-fbacf7f8954b for issue https://github.com/link-foundation/relative-meta-logic/issues/30

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -97,3 +97,90 @@ explicitly note a breaking change in the changelog. The accompanying
 3. Add a test in `js/tests/diagnostics.test.mjs` and a mirrored test in
    `rust/tests/diagnostics_tests.rs` so drift between the two
    implementations fails CI.
+
+## Trace mode
+
+Both runners support an opt-in **trace mode** that records a deterministic
+sequence of evaluator events: operator resolutions, assignment lookups,
+probability assignments, and one reduction summary per top-level form.
+Trace events share the same `file:line:col` span machinery as diagnostics,
+so they pinpoint exactly which line of the source produced each step.
+
+### Enabling tracing
+
+```sh
+node js/src/rml-links.mjs --trace examples/demo.lino
+rml --trace examples/demo.lino
+```
+
+The `--trace` flag writes one event per line to **stderr**, in source order.
+Query results still go to stdout, so piping a script through trace mode
+won't disturb downstream tools.
+
+### Library API
+
+JavaScript:
+
+```js
+import { evaluate, formatTraceEvent } from 'relative-meta-logic';
+
+const { results, diagnostics, trace } =
+  evaluate(source, { file: 'demo.lino', trace: true });
+
+for (const event of trace) {
+  console.error(formatTraceEvent(event));
+}
+```
+
+Rust:
+
+```rust
+use rml::{evaluate_with_options, format_trace_event, EvaluateOptions};
+
+let evaluation = evaluate_with_options(
+    &source,
+    Some("demo.lino"),
+    EvaluateOptions { env: None, trace: true },
+);
+for event in &evaluation.trace {
+    eprintln!("{}", format_trace_event(event));
+}
+```
+
+### Output format
+
+Each trace event prints as:
+
+```
+[span <file>:<line>:<col>] <kind> <details>
+```
+
+Example, derived from `examples/demo.lino`:
+
+```
+[span examples/demo.lino:5:1] resolve (!=: not =)
+[span examples/demo.lino:6:1] resolve (and: avg)
+[span examples/demo.lino:7:1] resolve (or: max)
+[span examples/demo.lino:10:1] assign (a = a) ← 1
+[span examples/demo.lino:14:1] lookup (a = a) → 1
+[span examples/demo.lino:14:1] eval (? ((a = a) and (a != a))) → query 0.5
+```
+
+### Event kinds
+
+| Kind      | Emitted when |
+|-----------|--------------|
+| `resolve` | An operator definition or aggregator selection runs, e.g. `(and: avg)` or `(!=: not =)`. The detail is the form being installed. |
+| `assign`  | A probability assignment runs: `((expr) has probability v)`. Detail is `<expr-key> ← <clamped value>`. |
+| `lookup`  | An equality `(L = R)` (or its inequality) finds a previously assigned probability. Detail is `<key> → <value>`. |
+| `eval`    | A top-level form finishes evaluating. Detail is `<form-key> → <summary>`, where the summary is `query <v>`, `type <t>`, or just the value. |
+
+### Determinism
+
+Trace output is reproducible: top-level forms are processed in source order,
+operator hooks fire in a fixed evaluation order, and numbers are normalized
+through the same `formatTraceValue` helper in both runtimes. Two consecutive
+runs on the same input produce identical traces, and the JavaScript and
+Rust implementations produce the same trace lines for the same input — both
+properties are exercised by the trace test suites.
+

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -37,6 +37,25 @@ class RmlError extends Error {
   }
 }
 
+// ---------- Trace events ----------
+// When `trace: true` is passed to `evaluate()` the evaluator records a
+// deterministic sequence of `TraceEvent` objects describing operator
+// resolutions, assignment lookups, and reduction steps. The CLI's `--trace`
+// flag prints each one as `[span <file>:<line>:<col>] <kind> <details>`.
+class TraceEvent {
+  constructor({ kind, detail, span }) {
+    this.kind = kind;
+    this.detail = detail;
+    this.span = span || { file: null, line: 1, col: 1, length: 0 };
+  }
+}
+
+function formatTraceEvent(event) {
+  const span = event.span || { file: null, line: 1, col: 1, length: 0 };
+  const file = span.file || '<input>';
+  return `[span ${file}:${span.line}:${span.col}] ${event.kind} ${event.detail}`;
+}
+
 // Format a diagnostic for human-readable CLI output:
 //   <file>:<line>:<col>: <CODE>: <message>
 //       <source line>
@@ -155,6 +174,12 @@ class Env {
     this.symbolProb = new Map();                // optional symbol priors if you want (x: 0.7)
     this.types = new Map();                     // key(expr) -> type expression (as string)
     this.lambdas = new Map();                   // name -> { param, paramType, body } for named lambdas
+    // Optional tracer: when set, key evaluation events (operator resolutions,
+    // assignment lookups, top-level reductions) are pushed via `trace(kind, detail)`.
+    // The current top-level form span is stashed on the Env so leaf hooks can
+    // attach a location without threading spans through every helper.
+    this._tracer = null;
+    this._currentSpan = null;
 
     // Range: [lo, hi] — default [0, 1] (standard probabilistic)
     // Use [-1, 1] for balanced/symmetric range
@@ -183,9 +208,17 @@ class Env {
       '='  : (L,R,ctx)=> {
         // If assigned explicitly, use that (check both prefix and infix key forms)
         const kPrefix = keyOf(['=',L,R]);
-        if (this.assign.has(kPrefix)) return this.assign.get(kPrefix);
+        if (this.assign.has(kPrefix)) {
+          const v = this.assign.get(kPrefix);
+          this.trace('lookup', `${kPrefix} → ${formatTraceValue(v)}`);
+          return v;
+        }
         const kInfix = keyOf([L,'=',R]);
-        if (this.assign.has(kInfix)) return this.assign.get(kInfix);
+        if (this.assign.has(kInfix)) {
+          const v = this.assign.get(kInfix);
+          this.trace('lookup', `${kInfix} → ${formatTraceValue(v)}`);
+          return v;
+        }
         // Default: syntactic equality of terms/trees
         return isStructurallySame(L,R) ? this.hi : this.lo;
       },
@@ -265,6 +298,9 @@ class Env {
   }
   setSymbolProb(sym, p){ this.symbolProb.set(sym, this.clamp(p)); }
   getSymbolProb(sym){ return this.symbolProb.has(sym) ? this.symbolProb.get(sym) : this.mid; }
+  trace(kind, detail){
+    if (this._tracer) this._tracer(kind, detail, this._currentSpan);
+  }
 }
 
 // ---------- Binding parser ----------
@@ -350,6 +386,17 @@ function substitute(expr, name, replacement) {
 }
 
 // ---------- Eval ----------
+// Format a numeric value for trace output — strips trailing zeros so
+// `1.000000` reads as `1` and `0.5` stays `0.5`. Used both for assignment
+// values and for reduction results to keep trace lines reproducible.
+function formatTraceValue(v) {
+  if (typeof v !== 'number') return String(v);
+  if (!Number.isFinite(v)) return String(v);
+  const rounded = +v.toFixed(6);
+  const s = String(rounded);
+  return s;
+}
+
 // Evaluate a node in arithmetic context — numeric literals are NOT clamped to the logic range.
 function evalArith(node, env){
   if (typeof node === 'string' && isNum(node)) return parseFloat(node);
@@ -373,7 +420,9 @@ function evalNode(node, env){
 
   // Assignment: ((expr) has probability p)
   if (node.length === 4 && node[1] === 'has' && node[2] === 'probability' && isNum(node[3])) {
-    env.setExprProb(node[0], parseFloat(node[3]));
+    const p = parseFloat(node[3]);
+    env.setExprProb(node[0], p);
+    env.trace('assign', `${keyOf(node[0])} ← ${formatTraceValue(env.clamp(p))}`);
     return env.toNum(node[3]);
   }
 
@@ -610,9 +659,17 @@ function _reinitOps(env) {
   env.ops.set('neither', (...xs) => xs.length ? decRound(xs.reduce((a,b)=>a*b,1)) : env.lo);
   env.ops.set('=', (L,R,ctx) => {
     const kPrefix = keyOf(['=',L,R]);
-    if (env.assign.has(kPrefix)) return env.assign.get(kPrefix);
+    if (env.assign.has(kPrefix)) {
+      const v = env.assign.get(kPrefix);
+      env.trace('lookup', `${kPrefix} → ${formatTraceValue(v)}`);
+      return v;
+    }
     const kInfix = keyOf([L,'=',R]);
-    if (env.assign.has(kInfix)) return env.assign.get(kInfix);
+    if (env.assign.has(kInfix)) {
+      const v = env.assign.get(kInfix);
+      env.trace('lookup', `${kInfix} → ${formatTraceValue(v)}`);
+      return v;
+    }
     return isStructurallySame(L,R) ? env.hi : env.lo;
   });
   env.ops.set('!=', (...args) => env.getOp('not')( env.getOp('=')(...args) ));
@@ -695,6 +752,7 @@ function defineForm(head, rhs, env){
       const outer = env.getOp(rhs[0]);
       const inner = env.getOp(rhs[1]);
       env.defineOp(head, (...xs) => env.clamp( outer( inner(...xs) ) ));
+      env.trace('resolve', `(${head}: ${rhs[0]} ${rhs[1]})`);
       return 1;
     }
 
@@ -710,6 +768,7 @@ function defineForm(head, rhs, env){
         sel==='probabilistic_sum' || sel==='ps' ? xs=> 1 - xs.reduce((a,b)=>a*(1-b),1) : null;
       if (!agg) throw new RmlError('E004', `Unknown aggregator "${sel}"`);
       env.defineOp(head, (...xs)=> xs.length? agg(xs) : lo);
+      env.trace('resolve', `(${head}: ${sel})`);
       return 1;
     }
 
@@ -776,7 +835,9 @@ function parseLinoForms(text) {
 // A "top-level link" is a parenthesized form that is not nested inside another;
 // position is reported as 1-based line and column of its opening `(`.
 // Lines starting with `#` are treated as full-line comments and ignored, just
-// like `stripLinoComments` does.
+// like `stripLinoComments` does. Inline `# ...` comments that follow a closing
+// paren (matching `(\)[ \t]+)#.*$` in `stripLinoComments`) are also skipped so
+// parens inside the comment don't disturb the depth counter.
 function computeFormSpans(text, file) {
   const spans = [];
   const lines = text.split('\n');
@@ -786,20 +847,30 @@ function computeFormSpans(text, file) {
   let colNum = 1;
   let pendingStart = null; // {line, col, offset} for the next top-level link
   let inLineComment = false;
+  let lastClosingDepthZeroCol = -1;
+  let sawWsAfterClose = false;
   for (let off = 0; off < text.length; off++) {
     const ch = text[off];
     if (ch === '\n') {
       inLineComment = false;
       lineNum++;
       colNum = 1;
+      lastClosingDepthZeroCol = -1;
+      sawWsAfterClose = false;
       continue;
     }
     if (inLineComment) { colNum++; continue; }
     // Detect a full-line comment (line begins with optional whitespace + #).
     if (ch === '#' && depth === 0) {
-      // Check if the line so far contains only whitespace.
+      // Full-line comment: line so far is all whitespace.
       const lineSoFar = lines[lineNum - 1].slice(0, colNum - 1);
       if (/^[ \t]*$/.test(lineSoFar)) {
+        inLineComment = true;
+        colNum++;
+        continue;
+      }
+      // Inline comment after `)` + whitespace: discard rest of line.
+      if (lastClosingDepthZeroCol >= 0 && sawWsAfterClose) {
         inLineComment = true;
         colNum++;
         continue;
@@ -810,12 +881,21 @@ function computeFormSpans(text, file) {
         pendingStart = { line: lineNum, col: colNum };
       }
       depth++;
+      sawWsAfterClose = false;
     } else if (ch === ')') {
       depth--;
       if (depth === 0 && pendingStart) {
         spans.push({ file: file || null, line: pendingStart.line, col: pendingStart.col, length: 1 });
         pendingStart = null;
+        lastClosingDepthZeroCol = colNum;
+        sawWsAfterClose = false;
       }
+    } else if (ch === ' ' || ch === '\t') {
+      if (lastClosingDepthZeroCol >= 0) sawWsAfterClose = true;
+    } else {
+      // Any other character resets the inline-comment-eligible state.
+      lastClosingDepthZeroCol = -1;
+      sawWsAfterClose = false;
     }
     colNum++;
   }
@@ -832,6 +912,13 @@ function evaluate(code, options) {
   const env = new Env(opts.env || opts);
   const results = [];
   const diagnostics = [];
+  const traceEnabled = !!opts.trace;
+  const trace = traceEnabled ? [] : null;
+  if (traceEnabled) {
+    env._tracer = (kind, detail, span) => {
+      trace.push(new TraceEvent({ kind, detail, span: span || { file, line: 1, col: 1, length: 0 } }));
+    };
+  }
 
   // Pre-compute spans for each top-level form so error reporting can attach
   // a real source location even when the parser/evaluator throw deep inside.
@@ -845,7 +932,9 @@ function evaluate(code, options) {
       ? new Diagnostic({ code: err.code, message: err.message, span: { file, line: 1, col: 1, length: 0 } })
       : new Diagnostic({ code: 'E006', message: `LiNo parse failure: ${err && err.message ? err.message : String(err)}`, span: { file, line: 1, col: 1, length: 0 } });
     diagnostics.push(diag);
-    return { results, diagnostics };
+    const out = { results, diagnostics };
+    if (traceEnabled) out.trace = trace;
+    return out;
   }
 
   for (let idx = 0; idx < forms.length; idx++) {
@@ -854,8 +943,20 @@ function evaluate(code, options) {
       form = form[0];
     }
     const span = formSpans[idx] || { file, line: 1, col: 1, length: 0 };
+    env._currentSpan = span;
     try {
       const res = evalNode(form, env);
+      if (traceEnabled) {
+        const formKey = keyOf(form);
+        let summary;
+        if (res && res.query) {
+          const tag = res.typeQuery ? 'type' : 'query';
+          summary = `${formKey} → ${tag} ${formatTraceValue(res.value)}`;
+        } else {
+          summary = `${formKey} → ${formatTraceValue(res)}`;
+        }
+        trace.push(new TraceEvent({ kind: 'eval', detail: summary, span }));
+      }
       if (res && res.query) {
         results.push(res.value);
       }
@@ -866,7 +967,11 @@ function evaluate(code, options) {
       diagnostics.push(new Diagnostic({ code, message, span: diagSpan }));
     }
   }
-  return { results, diagnostics };
+  env._currentSpan = null;
+  env._tracer = null;
+  const out = { results, diagnostics };
+  if (traceEnabled) out.trace = trace;
+  return out;
 }
 
 // ---------- Meta-expression adapter ----------
@@ -1067,24 +1172,36 @@ function run(text, options){
 
 // CLI
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const file = process.argv[2];
+  const argv = process.argv.slice(2);
+  let trace = false;
+  const positionals = [];
+  for (const arg of argv) {
+    if (arg === '--trace') trace = true;
+    else positionals.push(arg);
+  }
+  const file = positionals[0];
   if (!file) {
-    console.error('Usage: node src/rml-links.mjs <kb.lino>');
+    console.error('Usage: node src/rml-links.mjs [--trace] <kb.lino>');
     process.exit(1);
   }
   const text = fs.readFileSync(file, 'utf8');
-  const { results, diagnostics } = evaluate(text, { file });
-  for (const v of results) {
+  const out = evaluate(text, { file, trace });
+  if (trace && out.trace) {
+    for (const event of out.trace) {
+      console.error(formatTraceEvent(event));
+    }
+  }
+  for (const v of out.results) {
     if (typeof v === 'string') {
       console.log(v);
     } else {
       console.log(String(+v.toFixed(6)).replace(/\.0+$/,''));
     }
   }
-  for (const diag of diagnostics) {
+  for (const diag of out.diagnostics) {
     console.error(formatDiagnostic(diag, text));
   }
-  if (diagnostics.length > 0) process.exit(1);
+  if (out.diagnostics.length > 0) process.exit(1);
 }
 
 export {
@@ -1092,7 +1209,9 @@ export {
   evaluate,
   Diagnostic,
   RmlError,
+  TraceEvent,
   formatDiagnostic,
+  formatTraceEvent,
   computeFormSpans,
   parseLino,
   tokenizeOne,

--- a/js/tests/trace.test.mjs
+++ b/js/tests/trace.test.mjs
@@ -1,0 +1,112 @@
+// Tests for evaluation trace mode (issue #30).
+// Covers the evaluate() trace option, TraceEvent shape, format helper, and
+// determinism across repeated runs. The Rust suite mirrors these cases in
+// rust/tests/trace_tests.rs to keep the two implementations in lock-step.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  evaluate,
+  TraceEvent,
+  formatTraceEvent,
+} from '../src/rml-links.mjs';
+
+const DEMO = [
+  '(a: a is a)',
+  '(!=: not =)',
+  '(and: avg)',
+  '((a = a) has probability 1)',
+  '((a != a) has probability 0)',
+  '(? ((a = a) and (a != a)))',
+].join('\n');
+
+describe('evaluate() with trace: true returns trace events', () => {
+  it('returns no trace array when trace is not enabled', () => {
+    const out = evaluate('(? 1)', { file: 'q.lino' });
+    assert.strictEqual(out.trace, undefined);
+  });
+
+  it('returns a deterministic, non-empty trace when trace is enabled', () => {
+    const out = evaluate(DEMO, { file: 'demo.lino', trace: true });
+    assert.ok(Array.isArray(out.trace));
+    assert.ok(out.trace.length > 0);
+    for (const ev of out.trace) {
+      assert.ok(ev instanceof TraceEvent);
+      assert.ok(['resolve', 'assign', 'lookup', 'eval'].includes(ev.kind));
+      assert.strictEqual(ev.span.file, 'demo.lino');
+      assert.ok(ev.span.line >= 1);
+      assert.ok(ev.span.col >= 1);
+    }
+  });
+
+  it('produces the same trace on repeated runs (determinism)', () => {
+    const a = evaluate(DEMO, { file: 'demo.lino', trace: true });
+    const b = evaluate(DEMO, { file: 'demo.lino', trace: true });
+    const fmt = (out) => out.trace.map(formatTraceEvent).join('\n');
+    assert.strictEqual(fmt(a), fmt(b));
+  });
+
+  it('does not affect query results when enabled', () => {
+    const plain = evaluate(DEMO, { file: 'demo.lino' });
+    const traced = evaluate(DEMO, { file: 'demo.lino', trace: true });
+    assert.deepStrictEqual(plain.results, traced.results);
+    assert.deepStrictEqual(plain.diagnostics, traced.diagnostics);
+  });
+});
+
+describe('TraceEvent shape and span tracking', () => {
+  it('records a resolve event for (and: avg) with the operator span', () => {
+    const out = evaluate('(and: avg)', { file: 'op.lino', trace: true });
+    const resolves = out.trace.filter((e) => e.kind === 'resolve');
+    assert.strictEqual(resolves.length, 1);
+    assert.strictEqual(resolves[0].detail, '(and: avg)');
+    assert.strictEqual(resolves[0].span.file, 'op.lino');
+    assert.strictEqual(resolves[0].span.line, 1);
+    assert.strictEqual(resolves[0].span.col, 1);
+  });
+
+  it('records an assign event for ((p) has probability v)', () => {
+    const out = evaluate('((a = a) has probability 1)', {
+      file: 'p.lino',
+      trace: true,
+    });
+    const assigns = out.trace.filter((e) => e.kind === 'assign');
+    assert.strictEqual(assigns.length, 1);
+    assert.strictEqual(assigns[0].detail, '(a = a) ← 1');
+    assert.strictEqual(assigns[0].span.line, 1);
+  });
+
+  it('records a lookup event when an assigned equality fires', () => {
+    const src = '((a = a) has probability 0.7)\n(? (a = a))';
+    const out = evaluate(src, { file: 'lk.lino', trace: true });
+    const lookups = out.trace.filter((e) => e.kind === 'lookup');
+    assert.ok(lookups.length >= 1);
+    assert.match(lookups[0].detail, /\(a = a\) → 0\.7/);
+    assert.strictEqual(lookups[0].span.line, 2);
+  });
+
+  it('records an eval event per top-level form', () => {
+    const out = evaluate(DEMO, { file: 'demo.lino', trace: true });
+    const evals = out.trace.filter((e) => e.kind === 'eval');
+    // One eval event per top-level form (6 forms in DEMO).
+    assert.strictEqual(evals.length, 6);
+    // Final form is the query and its summary uses the `query` tag.
+    const lastEval = evals[evals.length - 1];
+    assert.match(lastEval.detail, /→ query 0\.5$/);
+    assert.strictEqual(lastEval.span.line, 6);
+  });
+});
+
+describe('formatTraceEvent formats span and kind', () => {
+  it('renders [span <file>:<line>:<col>] <kind> <detail>', () => {
+    const out = evaluate('(and: avg)', { file: 'fmt.lino', trace: true });
+    const line = formatTraceEvent(out.trace[0]);
+    assert.strictEqual(line, '[span fmt.lino:1:1] resolve (and: avg)');
+  });
+
+  it('falls back to <input> when the span has no file', () => {
+    const out = evaluate('(and: avg)', { trace: true });
+    const line = formatTraceEvent(out.trace[0]);
+    assert.strictEqual(line, '[span <input>:1:1] resolve (and: avg)');
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -68,11 +68,73 @@ impl Diagnostic {
 }
 
 /// Result of `evaluate(src)`: a list of query results (numeric or type) plus
-/// any diagnostics emitted while parsing/evaluating.
+/// any diagnostics emitted while parsing/evaluating. When tracing is enabled
+/// via `evaluate_with_options`, `trace` carries the deterministic sequence of
+/// `TraceEvent` values recorded during evaluation; otherwise it is empty.
 #[derive(Debug, Clone, Default)]
 pub struct EvaluateResult {
     pub results: Vec<RunResult>,
     pub diagnostics: Vec<Diagnostic>,
+    pub trace: Vec<TraceEvent>,
+}
+
+/// Options for `evaluate_with_options` — bundles environment settings with
+/// runtime flags like `trace`. Keeps `evaluate()` backwards compatible.
+#[derive(Debug, Clone, Default)]
+pub struct EvaluateOptions {
+    pub env: Option<EnvOptions>,
+    pub trace: bool,
+}
+
+// ========== Trace events ==========
+// When `evaluate` is called with `EvaluateOptions { trace: true }` the
+// evaluator records a deterministic sequence of `TraceEvent` values describing
+// operator resolutions, assignment lookups, and reduction steps. The CLI's
+// `--trace` flag prints each one as `[span <file>:<line>:<col>] <kind> <details>`.
+// Mirrors `TraceEvent` / `formatTraceEvent` in `js/src/rml-links.mjs`.
+
+/// A single trace event emitted by the evaluator.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraceEvent {
+    pub kind: String,
+    pub detail: String,
+    pub span: Span,
+}
+
+impl TraceEvent {
+    pub fn new(kind: &str, detail: impl Into<String>, span: Span) -> Self {
+        Self {
+            kind: kind.to_string(),
+            detail: detail.into(),
+            span,
+        }
+    }
+}
+
+/// Format a trace event as `[span <file>:<line>:<col>] <kind> <details>`.
+pub fn format_trace_event(event: &TraceEvent) -> String {
+    let file = event.span.file.as_deref().unwrap_or("<input>");
+    format!(
+        "[span {}:{}:{}] {} {}",
+        file, event.span.line, event.span.col, event.kind, event.detail
+    )
+}
+
+/// Format a numeric value for trace output — strips trailing zeros so
+/// `1.000000` reads as `1` and `0.5` stays `0.5`. Mirrors `formatTraceValue`
+/// in the JavaScript implementation so cross-runtime traces match exactly.
+pub fn format_trace_value(v: f64) -> String {
+    if !v.is_finite() {
+        return v.to_string();
+    }
+    let rounded = format!("{:.6}", v);
+    // Trim trailing zeros and possibly the decimal point.
+    let trimmed = rounded.trim_end_matches('0').trim_end_matches('.');
+    if trimmed.is_empty() || trimmed == "-" {
+        "0".to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 /// Format a diagnostic for human-readable CLI output:
@@ -103,6 +165,12 @@ pub fn format_diagnostic(diag: &Diagnostic, source: Option<&str>) -> String {
 
 /// Compute (line, col) source positions for every top-level link in `text`.
 /// Mirrors `compute_form_spans` in the JavaScript implementation.
+///
+/// A "top-level link" is a parenthesized form not nested inside another; the
+/// position is the 1-based line/col of its opening `(`. Full-line `# ...`
+/// comments and inline `# ...` comments after a closing paren plus whitespace
+/// are skipped so that parens inside a comment don't disturb the depth
+/// counter.
 pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
     let mut spans = Vec::new();
     let mut depth: i32 = 0;
@@ -111,6 +179,8 @@ pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
     let mut pending_start: Option<(usize, usize)> = None;
     let mut in_line_comment = false;
     let mut line_start_idx: usize = 0;
+    let mut last_closing_depth_zero_col: i32 = -1;
+    let mut saw_ws_after_close = false;
     let bytes = text.as_bytes();
     for (off, &b) in bytes.iter().enumerate() {
         let ch = b as char;
@@ -119,6 +189,8 @@ pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
             line += 1;
             col = 1;
             line_start_idx = off + 1;
+            last_closing_depth_zero_col = -1;
+            saw_ws_after_close = false;
             continue;
         }
         if in_line_comment {
@@ -126,9 +198,15 @@ pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
             continue;
         }
         if ch == '#' && depth == 0 {
-            // Determine if the line so far contains only whitespace.
+            // Full-line comment: line so far is all whitespace.
             let line_so_far = &text[line_start_idx..off];
             if line_so_far.chars().all(|c| c == ' ' || c == '\t') {
+                in_line_comment = true;
+                col += 1;
+                continue;
+            }
+            // Inline comment after `)` + whitespace: discard rest of line.
+            if last_closing_depth_zero_col >= 0 && saw_ws_after_close {
                 in_line_comment = true;
                 col += 1;
                 continue;
@@ -139,13 +217,24 @@ pub fn compute_form_spans(text: &str, file: Option<&str>) -> Vec<Span> {
                 pending_start = Some((line, col));
             }
             depth += 1;
+            saw_ws_after_close = false;
         } else if ch == ')' {
             depth -= 1;
             if depth == 0 {
                 if let Some((sl, sc)) = pending_start.take() {
                     spans.push(Span::new(file.map(|s| s.to_string()), sl, sc, 1));
                 }
+                last_closing_depth_zero_col = col as i32;
+                saw_ws_after_close = false;
             }
+        } else if ch == ' ' || ch == '\t' {
+            if last_closing_depth_zero_col >= 0 {
+                saw_ws_after_close = true;
+            }
+        } else {
+            // Any other character resets the inline-comment-eligible state.
+            last_closing_depth_zero_col = -1;
+            saw_ws_after_close = false;
         }
         col += 1;
     }
@@ -515,6 +604,16 @@ pub struct Env {
     pub ops: HashMap<String, Op>,
     pub types: HashMap<String, String>,
     pub lambdas: HashMap<String, Lambda>,
+    /// Tracing state. When `trace_enabled` is true, key evaluation events
+    /// (operator resolutions, assignment lookups, top-level reductions) are
+    /// appended to `trace_events`. The current top-level form span is stashed
+    /// on the Env so leaf hooks can attach a location without threading spans
+    /// through every helper. Mirrors the `_tracer`/`_currentSpan` design in
+    /// `js/src/rml-links.mjs`.
+    pub trace_enabled: bool,
+    pub trace_events: Vec<TraceEvent>,
+    pub current_span: Option<Span>,
+    pub default_span: Span,
 }
 
 impl Env {
@@ -547,6 +646,10 @@ impl Env {
             ops,
             types: HashMap::new(),
             lambdas: HashMap::new(),
+            trace_enabled: false,
+            trace_events: Vec::new(),
+            current_span: None,
+            default_span: Span::unknown(),
         };
 
         // Initialize truth constants: true, false, unknown, undefined
@@ -612,6 +715,21 @@ impl Env {
             .get(sym)
             .copied()
             .unwrap_or_else(|| self.mid())
+    }
+
+    /// Push a trace event when tracing is enabled. The event's span is taken
+    /// from `current_span` if set, else `default_span`. Mirrors `Env.trace`
+    /// in the JavaScript implementation.
+    pub fn trace(&mut self, kind: &str, detail: impl Into<String>) {
+        if !self.trace_enabled {
+            return;
+        }
+        let span = self
+            .current_span
+            .clone()
+            .unwrap_or_else(|| self.default_span.clone());
+        self.trace_events
+            .push(TraceEvent::new(kind, detail, span));
     }
 
     pub fn set_type(&mut self, expr: &str, type_expr: &str) {
@@ -685,7 +803,8 @@ impl Env {
     }
 
     /// Apply equality operator, checking assigned probabilities first.
-    pub fn apply_eq(&self, left: &Node, right: &Node) -> f64 {
+    /// Takes `&mut self` so it can emit `lookup` trace events.
+    pub fn apply_eq(&mut self, left: &Node, right: &Node) -> f64 {
         // Check prefix form: (= L R)
         let k_prefix = key_of(&Node::List(vec![
             Node::Leaf("=".to_string()),
@@ -693,6 +812,10 @@ impl Env {
             right.clone(),
         ]));
         if let Some(&v) = self.assign.get(&k_prefix) {
+            self.trace(
+                "lookup",
+                format!("{} → {}", k_prefix, format_trace_value(v)),
+            );
             return v;
         }
         // Check infix form: (L = R)
@@ -702,6 +825,10 @@ impl Env {
             right.clone(),
         ]));
         if let Some(&v) = self.assign.get(&k_infix) {
+            self.trace(
+                "lookup",
+                format!("{} → {}", k_infix, format_trace_value(v)),
+            );
             return v;
         }
         // Default: syntactic equality
@@ -713,7 +840,7 @@ impl Env {
     }
 
     /// Apply inequality operator: not(eq(L, R))
-    pub fn apply_neq(&self, left: &Node, right: &Node) -> f64 {
+    pub fn apply_neq(&mut self, left: &Node, right: &Node) -> f64 {
         let eq_val = self.apply_eq(left, right);
         self.apply_op("not", &[eq_val])
     }
@@ -934,6 +1061,12 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                     if w1 == "has" && w2 == "probability" && is_num(w3) {
                         let p: f64 = w3.parse().unwrap_or(0.0);
                         env.set_expr_prob(&children[0], p);
+                        let key = key_of(&children[0]);
+                        let clamped = env.clamp(p);
+                        env.trace(
+                            "assign",
+                            format!("{} ← {}", key, format_trace_value(clamped)),
+                        );
                         return EvalResult::Value(env.to_num(w3));
                     }
                 }
@@ -1114,9 +1247,8 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                                     || env.assign.contains_key(&k_infix)
                                     || is_structurally_same(&children[0], &children[2])
                                 {
-                                    return EvalResult::Value(
-                                        env.clamp(env.apply_neq(&children[0], &children[2])),
-                                    );
+                                    let neq = env.apply_neq(&children[0], &children[2]);
+                                    return EvalResult::Value(env.clamp(neq));
                                 }
                                 // No explicit assignment — try numeric comparison
                                 let l = eval_arith(&children[0], env);
@@ -1319,8 +1451,9 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
 }
 
 /// Helper for applying a named op when dealing with node-based equality.
-fn apply_named_op_on_nodes(env: &Env, op_name: &str, left: &Node, right: &Node) -> f64 {
-    match env.ops.get(op_name) {
+fn apply_named_op_on_nodes(env: &mut Env, op_name: &str, left: &Node, right: &Node) -> f64 {
+    let op = env.ops.get(op_name).cloned();
+    match op {
         Some(Op::Eq) => env.apply_eq(left, right),
         Some(Op::Neq) => env.apply_neq(left, right),
         _ => env.lo,
@@ -1425,6 +1558,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
                             inner: inner.clone(),
                         },
                     );
+                    env.trace("resolve", format!("({}: {} {})", head, outer, inner));
                     return EvalResult::Value(1.0);
                 }
                 // Mirror JS behavior: surface a diagnostic for the missing op.
@@ -1443,6 +1577,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
             if let Node::Leaf(ref sel) = rhs[0] {
                 if let Some(agg) = Aggregator::from_name(sel) {
                     env.define_op(head, Op::Agg(agg));
+                    env.trace("resolve", format!("({}: {})", head, sel));
                     return EvalResult::Value(1.0);
                 } else {
                     panic!("Unknown aggregator \"{}\"", sel);
@@ -1883,6 +2018,26 @@ pub enum RunResult {
 /// full code list.  Errors do not abort evaluation: independent forms
 /// continue to be processed after a failing one.
 pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> EvaluateResult {
+    evaluate_with_options(
+        text,
+        file,
+        EvaluateOptions {
+            env: options,
+            trace: false,
+        },
+    )
+}
+
+/// Like `evaluate`, but takes structured `EvaluateOptions`. When
+/// `options.trace` is true the returned `EvaluateResult.trace` carries a
+/// deterministic sequence of `TraceEvent` values (operator resolutions,
+/// assignment lookups, top-level reductions) — one entry per event,
+/// in source order.
+pub fn evaluate_with_options(
+    text: &str,
+    file: Option<&str>,
+    options: EvaluateOptions,
+) -> EvaluateResult {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     let spans = compute_form_spans(text, file);
 
@@ -1909,7 +2064,9 @@ pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> 
         })
         .collect();
 
-    let mut env = Env::new(options);
+    let mut env = Env::new(options.env);
+    env.trace_enabled = options.trace;
+    env.default_span = Span::new(file.map(|s| s.to_string()), 1, 1, 0);
     let mut results: Vec<RunResult> = Vec::new();
 
     // Silence the default panic hook while we deliberately catch evaluator
@@ -1935,11 +2092,43 @@ pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> 
             .get(idx)
             .cloned()
             .unwrap_or_else(|| Span::new(file.map(|s| s.to_string()), 1, 1, 0));
+        env.current_span = Some(span.clone());
+        // We need to capture the form so the eval-trace event can reference it
+        // by canonical key. Cloning is cheap: AST nodes are small strings.
+        let form_for_trace = if options.trace {
+            Some(form.clone())
+        } else {
+            None
+        };
         let result = catch_unwind(AssertUnwindSafe(|| eval_node(&form, &mut env)));
         match result {
-            Ok(EvalResult::Query(v)) => results.push(RunResult::Num(v)),
-            Ok(EvalResult::TypeQuery(s)) => results.push(RunResult::Type(s)),
-            Ok(_) => {}
+            Ok(eval_res) => {
+                if options.trace {
+                    if let Some(ref form_node) = form_for_trace {
+                        let form_key = key_of(form_node);
+                        let summary = match &eval_res {
+                            EvalResult::Query(v) => format!(
+                                "{} → query {}",
+                                form_key,
+                                format_trace_value(*v)
+                            ),
+                            EvalResult::TypeQuery(s) => {
+                                format!("{} → type {}", form_key, s)
+                            }
+                            EvalResult::Value(v) => {
+                                format!("{} → {}", form_key, format_trace_value(*v))
+                            }
+                        };
+                        env.trace_events
+                            .push(TraceEvent::new("eval", summary, span.clone()));
+                    }
+                }
+                match eval_res {
+                    EvalResult::Query(v) => results.push(RunResult::Num(v)),
+                    EvalResult::TypeQuery(s) => results.push(RunResult::Type(s)),
+                    _ => {}
+                }
+            }
             Err(payload) => {
                 let (code, message) = decode_panic_payload(&payload);
                 diagnostics.push(Diagnostic::new(&code, message, span));
@@ -1947,11 +2136,20 @@ pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> 
         }
     }
 
+    env.current_span = None;
+
     std::panic::set_hook(prev_hook);
+
+    let trace = if options.trace {
+        std::mem::take(&mut env.trace_events)
+    } else {
+        Vec::new()
+    };
 
     EvaluateResult {
         results,
         diagnostics,
+        trace,
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,16 +1,27 @@
 // RML CLI — run a LiNo knowledge base and print query results
-use rml::{evaluate, format_diagnostic, RunResult};
+use rml::{
+    evaluate_with_options, format_diagnostic, format_trace_event, EvaluateOptions, RunResult,
+};
 use std::env;
 use std::fs;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: rml <kb.lino>");
+    let mut trace = false;
+    let mut positionals: Vec<String> = Vec::new();
+    for arg in args.iter().skip(1) {
+        if arg == "--trace" {
+            trace = true;
+        } else {
+            positionals.push(arg.clone());
+        }
+    }
+    if positionals.is_empty() {
+        eprintln!("Usage: rml [--trace] <kb.lino>");
         return ExitCode::from(1);
     }
-    let file = &args[1];
+    let file = &positionals[0];
     let text = match fs::read_to_string(file) {
         Ok(t) => t,
         Err(e) => {
@@ -18,7 +29,19 @@ fn main() -> ExitCode {
             return ExitCode::from(1);
         }
     };
-    let evaluation = evaluate(&text, Some(file), None);
+    let evaluation = evaluate_with_options(
+        &text,
+        Some(file),
+        EvaluateOptions {
+            env: None,
+            trace,
+        },
+    );
+    if trace {
+        for event in &evaluation.trace {
+            eprintln!("{}", format_trace_event(event));
+        }
+    }
     for v in evaluation.results {
         match v {
             RunResult::Num(n) => {

--- a/rust/tests/trace_tests.rs
+++ b/rust/tests/trace_tests.rs
@@ -1,0 +1,186 @@
+// Tests for evaluation trace mode (issue #30).
+// Mirrors js/tests/trace.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{
+    evaluate, evaluate_with_options, format_trace_event, EvaluateOptions, TraceEvent,
+};
+
+const DEMO: &str = "(a: a is a)\n\
+(!=: not =)\n\
+(and: avg)\n\
+((a = a) has probability 1)\n\
+((a != a) has probability 0)\n\
+(? ((a = a) and (a != a)))";
+
+fn trace_demo() -> Vec<TraceEvent> {
+    let out = evaluate_with_options(
+        DEMO,
+        Some("demo.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    out.trace
+}
+
+#[test]
+fn evaluate_without_trace_returns_empty_trace() {
+    let out = evaluate("(? 1)", Some("q.lino"), None);
+    assert!(out.trace.is_empty());
+}
+
+#[test]
+fn evaluate_with_trace_returns_non_empty_trace() {
+    let trace = trace_demo();
+    assert!(!trace.is_empty());
+    for ev in &trace {
+        assert!(matches!(
+            ev.kind.as_str(),
+            "resolve" | "assign" | "lookup" | "eval"
+        ));
+        assert_eq!(ev.span.file.as_deref(), Some("demo.lino"));
+        assert!(ev.span.line >= 1);
+        assert!(ev.span.col >= 1);
+    }
+}
+
+#[test]
+fn trace_is_deterministic_across_runs() {
+    let a = trace_demo();
+    let b = trace_demo();
+    let fmt = |events: &[TraceEvent]| -> String {
+        events
+            .iter()
+            .map(format_trace_event)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    assert_eq!(fmt(&a), fmt(&b));
+}
+
+#[test]
+fn trace_does_not_affect_results_or_diagnostics() {
+    let plain = evaluate(DEMO, Some("demo.lino"), None);
+    let traced = evaluate_with_options(
+        DEMO,
+        Some("demo.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    assert_eq!(plain.results, traced.results);
+    assert_eq!(plain.diagnostics, traced.diagnostics);
+}
+
+#[test]
+fn resolve_event_for_aggregator_redef() {
+    let out = evaluate_with_options(
+        "(and: avg)",
+        Some("op.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    let resolves: Vec<_> = out
+        .trace
+        .iter()
+        .filter(|e| e.kind == "resolve")
+        .collect();
+    assert_eq!(resolves.len(), 1);
+    assert_eq!(resolves[0].detail, "(and: avg)");
+    assert_eq!(resolves[0].span.file.as_deref(), Some("op.lino"));
+    assert_eq!(resolves[0].span.line, 1);
+    assert_eq!(resolves[0].span.col, 1);
+}
+
+#[test]
+fn assign_event_for_probability_form() {
+    let out = evaluate_with_options(
+        "((a = a) has probability 1)",
+        Some("p.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    let assigns: Vec<_> = out
+        .trace
+        .iter()
+        .filter(|e| e.kind == "assign")
+        .collect();
+    assert_eq!(assigns.len(), 1);
+    assert_eq!(assigns[0].detail, "(a = a) ← 1");
+    assert_eq!(assigns[0].span.line, 1);
+}
+
+#[test]
+fn lookup_event_when_assigned_equality_fires() {
+    let src = "((a = a) has probability 0.7)\n(? (a = a))";
+    let out = evaluate_with_options(
+        src,
+        Some("lk.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    let lookups: Vec<_> = out
+        .trace
+        .iter()
+        .filter(|e| e.kind == "lookup")
+        .collect();
+    assert!(!lookups.is_empty());
+    assert!(
+        lookups[0].detail.contains("(a = a) → 0.7"),
+        "detail was: {}",
+        lookups[0].detail
+    );
+    assert_eq!(lookups[0].span.line, 2);
+}
+
+#[test]
+fn eval_event_per_top_level_form() {
+    let trace = trace_demo();
+    let evals: Vec<_> = trace.iter().filter(|e| e.kind == "eval").collect();
+    // One eval event per top-level form (6 forms in DEMO).
+    assert_eq!(evals.len(), 6);
+    let last = evals.last().unwrap();
+    assert!(
+        last.detail.ends_with("→ query 0.5"),
+        "detail was: {}",
+        last.detail
+    );
+    assert_eq!(last.span.line, 6);
+}
+
+#[test]
+fn format_trace_event_renders_span_kind_detail() {
+    let out = evaluate_with_options(
+        "(and: avg)",
+        Some("fmt.lino"),
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    let line = format_trace_event(&out.trace[0]);
+    assert_eq!(line, "[span fmt.lino:1:1] resolve (and: avg)");
+}
+
+#[test]
+fn format_trace_event_falls_back_to_input_when_no_file() {
+    let out = evaluate_with_options(
+        "(and: avg)",
+        None,
+        EvaluateOptions {
+            env: None,
+            trace: true,
+        },
+    );
+    let line = format_trace_event(&out.trace[0]);
+    assert_eq!(line, "[span <input>:1:1] resolve (and: avg)");
+}


### PR DESCRIPTION
Fixes #30.

## Summary

Adds an opt-in **trace mode** that records a deterministic, reproducible sequence of evaluator events — operator resolutions, probability assignments, equality lookups, and one summary per top-level form — each tagged with a \`file:line:col\` span. Both the JavaScript and Rust runtimes share the same event shape, formatting, and ordering, so the same input produces the same trace lines in either implementation.

This branch is now merged with main (includes REPL from #100).

## What's new

- **CLI flag** \`--trace\` on both runners writes one event per line to **stderr** in source order:
  \`\`\`sh
  node js/src/rml-links.mjs --trace examples/demo.lino
  rml --trace examples/demo.lino
  \`\`\`
  Query results still go to stdout, so piping a script through trace mode does not disturb downstream tools.

- **REPL compatibility**: \`rml repl\` subcommand (from #100) works alongside \`--trace\`. The CLI usage is now:
  \`\`\`
  rml [--trace] <kb.lino>   |   rml repl
  \`\`\`

- **Library API**:
  - JS: \`evaluate(source, { file, trace: true })\` → \`{ results, diagnostics, trace }\` plus a new \`formatTraceEvent\` helper.
  - Rust: new \`evaluate_with_options(text, file, EvaluateOptions { env, trace })\` → \`EvaluateResult { results, diagnostics, trace }\` plus \`format_trace_event\`. The original \`evaluate\` and new \`evaluate_with_env\` (used by REPL) keep their signatures.

- **Output format**:
  \`\`\`
  [span <file>:<line>:<col>] <kind> <details>
  \`\`\`
  Falls back to \`<input>\` when no file is provided.

- **Event kinds**:
  | Kind      | Emitted when |
  |-----------|--------------|
  | \`resolve\` | An operator definition or aggregator selection runs, e.g. \`(and: avg)\` or \`(!=: not =)\`. |
  | \`assign\`  | A probability assignment runs: \`((expr) has probability v)\`. Detail is \`<expr-key> ← <clamped value>\`. |
  | \`lookup\`  | An equality \`(L = R)\` (or its inequality) finds a previously assigned probability. |
  | \`eval\`    | A top-level form finishes evaluating. Detail is \`<form-key> → <summary>\` (\`query <v>\`, \`type <t>\`, or just the value). |

- **Determinism**: top-level forms are processed in source order, operator hooks fire in a fixed order, and numbers are normalized through the same \`formatTraceValue\` helper in both runtimes. Two runs on the same input produce identical traces, and the JS and Rust implementations produce the same trace lines for the same input — both properties are exercised by the new test suites.

## Example

Running either CLI on \`examples/demo.lino\` with \`--trace\` prints (to stderr):

\`\`\`
[span examples/demo.lino:5:1] resolve (!=: not =)
[span examples/demo.lino:6:1] resolve (and: avg)
[span examples/demo.lino:7:1] resolve (or: max)
[span examples/demo.lino:10:1] assign (a = a) ← 1
[span examples/demo.lino:14:1] lookup (a = a) → 1
[span examples/demo.lino:14:1] eval (? ((a = a) and (a != a))) → query 0.5
\`\`\`

## Test plan

- [x] \`cd js && node --test tests/\` — 454 tests pass (10 new in \`js/tests/trace.test.mjs\`)
- [x] \`cd rust && cargo test\` — 292 tests pass (10 new in \`rust/tests/trace_tests.rs\`, mirroring the JS suite)
- [x] Cross-runtime parity: ran both CLIs on \`examples/demo.lino --trace\`; outputs are byte-identical
- [x] \`--trace\` does not affect \`results\` or \`diagnostics\`
- [x] Trace is deterministic across repeated runs
- [x] Documentation: new "Trace mode" section in \`docs/DIAGNOSTICS.md\`
- [x] Merged with main: REPL (\`rml repl\`) and trace (\`--trace\`) coexist correctly