### PR TITLE
[A5] English-readability lint for `lib/` and `examples/`

### DIFF
--- a/.github/workflows/lint-english.yml
+++ b/.github/workflows/lint-english.yml
@@ -1,0 +1,21 @@
+name: lint-english
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-english:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Lint examples for English readability
+        run: node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino
+      - name: Run lint unit tests
+        run: node --test scripts/lint-english.test.mjs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T15:50:40.314Z for PR creation at branch issue-32-a4e1d0c6a4f0 for issue https://github.com/link-foundation/relative-meta-logic/issues/32

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T15:50:40.314Z for PR creation at branch issue-32-a4e1d0c6a4f0 for issue https://github.com/link-foundation/relative-meta-logic/issues/32

--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ The test suites cover:
 - Markov chains: one-step and multi-step transitions, joint probability, stationary distribution, conditional transitions with links
 - Markov networks: cyclic graphs, pairwise joints, three-way cliques, clique potentials, normalization
 - Comprehensive valence coverage: 0 (continuous), 1 (unary), 2–10, 100, 1000, with both ranges
+- English-readability lint: identifier shape, operator-only links, allow-list (see [English-readability lint](#english-readability-lint))
 
 ## API
 
@@ -680,6 +681,48 @@ checker error carries a stable code (`E001`, …), a message, and a 1-based
 source span. The CLIs print them as `file:line:col: Exxx: message` with a
 caret under the offending token. See [docs/DIAGNOSTICS.md](./docs/DIAGNOSTICS.md)
 for the full code list and usage examples.
+
+## English-readability lint
+
+Every link in `examples/` (and, when introduced, `lib/`) is expected to read
+as an English sentence. A small lint script enforces the conventions:
+
+```bash
+node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino
+# or, from the JS package:
+(cd js && npm run lint:english)
+```
+
+The lint reports two classes of violation in `file:line:col: code: message`
+form (the same shape used by structured diagnostics):
+
+- `identifiers-without-hyphens` — identifiers that combine multiple words
+  with `_` or `camelCase` instead of `kebab-case`. The lint suggests the
+  hyphenated form (e.g. `wet_grass` → `wet-grass`).
+- `operator-only-link` — an operator definition such as `(@: + -)` whose
+  body contains no English word. The lint suggests adding a word-form
+  alternative (e.g. `(equals: =)`, `(plus: +)`).
+
+Reserved RML/LiNo vocabulary (`and`, `or`, `not`, `is`, `has`, `probability`,
+`true`, `false`, `unknown`, `Type`, `lambda`, …) is never flagged, and
+single-word identifiers (`alice`, `cloudy`, `Natural`) are accepted as-is.
+
+### Allow-list
+
+For deliberate exceptions, `scripts/lint-english.allowlist.json` accepts
+two arrays:
+
+```json
+{
+  "identifiers": ["legacy_name"],
+  "links": ["demo.lino:5"]
+}
+```
+
+Identifiers in `identifiers` are silenced wherever they appear; entries in
+`links` are keyed by `<basename>:<line>` and silence the
+`operator-only-link` rule for that specific definition. CI runs the lint
+with this file so any new violation fails the build.
 
 ## References
 

--- a/examples/bayesian-network.lino
+++ b/examples/bayesian-network.lino
@@ -19,7 +19,7 @@
 (cloudy: cloudy is cloudy)
 (sprinkler: sprinkler is sprinkler)
 (rain: rain is rain)
-(wet_grass: wet_grass is wet_grass)
+(wet-grass: wet-grass is wet-grass)
 
 # Configure probabilistic operators
 (and: product)              # P(A ∩ B) = P(A) * P(B) for independent events
@@ -33,8 +33,8 @@
 # Directed conditional dependencies (cause → effect):
 # cloudy → sprinkler: P(Sprinkler | Cloudy)
 # cloudy → rain:      P(Rain | Cloudy)
-# sprinkler → wet_grass: P(WetGrass | Sprinkler)
-# rain → wet_grass:      P(WetGrass | Rain)
+# sprinkler → wet-grass: P(WetGrass | Sprinkler)
+# rain → wet-grass:      P(WetGrass | Rain)
 
 # Query marginal probabilities
 (? (cloudy = true))                          # -> 0.5

--- a/examples/self-reasoning.lino
+++ b/examples/self-reasoning.lino
@@ -13,22 +13,22 @@
 (RML: Logic RML)
 
 # Define properties that logics can have
-(supports_many_valued: Property supports_many_valued)
-(supports_self_reference: Property supports_self_reference)
-(resolves_paradoxes: Property resolves_paradoxes)
-(is_meta_logic: Property is_meta_logic)
+(supports-many-valued: Property supports-many-valued)
+(supports-self-reference: Property supports-self-reference)
+(resolves-paradoxes: Property resolves-paradoxes)
+(is-meta-logic: Property is-meta-logic)
 
 # RML has these properties (with full confidence)
-(((RML supports_many_valued) = true) has probability 1)
-(((RML supports_self_reference) = true) has probability 1)
-(((RML resolves_paradoxes) = true) has probability 1)
-(((RML is_meta_logic) = true) has probability 1)
+(((RML supports-many-valued) = true) has probability 1)
+(((RML supports-self-reference) = true) has probability 1)
+(((RML resolves-paradoxes) = true) has probability 1)
+(((RML is-meta-logic) = true) has probability 1)
 
 # Query: Does RML support many-valued logic?
-(? ((RML supports_many_valued) = true))           # -> 1
+(? ((RML supports-many-valued) = true))           # -> 1
 
 # Query: Is RML a meta-logic?
-(? ((RML is_meta_logic) = true))                   # -> 1
+(? ((RML is-meta-logic) = true))                   # -> 1
 
 # Self-reference: RML can reason about itself being a logic
 (? (RML of Logic))                                 # -> 1
@@ -37,11 +37,11 @@
 
 # Define another logic (Classical) and compare
 (Classical: Logic Classical)
-(((Classical supports_many_valued) = true) has probability 0)
-(((Classical supports_self_reference) = true) has probability 0)
+(((Classical supports-many-valued) = true) has probability 0)
+(((Classical supports-self-reference) = true) has probability 0)
 
 # Compare: does Classical support self-reference?
-(? ((Classical supports_self_reference) = true))   # -> 0
+(? ((Classical supports-self-reference) = true))   # -> 0
 
 # RML can reason about the liar paradox within its own system
 (liar: liar is liar)

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,12 +1,13 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",
   "scripts": {
-    "test": "node --test",
-    "demo": "node src/rml-links.mjs ../examples/demo.lino"
+    "test": "node --test tests/ ../scripts/",
+    "demo": "node src/rml-links.mjs ../examples/demo.lino",
+    "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino"
   },
   "keywords": [
     "logic",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/scripts/lint-english.allowlist.json
+++ b/scripts/lint-english.allowlist.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Allow-list for scripts/lint-english.mjs. Every entry is a deliberate exception that should still read as English in context. Add inline reasons in this file's history (commit messages / PR descriptions).",
+  "identifiers": [],
+  "links": []
+}

--- a/scripts/lint-english.mjs
+++ b/scripts/lint-english.mjs
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+// English-readability lint for `.lino` files.
+//
+// Heuristically flags links that drift away from the design promise that
+// every link should read as an English sentence. Two classes of violation
+// are reported:
+//
+//   identifiers-without-hyphens  — multi-word identifiers that use `_` or
+//                                  run-together camelCase / lower-case words
+//                                  instead of `kebab-case`.
+//   operator-only-link           — top-level links whose body contains no
+//                                  word-form alternative (purely operator
+//                                  characters, numbers and punctuation).
+//
+// Usage: node scripts/lint-english.mjs <files...>
+//        node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino
+//
+// Exits with a non-zero status when any violation is reported. An allow-list
+// file (JSON) may contain `identifiers` (array of strings) and `links`
+// (array of `file:line` strings) to silence specific known cases.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+// ---------- Reserved vocabulary ----------
+// Built-in operators and keywords are part of the RML/LiNo surface and must
+// not be flagged when they appear as identifiers. They are the natural
+// English-readable spelling on their own.
+const RESERVED_KEYWORDS = new Set([
+  // Operators (symbols)
+  '=', '!=', '+', '-', '*', '/', '?', ':',
+  // Logical connectives & prepositions
+  'is', 'has', 'probability', 'of', 'not', 'and', 'or',
+  'both', 'neither', 'nor',
+  // Configuration
+  'range', 'valence',
+  // Truth constants
+  'true', 'false', 'unknown', 'undefined',
+  // Aggregator names
+  'min', 'max', 'avg', 'product', 'prod', 'probabilistic_sum', 'ps',
+  // Type system
+  'Type', 'type', 'apply', 'lambda', 'Pi',
+]);
+
+// Word-form alternatives that count as making a link "read as English".
+// A link that references at least one of these (or any plain alphabetic
+// identifier) avoids the operator-only-link rule.
+//
+// Note: numeric literals do not count.
+const ENGLISH_WORD_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
+
+// ---------- Tokenizer ----------
+// Each token is `{ value, line, col, length }` with 1-based positions.
+// Comments (`#` to end of line) are stripped but their newlines preserved.
+function tokenize(source) {
+  const tokens = [];
+  let line = 1;
+  let col = 1;
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '\n') { line++; col = 1; i++; continue; }
+    if (ch === '\r') { i++; continue; }
+    if (/\s/.test(ch)) { col++; i++; continue; }
+    if (ch === '#') {
+      while (i < source.length && source[i] !== '\n') { i++; col++; }
+      continue;
+    }
+    if (ch === '(' || ch === ')') {
+      tokens.push({ value: ch, line, col, length: 1 });
+      i++; col++; continue;
+    }
+    // Atom: collect until whitespace, parenthesis, or comment marker
+    const startLine = line;
+    const startCol = col;
+    let j = i;
+    while (j < source.length) {
+      const cj = source[j];
+      if (cj === '(' || cj === ')' || cj === '#' || /\s/.test(cj)) break;
+      j++;
+    }
+    tokens.push({
+      value: source.slice(i, j),
+      line: startLine,
+      col: startCol,
+      length: j - i,
+    });
+    col += j - i;
+    i = j;
+  }
+  return tokens;
+}
+
+// ---------- Parser: a tree of tokens preserving source positions ----------
+function parseLinks(tokens) {
+  const links = [];
+  let i = 0;
+  function readNode() {
+    const tok = tokens[i];
+    if (tok.value === '(') {
+      const open = tok;
+      i++;
+      const children = [];
+      while (i < tokens.length && tokens[i].value !== ')') {
+        children.push(readNode());
+      }
+      if (i >= tokens.length) {
+        throw new Error(`Unmatched "(" at line ${open.line}:${open.col}`);
+      }
+      i++; // consume ')'
+      return { kind: 'list', children, line: open.line, col: open.col };
+    }
+    if (tok.value === ')') {
+      throw new Error(`Unmatched ")" at line ${tok.line}:${tok.col}`);
+    }
+    i++;
+    return { kind: 'atom', value: tok.value, line: tok.line, col: tok.col, length: tok.length };
+  }
+  while (i < tokens.length) {
+    if (tokens[i].value !== '(') {
+      throw new Error(`Expected "(" at line ${tokens[i].line}:${tokens[i].col}, got "${tokens[i].value}"`);
+    }
+    links.push(readNode());
+  }
+  return links;
+}
+
+// ---------- Identifier collection ----------
+function* walkAtoms(node) {
+  if (node.kind === 'atom') {
+    yield node;
+    return;
+  }
+  for (const child of node.children) yield* walkAtoms(child);
+}
+
+const NUMERIC_RE = /^-?(\d+(\.\d+)?|\.\d+)$/;
+
+function isNumeric(value) {
+  return NUMERIC_RE.test(value);
+}
+
+function isReserved(value) {
+  return RESERVED_KEYWORDS.has(value);
+}
+
+// ---------- Rule 1: identifiers-without-hyphens ----------
+// Flags identifiers that appear to combine multiple English words without a
+// hyphen separator. The heuristic catches:
+//   - underscores: foo_bar           → suggest foo-bar
+//   - lowerCamelCase: fooBar         → suggest foo-bar
+//   - PascalCase across >1 word with all-lower neighbours: e.g. fooBar (above)
+//
+// Single-word lowercase identifiers (`alice`, `cloudy`) are fine.
+// Single-word PascalCase type names (`Natural`, `Boolean`, `Type`) are fine.
+function suggestKebab(value) {
+  // Replace underscores with hyphens, then split camelCase boundaries.
+  const replaced = value
+    .replace(/_/g, '-')
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2');
+  // Avoid leading capitals affecting the suggestion when the original was lower.
+  return replaced.toLowerCase();
+}
+
+function checkIdentifierShape(value) {
+  if (isReserved(value)) return null;
+  if (isNumeric(value)) return null;
+  // Allow pure-symbol operator-style atoms here — those are caught by rule 2.
+  if (!/[A-Za-z]/.test(value)) return null;
+
+  // Underscores are an explicit violation.
+  if (value.includes('_')) {
+    return {
+      code: 'identifiers-without-hyphens',
+      message: `identifier "${value}" uses "_"; prefer hyphen-case "${suggestKebab(value)}"`,
+    };
+  }
+
+  // CamelCase that is NOT a single PascalCase word.
+  // A pure PascalCase single word like `Natural` matches /^[A-Z][a-z0-9]*$/.
+  // A pure lowercase single word like `alice` matches /^[a-z][a-z0-9]*$/.
+  // Anything else with internal capital boundaries is flagged.
+  const isPascalSingle = /^[A-Z][a-z0-9]*$/.test(value);
+  const isLowerSingle = /^[a-z][a-z0-9]*$/.test(value);
+  const isAlreadyKebab = /^[A-Za-z][A-Za-z0-9]*(-[A-Za-z0-9]+)+$/.test(value);
+  if (isPascalSingle || isLowerSingle || isAlreadyKebab) return null;
+
+  // Detect a camelCase / mixed-case multi-word identifier: at least one
+  // lower-then-upper transition (`fooBar`).
+  if (/[a-z][A-Z]/.test(value)) {
+    return {
+      code: 'identifiers-without-hyphens',
+      message: `identifier "${value}" uses camelCase; prefer hyphen-case "${suggestKebab(value)}"`,
+    };
+  }
+
+  return null;
+}
+
+// ---------- Rule 2: operator-only-link ----------
+// A top-level link is "operator-only" when its body contains no word-form
+// alternative — every atom is either a symbol/operator from RESERVED_KEYWORDS
+// or a numeric literal. Such a link does not read as an English sentence.
+//
+// Exceptions:
+//   - The empty link `()` is not flagged (parser tolerance).
+//   - A bare query of a numeric expression like `(? 0.5)` IS flagged because
+//     it conveys nothing in English — though numeric calculations like
+//     `(? (0.1 + 0.2))` are also flagged. To keep the lint useful without
+//     over-firing on the bayesian / markov examples that legitimately probe
+//     arithmetic, we only flag operator-only DEFINITIONS, not queries.
+function isOperatorOnlyDefinition(node) {
+  if (node.kind !== 'list') return false;
+  // Look at the head token to spot definitions: `(head: ...)` form.
+  // The tokenizer keeps `:` attached to the head when written as `head:`,
+  // so we recognise both `(name:` and `(name :` shapes.
+  const children = node.children;
+  if (children.length < 1) return false;
+  const head = children[0];
+  // Find a definition shape: head atom ending in ':' OR second atom equal to ':'.
+  let definedName = null;
+  if (head.kind === 'atom' && head.value.endsWith(':') && head.value.length > 1) {
+    definedName = head.value.slice(0, -1);
+  } else if (head.kind === 'atom' && children[1] && children[1].kind === 'atom' && children[1].value === ':') {
+    definedName = head.value;
+  }
+  if (definedName == null) return false;
+
+  // Skip queries, anything that is not a definition.
+  if (definedName === '?' || definedName === '') return false;
+  // The defined name itself must be operator-only (no letters).
+  if (/[A-Za-z]/.test(definedName)) return false;
+  // Numeric "definitions" don't really happen in valid lino, but skip just in case.
+  if (isNumeric(definedName)) return false;
+  // Allowed operator-only definitions still need a word-form alternative; the
+  // fact that they are defined with operator-only body is what we flag.
+  // Any alphabetic atom in the body counts as an English word form, including
+  // reserved connectives like `not`, `and`, `is` — those make a definition
+  // such as `(!=: not =)` read as "!= is not equals", which is the desired
+  // shape.
+  for (const atom of walkAtoms(node)) {
+    // Skip the head's defined name itself.
+    if (atom === head) continue;
+    if (atom.value === ':') continue;
+    if (ENGLISH_WORD_RE.test(atom.value)) {
+      // A word-form atom appears in the body — link is not operator-only.
+      return false;
+    }
+  }
+  return { name: definedName };
+}
+
+// ---------- Allow-list ----------
+function loadAllowlist(allowlistPath) {
+  const empty = { identifiers: new Set(), links: new Set() };
+  if (!allowlistPath) return empty;
+  if (!fs.existsSync(allowlistPath)) {
+    throw new Error(`Allow-list file not found: ${allowlistPath}`);
+  }
+  const raw = fs.readFileSync(allowlistPath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Allow-list file is not valid JSON (${allowlistPath}): ${e.message}`);
+  }
+  return {
+    identifiers: new Set(Array.isArray(parsed.identifiers) ? parsed.identifiers : []),
+    links: new Set(Array.isArray(parsed.links) ? parsed.links : []),
+  };
+}
+
+// ---------- Lint a single file ----------
+function lintFile(filePath, source, allowlist) {
+  const violations = [];
+  let tokens;
+  try {
+    tokens = tokenize(source);
+  } catch (e) {
+    violations.push({
+      file: filePath,
+      line: 1,
+      col: 1,
+      code: 'parse-error',
+      message: `tokenizer error: ${e.message}`,
+    });
+    return violations;
+  }
+  let links;
+  try {
+    links = parseLinks(tokens);
+  } catch (e) {
+    violations.push({
+      file: filePath,
+      line: 1,
+      col: 1,
+      code: 'parse-error',
+      message: e.message,
+    });
+    return violations;
+  }
+
+  for (const link of links) {
+    // Rule 2: operator-only definition.
+    const opOnly = isOperatorOnlyDefinition(link);
+    if (opOnly) {
+      const linkKey = `${path.basename(filePath)}:${link.line}`;
+      if (!allowlist.links.has(linkKey)) {
+        violations.push({
+          file: filePath,
+          line: link.line,
+          col: link.col,
+          code: 'operator-only-link',
+          message: `definition of operator "${opOnly.name}" has no English word-form alternative; consider adding e.g. (${suggestWordForm(opOnly.name)}: ${opOnly.name})`,
+        });
+      }
+    }
+
+    // Rule 1: identifier shape — applied to every atom in the link.
+    for (const atom of walkAtoms(link)) {
+      // Strip a trailing ':' that the tokenizer keeps attached to definition heads.
+      let value = atom.value;
+      if (value.endsWith(':') && value.length > 1) value = value.slice(0, -1);
+      if (allowlist.identifiers.has(value)) continue;
+      const finding = checkIdentifierShape(value);
+      if (finding) {
+        violations.push({
+          file: filePath,
+          line: atom.line,
+          col: atom.col,
+          code: finding.code,
+          message: finding.message,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+// Suggest a plausible English word form for a known operator.
+const OPERATOR_WORD_FORMS = {
+  '=': 'equals',
+  '!=': 'differs-from',
+  '+': 'plus',
+  '-': 'minus',
+  '*': 'times',
+  '/': 'divided-by',
+};
+function suggestWordForm(op) {
+  return OPERATOR_WORD_FORMS[op] || `${op}-word-form`;
+}
+
+// ---------- CLI ----------
+function parseArgs(argv) {
+  const out = { files: [], allowlist: null, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') { out.help = true; continue; }
+    if (a === '--allowlist') {
+      out.allowlist = argv[++i];
+      continue;
+    }
+    if (a.startsWith('--allowlist=')) {
+      out.allowlist = a.slice('--allowlist='.length);
+      continue;
+    }
+    out.files.push(a);
+  }
+  return out;
+}
+
+function printHelp() {
+  process.stdout.write([
+    'Usage: node scripts/lint-english.mjs [--allowlist <path>] <files...>',
+    '',
+    'Flags links that violate the project\'s English-readability conventions:',
+    '  identifiers-without-hyphens  identifiers with `_` or camelCase',
+    '  operator-only-link           operator definitions with no word form',
+    '',
+    'The optional allow-list is a JSON file with two arrays: `identifiers`',
+    'and `links` (entries of the form "<basename>:<line>"). Listed entries',
+    'are exempted from their respective rule.',
+    '',
+  ].join('\n'));
+}
+
+function formatViolation(v) {
+  return `${v.file}:${v.line}:${v.col}: ${v.code}: ${v.message}`;
+}
+
+function main(argv) {
+  const args = parseArgs(argv);
+  if (args.help) { printHelp(); return 0; }
+  if (args.files.length === 0) {
+    process.stderr.write('No files supplied. See --help.\n');
+    return 2;
+  }
+  let allowlist;
+  try {
+    allowlist = loadAllowlist(args.allowlist);
+  } catch (e) {
+    process.stderr.write(`${e.message}\n`);
+    return 2;
+  }
+
+  let total = 0;
+  for (const file of args.files) {
+    let source;
+    try {
+      source = fs.readFileSync(file, 'utf8');
+    } catch (e) {
+      process.stderr.write(`${file}: cannot read (${e.message})\n`);
+      total++;
+      continue;
+    }
+    const violations = lintFile(file, source, allowlist);
+    for (const v of violations) {
+      process.stdout.write(`${formatViolation(v)}\n`);
+    }
+    total += violations.length;
+  }
+
+  if (total === 0) {
+    process.stdout.write(`lint-english: ${args.files.length} file(s) clean.\n`);
+    return 0;
+  }
+  process.stdout.write(`lint-english: ${total} violation(s) in ${args.files.length} file(s).\n`);
+  return 1;
+}
+
+// Exports for tests.
+export {
+  tokenize,
+  parseLinks,
+  checkIdentifierShape,
+  isOperatorOnlyDefinition,
+  lintFile,
+  loadAllowlist,
+  suggestKebab,
+  suggestWordForm,
+};
+
+// Run as CLI when invoked directly.
+const invokedDirectly = (() => {
+  try {
+    const thisFile = path.resolve(new URL(import.meta.url).pathname);
+    const argv1 = process.argv[1] ? path.resolve(process.argv[1]) : '';
+    return thisFile === argv1;
+  } catch { return false; }
+})();
+if (invokedDirectly) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/lint-english.test.mjs
+++ b/scripts/lint-english.test.mjs
@@ -1,0 +1,285 @@
+// Tests for the English-readability lint (issue #32).
+//
+// Run with: node --test scripts/lint-english.test.mjs
+// Or via the JS package script: (cd js && npm run lint-english:test)
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import {
+  tokenize,
+  parseLinks,
+  checkIdentifierShape,
+  isOperatorOnlyDefinition,
+  lintFile,
+  loadAllowlist,
+  suggestKebab,
+  suggestWordForm,
+} from './lint-english.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(__dirname, 'lint-english.mjs');
+
+function lintSource(source, file = 'inline.lino', allowlist = { identifiers: new Set(), links: new Set() }) {
+  return lintFile(file, source, allowlist);
+}
+
+describe('tokenize()', () => {
+  it('strips comments and tracks 1-based positions', () => {
+    const tokens = tokenize('# header\n(a: a is a)  # tail comment\n');
+    assert.deepStrictEqual(tokens.map(t => t.value), ['(', 'a:', 'a', 'is', 'a', ')']);
+    assert.strictEqual(tokens[0].line, 2);
+    assert.strictEqual(tokens[0].col, 1);
+    assert.strictEqual(tokens[1].line, 2);
+    assert.strictEqual(tokens[1].col, 2);
+  });
+});
+
+describe('parseLinks()', () => {
+  it('builds a tree of nested lists and atoms', () => {
+    const ast = parseLinks(tokenize('(a: a is a)'));
+    assert.strictEqual(ast.length, 1);
+    assert.strictEqual(ast[0].kind, 'list');
+    assert.strictEqual(ast[0].children.length, 4);
+    assert.strictEqual(ast[0].children[0].value, 'a:');
+  });
+
+  it('reports unmatched parens', () => {
+    assert.throws(() => parseLinks(tokenize('(a: a is a')), /Unmatched/);
+    assert.throws(() => parseLinks(tokenize('a: a is a)')), /Expected/);
+  });
+});
+
+describe('checkIdentifierShape()', () => {
+  it('flags underscore identifiers', () => {
+    const f = checkIdentifierShape('foo_bar');
+    assert.ok(f);
+    assert.strictEqual(f.code, 'identifiers-without-hyphens');
+    assert.match(f.message, /foo-bar/);
+  });
+
+  it('flags camelCase identifiers', () => {
+    const f = checkIdentifierShape('fooBar');
+    assert.ok(f);
+    assert.match(f.message, /foo-bar/);
+  });
+
+  it('accepts single-word lowercase identifiers', () => {
+    assert.strictEqual(checkIdentifierShape('alice'), null);
+    assert.strictEqual(checkIdentifierShape('cloudy'), null);
+  });
+
+  it('accepts single-word PascalCase type names', () => {
+    assert.strictEqual(checkIdentifierShape('Natural'), null);
+    assert.strictEqual(checkIdentifierShape('Boolean'), null);
+    assert.strictEqual(checkIdentifierShape('Type'), null);
+  });
+
+  it('accepts already-hyphenated identifiers', () => {
+    assert.strictEqual(checkIdentifierShape('wet-grass'), null);
+    assert.strictEqual(checkIdentifierShape('supports-many-valued'), null);
+    assert.strictEqual(checkIdentifierShape('true-val'), null);
+  });
+
+  it('does not flag reserved keywords or symbols', () => {
+    for (const k of ['and', 'or', 'not', 'is', 'has', 'probability', 'true', 'false',
+                     'unknown', 'undefined', 'both', 'neither', 'nor', 'min', 'max',
+                     'product', 'probabilistic_sum', 'avg', 'Type', 'type', 'apply',
+                     'lambda', 'Pi', 'range', 'valence', '=', '!=', '+', '-', '*', '/']) {
+      assert.strictEqual(checkIdentifierShape(k), null, `should not flag reserved "${k}"`);
+    }
+  });
+
+  it('does not flag numeric literals', () => {
+    assert.strictEqual(checkIdentifierShape('0.5'), null);
+    assert.strictEqual(checkIdentifierShape('-1'), null);
+    assert.strictEqual(checkIdentifierShape('42'), null);
+  });
+});
+
+describe('suggestKebab()', () => {
+  it('lowercases and joins underscores with hyphens', () => {
+    assert.strictEqual(suggestKebab('foo_bar'), 'foo-bar');
+    assert.strictEqual(suggestKebab('supports_many_valued'), 'supports-many-valued');
+  });
+  it('splits camelCase boundaries', () => {
+    assert.strictEqual(suggestKebab('fooBar'), 'foo-bar');
+    assert.strictEqual(suggestKebab('XMLHttpRequest'), 'xml-http-request');
+  });
+});
+
+describe('isOperatorOnlyDefinition()', () => {
+  it('flags operator-only definition with a body containing no English word', () => {
+    const ast = parseLinks(tokenize('(@: + -)'));
+    assert.ok(isOperatorOnlyDefinition(ast[0]));
+  });
+
+  it('does not flag operator-only definition with English connective in body', () => {
+    const ast = parseLinks(tokenize('(!=: not =)'));
+    assert.strictEqual(isOperatorOnlyDefinition(ast[0]), false);
+  });
+
+  it('does not flag definitions whose head is a regular identifier', () => {
+    const ast = parseLinks(tokenize('(a: a is a)'));
+    assert.strictEqual(isOperatorOnlyDefinition(ast[0]), false);
+  });
+
+  it('does not flag queries', () => {
+    const ast = parseLinks(tokenize('(? (0.1 + 0.2))'));
+    assert.strictEqual(isOperatorOnlyDefinition(ast[0]), false);
+  });
+});
+
+describe('suggestWordForm()', () => {
+  it('returns a known suggestion for built-in operators', () => {
+    assert.strictEqual(suggestWordForm('='), 'equals');
+    assert.strictEqual(suggestWordForm('!='), 'differs-from');
+    assert.strictEqual(suggestWordForm('+'), 'plus');
+    assert.strictEqual(suggestWordForm('-'), 'minus');
+    assert.strictEqual(suggestWordForm('*'), 'times');
+    assert.strictEqual(suggestWordForm('/'), 'divided-by');
+  });
+  it('falls back to a generic placeholder for unknown operators', () => {
+    assert.match(suggestWordForm('@'), /word-form/);
+  });
+});
+
+describe('lintFile() — end-to-end on inline sources', () => {
+  it('returns no violations for a clean program', () => {
+    const src = `# Clean example\n(alice: alice is alice)\n((alice = true) has probability 0.5)\n(? (alice = true))\n`;
+    assert.deepStrictEqual(lintSource(src), []);
+  });
+
+  it('flags underscore identifiers with line/col information', () => {
+    const src = `(wet_grass: wet_grass is wet_grass)\n`;
+    const violations = lintSource(src);
+    assert.strictEqual(violations.length, 3);
+    for (const v of violations) {
+      assert.strictEqual(v.code, 'identifiers-without-hyphens');
+      assert.strictEqual(v.line, 1);
+    }
+  });
+
+  it('flags operator-only definitions', () => {
+    // `(@: + -)` defines `@` with a body that has no English word.
+    const src = `(@: + -)\n`;
+    const violations = lintSource(src);
+    assert.ok(violations.some(v => v.code === 'operator-only-link'));
+  });
+
+  it('respects identifier allow-list', () => {
+    const src = `(wet_grass: wet_grass is wet_grass)\n`;
+    const allow = { identifiers: new Set(['wet_grass']), links: new Set() };
+    assert.deepStrictEqual(lintSource(src, 'inline.lino', allow), []);
+  });
+
+  it('respects link allow-list keyed by basename:line', () => {
+    const src = `(@: + -)\n`;
+    const allow = { identifiers: new Set(), links: new Set(['inline.lino:1']) };
+    assert.deepStrictEqual(lintSource(src, 'inline.lino', allow), []);
+  });
+
+  it('reports parse errors instead of crashing', () => {
+    const src = `(a: a is a\n`;
+    const violations = lintSource(src);
+    assert.strictEqual(violations.length, 1);
+    assert.strictEqual(violations[0].code, 'parse-error');
+  });
+});
+
+describe('loadAllowlist()', () => {
+  it('returns an empty allow-list when no path is provided', () => {
+    const a = loadAllowlist(null);
+    assert.strictEqual(a.identifiers.size, 0);
+    assert.strictEqual(a.links.size, 0);
+  });
+
+  it('parses identifiers and links from a JSON file', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-english-'));
+    const file = path.join(tmp, 'allowlist.json');
+    fs.writeFileSync(file, JSON.stringify({
+      identifiers: ['foo_bar'],
+      links: ['demo.lino:1'],
+    }));
+    try {
+      const a = loadAllowlist(file);
+      assert.ok(a.identifiers.has('foo_bar'));
+      assert.ok(a.links.has('demo.lino:1'));
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on missing file', () => {
+    assert.throws(() => loadAllowlist('/no/such/allowlist.json'), /not found/);
+  });
+
+  it('throws on malformed JSON', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-english-'));
+    const file = path.join(tmp, 'allowlist.json');
+    fs.writeFileSync(file, '{not-json');
+    try {
+      assert.throws(() => loadAllowlist(file), /not valid JSON/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('CLI', () => {
+  it('exits 0 when all bundled examples are clean', () => {
+    const examples = fs.readdirSync(path.join(REPO_ROOT, 'examples'))
+      .filter(f => f.endsWith('.lino'))
+      .map(f => path.join(REPO_ROOT, 'examples', f));
+    const r = spawnSync(process.execPath, [SCRIPT, ...examples], { encoding: 'utf8' });
+    assert.strictEqual(r.status, 0,
+      `expected clean lint, got status ${r.status}\n${r.stdout}\n${r.stderr}`);
+  });
+
+  it('exits 1 and prints a diagnostic for a known violation', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-english-'));
+    const file = path.join(tmp, 'bad.lino');
+    fs.writeFileSync(file, '(foo_bar: foo_bar is foo_bar)\n');
+    try {
+      const r = spawnSync(process.execPath, [SCRIPT, file], { encoding: 'utf8' });
+      assert.strictEqual(r.status, 1);
+      assert.match(r.stdout, /identifiers-without-hyphens/);
+      assert.match(r.stdout, /foo_bar/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('--help prints usage and exits 0', () => {
+    const r = spawnSync(process.execPath, [SCRIPT, '--help'], { encoding: 'utf8' });
+    assert.strictEqual(r.status, 0);
+    assert.match(r.stdout, /Usage:/);
+  });
+
+  it('exits 2 when no files are supplied', () => {
+    const r = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+    assert.strictEqual(r.status, 2);
+  });
+
+  it('honours an allow-list file passed via --allowlist', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lint-english-'));
+    const file = path.join(tmp, 'bad.lino');
+    fs.writeFileSync(file, '(foo_bar: foo_bar is foo_bar)\n');
+    const allow = path.join(tmp, 'allowlist.json');
+    fs.writeFileSync(allow, JSON.stringify({ identifiers: ['foo_bar'] }));
+    try {
+      const r = spawnSync(process.execPath, [SCRIPT, '--allowlist', allow, file], { encoding: 'utf8' });
+      assert.strictEqual(r.status, 0,
+        `expected clean lint with allow-list, got status ${r.status}\n${r.stdout}\n${r.stderr}`);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `scripts/lint-english.mjs`, a heuristic linter that flags `.lino` links violating the project's design promise that *every link reads as an English sentence* (issue #32, plan A5).

Two rule classes are implemented:

- **`identifiers-without-hyphens`** — flags identifiers using `_` or `camelCase` and suggests the `kebab-case` form. Reserved RML/LiNo vocabulary (`and`, `or`, `not`, `is`, `Type`, `lambda`, …) and single-word identifiers (`alice`, `Natural`) are accepted as-is.
- **`operator-only-link`** — flags operator-only definitions like `(@: + -)` whose body contains no English word at all. Definitions like `(!=: not =)` pass because `not` makes them read as English.

Diagnostics use the same `file:line:col: code: message` shape as the structured diagnostics introduced in #98.

### What's in this PR

- `scripts/lint-english.mjs` — the lint script (CLI + library exports for tests)
- `scripts/lint-english.test.mjs` — 33 unit tests covering tokenizer, parser, both rules, the allow-list, and the CLI (including an integration test that runs against every bundled `examples/*.lino` file)
- `scripts/lint-english.allowlist.json` — JSON allow-list with `identifiers` and `links` arrays (links keyed by `<basename>:<line>`)
- `.github/workflows/lint-english.yml` — CI workflow that runs the lint and the unit tests on every push/PR. Until this PR no `.github/` directory existed in the repo; this also gives the project its first GitHub Actions workflow.
- README — new "English-readability lint" section documenting usage, the rule set, and the allow-list mechanism
- `js/package.json` — `npm run lint:english` shortcut and an extended `npm test` that picks up the new lint test suite
- Existing examples brought into compliance:
  - `examples/bayesian-network.lino`: `wet_grass` → `wet-grass`
  - `examples/self-reasoning.lino`: `supports_many_valued`, `supports_self_reference`, `resolves_paradoxes`, `is_meta_logic` → hyphenated forms
- Version bump `0.9.0` → `0.10.0` in both `js/package.json` and `rust/Cargo.toml` for the next release

### How to reproduce / verify

```bash
# Lint the bundled examples (clean)
node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino

# Or via npm
(cd js && npm run lint:english)

# Run the lint unit tests
node --test scripts/lint-english.test.mjs

# Existing JS suite (now includes the lint tests)
(cd js && npm test)         # 457 tests pass

# Existing Rust suite is unaffected
(cd rust && cargo test)     # 254 tests pass
```

A negative example to demonstrate the lint reports diagnostics:

```bash
echo '(foo_bar: foo_bar is foo_bar)' > /tmp/bad.lino
node scripts/lint-english.mjs /tmp/bad.lino
# /tmp/bad.lino:1:2: identifiers-without-hyphens: identifier "foo_bar" uses "_"; prefer hyphen-case "foo-bar"
# ...
```

## Acceptance Criteria

- [x] CI fails if `examples/` (or `lib/` when introduced) contain violations — enforced by `.github/workflows/lint-english.yml` plus the integration test in `scripts/lint-english.test.mjs`
- [x] Lint script documented in README — new "English-readability lint" section
- [x] Allow-list mechanism for legitimate exceptions — `scripts/lint-english.allowlist.json` with `identifiers` (silenced wherever they appear) and `links` (silenced for `<basename>:<line>` only)

## Test plan

- [x] All 33 lint unit tests pass (`node --test scripts/lint-english.test.mjs`)
- [x] All 424 existing JS tests pass after example renames (`cd js && npm test`)
- [x] All 254 existing Rust tests pass (`cd rust && cargo test`)
- [x] Lint reports zero violations on the bundled `examples/*.lino`
- [x] Lint exits non-zero with a `file:line:col: code: message` diagnostic on a synthetic violating file

Fixes #32