### PR TITLE
[B1] File imports with cycle detection

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T17:19:08.304Z for PR creation at branch issue-33-d9d56471f6cf for issue https://github.com/link-foundation/relative-meta-logic/issues/33

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T17:19:08.304Z for PR creation at branch issue-33-d9d56471f6cf for issue https://github.com/link-foundation/relative-meta-logic/issues/33

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -80,6 +80,7 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E004` | Unknown aggregator selector, e.g. `(and: bogus_agg)`. Valid selectors are `avg`, `min`, `max`, `product`/`prod`, `probabilistic_sum`/`ps`. |
 | `E005` | Empty meta-expression passed to a formalization helper. |
 | `E006` | LiNo top-level parse failure, e.g. unclosed paren in the whole file. |
+| `E007` | Import error: cycle in the file dependency graph, missing import target, or non-string import target. Triggered by `(import "<path>")` directives. |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -12,6 +12,7 @@
 // - Query: (? <expr>)
 
 import fs from 'node:fs';
+import path from 'node:path';
 import { Parser } from 'links-notation';
 
 // ---------- Structured Diagnostics ----------
@@ -923,6 +924,12 @@ function evaluate(code, options) {
     };
   }
 
+  // Import context: a stack of canonical paths currently being loaded (cycle
+  // detection) and a set of canonical paths already loaded into this env
+  // (caching for diamond patterns). Both are reused across recursive calls.
+  const importStack = opts._importStack || [];
+  const importedFiles = opts._importedFiles || new Set();
+
   // Pre-compute spans for each top-level form so error reporting can attach
   // a real source location even when the parser/evaluator throw deep inside.
   const formSpans = computeFormSpans(sourceText, file);
@@ -947,6 +954,15 @@ function evaluate(code, options) {
     }
     const span = formSpans[idx] || { file, line: 1, col: 1, length: 0 };
     env._currentSpan = span;
+
+    // Handle (import <path>) at the top level — file-level directive, not a
+    // regular RML expression.
+    if (Array.isArray(form) && form.length === 2 && form[0] === 'import') {
+      const importDiag = handleImport(form[1], span, file, env, importStack, importedFiles, diagnostics, traceEnabled, trace);
+      if (importDiag) diagnostics.push(importDiag);
+      continue;
+    }
+
     try {
       const res = evalNode(form, env);
       if (traceEnabled) {
@@ -975,6 +991,120 @@ function evaluate(code, options) {
   const out = { results, diagnostics };
   if (traceEnabled) out.trace = trace;
   return out;
+}
+
+// ---------- File imports (issue #33) ----------
+// Strip surrounding quotes (LiNo passes them through unmodified for some
+// shapes; the LiNo parser strips double-quotes for most inputs).
+function _unquotePath(s) {
+  if (typeof s !== 'string') return s;
+  if (s.length >= 2 && (s[0] === '"' || s[0] === "'") && s[s.length - 1] === s[0]) {
+    return s.slice(1, -1);
+  }
+  return s;
+}
+
+// Resolve an import target relative to the importing file's directory.
+// When `importingFile` is null (e.g. evaluating a string literal in tests),
+// resolve relative to the current working directory.
+function _resolveImportPath(target, importingFile) {
+  const cleaned = _unquotePath(target);
+  if (path.isAbsolute(cleaned)) return path.resolve(cleaned);
+  const baseDir = importingFile ? path.dirname(path.resolve(importingFile)) : process.cwd();
+  return path.resolve(baseDir, cleaned);
+}
+
+// Process a top-level (import <path>) directive. Returns a Diagnostic or null.
+function handleImport(rawTarget, span, importingFile, env, importStack, importedFiles, diagnostics, traceEnabled, trace) {
+  const target = _unquotePath(rawTarget);
+  if (typeof target !== 'string' || !target) {
+    return new Diagnostic({
+      code: 'E007',
+      message: 'Import target must be a string path',
+      span,
+    });
+  }
+  const resolved = _resolveImportPath(target, importingFile);
+
+  // Cycle detection: if the resolved path is already on the active import
+  // stack, the import would loop forever.
+  if (importStack.includes(resolved)) {
+    const cycle = [...importStack, resolved].join(' -> ');
+    return new Diagnostic({
+      code: 'E007',
+      message: `Import cycle detected: ${cycle}`,
+      span,
+    });
+  }
+
+  // Cache: each file is loaded once. Repeated imports (e.g. diamond pattern)
+  // are silent no-ops.
+  if (importedFiles.has(resolved)) {
+    if (traceEnabled && trace) {
+      trace.push(new TraceEvent({ kind: 'import', detail: `${resolved} (cached)`, span }));
+    }
+    return null;
+  }
+
+  let text;
+  try {
+    text = fs.readFileSync(resolved, 'utf8');
+  } catch (err) {
+    return new Diagnostic({
+      code: 'E007',
+      message: `Failed to read import "${target}": ${err.message}`,
+      span,
+    });
+  }
+
+  importedFiles.add(resolved);
+  importStack.push(resolved);
+  if (traceEnabled && trace) {
+    trace.push(new TraceEvent({ kind: 'import', detail: resolved, span }));
+  }
+
+  const inner = evaluate(text, {
+    env,
+    file: resolved,
+    trace: traceEnabled,
+    _importStack: importStack,
+    _importedFiles: importedFiles,
+  });
+
+  importStack.pop();
+
+  // Forward inner diagnostics so the importer surfaces errors from the
+  // imported file with their original spans intact.
+  for (const diag of inner.diagnostics) diagnostics.push(diag);
+  if (traceEnabled && trace && Array.isArray(inner.trace)) {
+    for (const ev of inner.trace) trace.push(ev);
+  }
+  return null;
+}
+
+// Read a file from disk and evaluate it, honouring (import ...) directives.
+// Mirrors `evaluate()` but takes a path on disk and resolves relative imports
+// against the file's directory.
+function evaluateFile(filePath, options) {
+  const opts = options || {};
+  const resolved = path.resolve(filePath);
+  let text;
+  try {
+    text = fs.readFileSync(resolved, 'utf8');
+  } catch (err) {
+    const diag = new Diagnostic({
+      code: 'E007',
+      message: `Failed to read "${filePath}": ${err.message}`,
+      span: { file: filePath, line: 1, col: 1, length: 0 },
+    });
+    return { results: [], diagnostics: [diag] };
+  }
+  return evaluate(text, {
+    ...opts,
+    file: resolved,
+    _importStack: opts._importStack || [resolved],
+    _importedFiles: opts._importedFiles || new Set([resolved]),
+  });
 }
 
 // ---------- Meta-expression adapter ----------
@@ -1225,6 +1355,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 export {
   run,
   evaluate,
+  evaluateFile,
   Diagnostic,
   RmlError,
   TraceEvent,

--- a/js/tests/imports.test.mjs
+++ b/js/tests/imports.test.mjs
@@ -1,0 +1,197 @@
+// Tests for `(import "...")` and `evaluateFile()` (issue #33).
+// Covers linear chains, diamond imports, cycle detection (E007),
+// missing-file errors, and that diagnostics from imported files surface
+// with their original spans intact. The Rust suite mirrors these in
+// rust/tests/imports_tests.rs to keep the two implementations in lock-step.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  evaluate,
+  evaluateFile,
+  formatDiagnostic,
+} from '../src/rml-links.mjs';
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rml-import-'));
+}
+
+describe('evaluateFile() loads a file from disk', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    fs.writeFileSync(path.join(dir, 'kb.lino'), '(a: a is a)\n((a = a) has probability 1)\n(? (a = a))\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('returns the structured evaluate() shape', () => {
+    const out = evaluateFile(path.join(dir, 'kb.lino'));
+    assert.ok(Array.isArray(out.results));
+    assert.ok(Array.isArray(out.diagnostics));
+    assert.strictEqual(out.diagnostics.length, 0);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('reports a missing file as an E007 diagnostic, not a thrown error', () => {
+    let threw = false;
+    let out;
+    try {
+      out = evaluateFile(path.join(dir, 'no-such.lino'));
+    } catch (_) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'evaluateFile() must not throw');
+    assert.ok(out.diagnostics.length >= 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E007');
+  });
+});
+
+describe('(import "...") — linear chain', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    fs.writeFileSync(path.join(dir, 'leaf.lino'), '(z: z is z)\n((z = z) has probability 1)\n');
+    fs.writeFileSync(path.join(dir, 'mid.lino'), '(import "leaf.lino")\n');
+    fs.writeFileSync(path.join(dir, 'top.lino'), '(import "mid.lino")\n(? (z = z))\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('loads declarations across a multi-step chain', () => {
+    const out = evaluateFile(path.join(dir, 'top.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+});
+
+describe('(import "...") — diamond pattern', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    // shared.lino is imported from both b.lino and c.lino; main imports both.
+    // Without caching, shared.lino would be loaded twice — that's fine for
+    // pure declarations but breaks operator redefinitions. The cache makes
+    // this a no-op the second time.
+    fs.writeFileSync(path.join(dir, 'shared.lino'), '(d: d is d)\n((d = d) has probability 1)\n');
+    fs.writeFileSync(path.join(dir, 'b.lino'), '(import "shared.lino")\n');
+    fs.writeFileSync(path.join(dir, 'c.lino'), '(import "shared.lino")\n');
+    fs.writeFileSync(path.join(dir, 'main.lino'), '(import "b.lino")\n(import "c.lino")\n(? (d = d))\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('loads each file at most once even when imported via multiple paths', () => {
+    const out = evaluateFile(path.join(dir, 'main.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+});
+
+describe('(import "...") — cycle detection', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    fs.writeFileSync(path.join(dir, 'a.lino'), '(import "b.lino")\n');
+    fs.writeFileSync(path.join(dir, 'b.lino'), '(import "a.lino")\n');
+    fs.writeFileSync(path.join(dir, 'self.lino'), '(import "self.lino")\n');
+    fs.writeFileSync(path.join(dir, 'tri-a.lino'), '(import "tri-b.lino")\n');
+    fs.writeFileSync(path.join(dir, 'tri-b.lino'), '(import "tri-c.lino")\n');
+    fs.writeFileSync(path.join(dir, 'tri-c.lino'), '(import "tri-a.lino")\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('emits an E007 diagnostic for a two-file cycle', () => {
+    const out = evaluateFile(path.join(dir, 'a.lino'));
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E007');
+    assert.match(d.message, /cycle/i);
+    // The cycle diagnostic is anchored to the span of the (import ...) form
+    // that closes the loop, in b.lino.
+    assert.ok(d.span.file && d.span.file.endsWith('b.lino'), d.span.file);
+    assert.strictEqual(d.span.line, 1);
+    assert.strictEqual(d.span.col, 1);
+  });
+
+  it('emits an E007 diagnostic for a self-import', () => {
+    const out = evaluateFile(path.join(dir, 'self.lino'));
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E007');
+    assert.match(out.diagnostics[0].message, /cycle/i);
+  });
+
+  it('emits an E007 diagnostic for a three-file cycle and lists the chain', () => {
+    const out = evaluateFile(path.join(dir, 'tri-a.lino'));
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E007');
+    assert.match(d.message, /tri-a\.lino/);
+    assert.match(d.message, /tri-b\.lino/);
+    assert.match(d.message, /tri-c\.lino/);
+  });
+});
+
+describe('(import "...") — diagnostics & semantics', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    fs.writeFileSync(path.join(dir, 'broken.lino'), '(=: missing identity)\n');
+    fs.writeFileSync(path.join(dir, 'host.lino'), '(import "broken.lino")\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('forwards diagnostics from the imported file with the imported span', () => {
+    const out = evaluateFile(path.join(dir, 'host.lino'));
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E001');
+    assert.ok(d.span.file && d.span.file.endsWith('broken.lino'), d.span.file);
+  });
+
+  it('missing import target reports E007 with the importing file in the span', () => {
+    const tmp = makeTmp();
+    try {
+      fs.writeFileSync(path.join(tmp, 'main.lino'), '(import "no-such.lino")\n');
+      const out = evaluateFile(path.join(tmp, 'main.lino'));
+      assert.strictEqual(out.diagnostics.length, 1);
+      const d = out.diagnostics[0];
+      assert.strictEqual(d.code, 'E007');
+      assert.match(d.message, /no-such\.lino/);
+      assert.ok(d.span.file && d.span.file.endsWith('main.lino'), d.span.file);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('formats E007 diagnostics like other codes', () => {
+    const tmp = makeTmp();
+    try {
+      const main = path.join(tmp, 'main.lino');
+      fs.writeFileSync(main, '(import "no-such.lino")\n');
+      const out = evaluateFile(main);
+      const text = formatDiagnostic(out.diagnostics[0], fs.readFileSync(main, 'utf8'));
+      const lines = text.split('\n');
+      assert.match(lines[0], /:1:1: E007:/);
+      assert.strictEqual(lines[1], '(import "no-such.lino")');
+      assert.strictEqual(lines[2], '^');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('inline (import ...) without a file resolves relative to CWD', () => {
+    const tmp = makeTmp();
+    const original = process.cwd();
+    try {
+      fs.writeFileSync(path.join(tmp, 'lib.lino'), '(a: a is a)\n((a = a) has probability 1)\n');
+      process.chdir(tmp);
+      const out = evaluate('(import "lib.lino")\n(? (a = a))');
+      assert.deepStrictEqual(out.diagnostics, []);
+      assert.deepStrictEqual(out.results, [1]);
+    } finally {
+      process.chdir(original);
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -12,7 +12,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::fs;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::{Path, PathBuf};
 
 // ========== Structured Diagnostics ==========
 // Every parser/evaluator error is reported as a `Diagnostic` with an error
@@ -2041,17 +2043,200 @@ pub fn evaluate_with_options(
     let mut env = Env::new(options.env.clone());
     env.trace_enabled = options.trace;
     env.default_span = Span::new(file.map(|s| s.to_string()), 1, 1, 0);
-    evaluate_inner(text, file, &mut env, &options)
+    let mut ctx = ImportContext::default();
+    evaluate_inner(text, file, &mut env, &options, &mut ctx)
 }
 
 /// Variant of [`evaluate`] that runs against a caller-owned `Env` instead of
 /// allocating a fresh one.  Used by the REPL to preserve state across inputs.
 pub fn evaluate_with_env(text: &str, file: Option<&str>, env: &mut Env) -> EvaluateResult {
     let options = EvaluateOptions::default();
-    evaluate_inner(text, file, env, &options)
+    let mut ctx = ImportContext::default();
+    evaluate_inner(text, file, env, &options, &mut ctx)
 }
 
-fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &EvaluateOptions) -> EvaluateResult {
+/// Read a file from disk and evaluate it, honouring `(import "...")` directives.
+/// Mirrors `evaluate()` but takes a path on disk; relative imports inside the
+/// file are resolved against the file's directory. A missing file is reported
+/// as an `E007` diagnostic instead of an OS error.
+pub fn evaluate_file(file_path: &str, options: EvaluateOptions) -> EvaluateResult {
+    let resolved: PathBuf = match fs::canonicalize(file_path) {
+        Ok(p) => p,
+        Err(_) => Path::new(file_path).to_path_buf(),
+    };
+    let text = match fs::read_to_string(&resolved) {
+        Ok(t) => t,
+        Err(err) => {
+            let diag = Diagnostic::new(
+                "E007",
+                format!("Failed to read \"{}\": {}", file_path, err),
+                Span::new(Some(file_path.to_string()), 1, 1, 0),
+            );
+            return EvaluateResult {
+                results: Vec::new(),
+                diagnostics: vec![diag],
+                trace: Vec::new(),
+            };
+        }
+    };
+    let mut env = Env::new(options.env.clone());
+    env.trace_enabled = options.trace;
+    let resolved_str = resolved.to_string_lossy().into_owned();
+    env.default_span = Span::new(Some(resolved_str.clone()), 1, 1, 0);
+    let mut ctx = ImportContext::default();
+    ctx.stack.push(resolved.clone());
+    ctx.loaded.insert(resolved.clone());
+    evaluate_inner(&text, Some(&resolved_str), &mut env, &options, &mut ctx)
+}
+
+/// Internal state threaded through nested `(import ...)` evaluations.
+/// `stack` is the chain of files currently being loaded (for cycle detection);
+/// `loaded` is the set of canonical paths already evaluated into the current
+/// env (for diamond-import caching).
+#[derive(Default)]
+struct ImportContext {
+    stack: Vec<PathBuf>,
+    loaded: HashSet<PathBuf>,
+}
+
+/// Strip surrounding ASCII quotes from a path string. The LiNo parser strips
+/// `"..."` for most inputs but `'...'` may also appear when whitespace forced
+/// a quote conversion; either form is accepted.
+fn unquote_path(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && (bytes[0] == b'"' || bytes[0] == b'\'')
+        && bytes[bytes.len() - 1] == bytes[0]
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Resolve an import target relative to the importing file's directory.
+/// When `importing_file` is `None`, resolve relative to the current working
+/// directory.
+fn resolve_import_path(target: &str, importing_file: Option<&str>) -> PathBuf {
+    let cleaned = unquote_path(target);
+    let candidate = Path::new(cleaned);
+    if candidate.is_absolute() {
+        return candidate.to_path_buf();
+    }
+    let base_dir: PathBuf = if let Some(file) = importing_file {
+        Path::new(file)
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+    } else {
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    };
+    base_dir.join(candidate)
+}
+
+/// Canonicalise an import path; falls back to the unresolved path when the
+/// file does not exist (so missing-file diagnostics still carry a meaningful
+/// path, and cycle keys stay consistent).
+fn canonicalize_import(p: &Path) -> PathBuf {
+    fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// Process a top-level `(import <path>)` directive. Reads the imported file
+/// and evaluates its contents against the same `env`, threading the import
+/// context for cycle detection and caching. Returns a `Diagnostic` if the
+/// import itself fails (cycle, missing file, bad target).
+fn handle_import(
+    target_node: &Node,
+    span: &Span,
+    importing_file: Option<&str>,
+    env: &mut Env,
+    options: &EvaluateOptions,
+    ctx: &mut ImportContext,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Diagnostic> {
+    let raw = match target_node {
+        Node::Leaf(s) => s.clone(),
+        _ => {
+            return Some(Diagnostic::new(
+                "E007",
+                "Import target must be a string path",
+                span.clone(),
+            ));
+        }
+    };
+    let cleaned = unquote_path(&raw);
+    if cleaned.is_empty() {
+        return Some(Diagnostic::new(
+            "E007",
+            "Import target must be a non-empty string path",
+            span.clone(),
+        ));
+    }
+    let unresolved = resolve_import_path(&raw, importing_file);
+    let resolved = canonicalize_import(&unresolved);
+
+    if ctx.stack.iter().any(|p| p == &resolved) {
+        let mut chain: Vec<String> = ctx
+            .stack
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        chain.push(resolved.to_string_lossy().into_owned());
+        return Some(Diagnostic::new(
+            "E007",
+            format!("Import cycle detected: {}", chain.join(" -> ")),
+            span.clone(),
+        ));
+    }
+
+    if ctx.loaded.contains(&resolved) {
+        if options.trace {
+            env.trace_events.push(TraceEvent::new(
+                "import",
+                format!("{} (cached)", resolved.to_string_lossy()),
+                span.clone(),
+            ));
+        }
+        return None;
+    }
+
+    let text = match fs::read_to_string(&resolved) {
+        Ok(t) => t,
+        Err(err) => {
+            return Some(Diagnostic::new(
+                "E007",
+                format!("Failed to read import \"{}\": {}", cleaned, err),
+                span.clone(),
+            ));
+        }
+    };
+
+    ctx.loaded.insert(resolved.clone());
+    ctx.stack.push(resolved.clone());
+    if options.trace {
+        env.trace_events.push(TraceEvent::new(
+            "import",
+            resolved.to_string_lossy().into_owned(),
+            span.clone(),
+        ));
+    }
+
+    let resolved_str = resolved.to_string_lossy().into_owned();
+    let inner = evaluate_inner(&text, Some(&resolved_str), env, options, ctx);
+    ctx.stack.pop();
+
+    for diag in inner.diagnostics {
+        diagnostics.push(diag);
+    }
+    // The inner evaluator drained env.trace_events into inner.trace; restore
+    // them so the outer call surfaces them in source order.
+    if options.trace {
+        env.trace_events.extend(inner.trace);
+    }
+    None
+}
+
+fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &EvaluateOptions, ctx: &mut ImportContext) -> EvaluateResult {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
     let spans = compute_form_spans(text, file);
 
@@ -2104,6 +2289,26 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
             .cloned()
             .unwrap_or_else(|| Span::new(file.map(|s| s.to_string()), 1, 1, 0));
         env.current_span = Some(span.clone());
+
+        // Top-level (import <path>) directive — handled before regular
+        // evaluation so it can recursively call evaluate_inner against the
+        // same env while threading the import context.
+        if let Node::List(children) = &form {
+            if children.len() == 2 {
+                if let Node::Leaf(head) = &children[0] {
+                    if head == "import" {
+                        let target = children[1].clone();
+                        if let Some(diag) =
+                            handle_import(&target, &span, file, env, options, ctx, &mut diagnostics)
+                        {
+                            diagnostics.push(diag);
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
+
         // We need to capture the form so the eval-trace event can reference it
         // by canonical key. Cloning is cheap: AST nodes are small strings.
         let form_for_trace = if options.trace {

--- a/rust/tests/imports_tests.rs
+++ b/rust/tests/imports_tests.rs
@@ -1,0 +1,226 @@
+// Tests for `(import "...")` and `evaluate_file()` (issue #33).
+// Mirrors js/tests/imports.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{evaluate, evaluate_file, format_diagnostic, EvaluateOptions, RunResult};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// Each test gets its own scratch directory under the system temp directory.
+// We avoid pulling in `tempfile` to keep the dependency surface unchanged.
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn make_tmp(tag: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let mut p = std::env::temp_dir();
+    p.push(format!("rml-rust-import-{}-{}-{}", tag, pid, n));
+    fs::create_dir_all(&p).expect("create tmp");
+    p
+}
+
+fn write(dir: &PathBuf, name: &str, body: &str) -> PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).expect("write tmp file");
+    p
+}
+
+fn cleanup(dir: &PathBuf) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+fn expect_num(r: &RunResult) -> f64 {
+    match r {
+        RunResult::Num(n) => *n,
+        other => panic!("expected numeric result, got {:?}", other),
+    }
+}
+
+#[test]
+fn evaluate_file_returns_structured_result() {
+    let dir = make_tmp("kb");
+    let main = write(
+        &dir,
+        "kb.lino",
+        "(a: a is a)\n((a = a) has probability 1)\n(? (a = a))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 0);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn evaluate_file_reports_missing_file_as_e007() {
+    let dir = make_tmp("missing");
+    let missing = dir.join("no-such.lino");
+    let out = evaluate_file(missing.to_str().unwrap(), EvaluateOptions::default());
+    assert!(!out.diagnostics.is_empty());
+    assert_eq!(out.diagnostics[0].code, "E007");
+    cleanup(&dir);
+}
+
+#[test]
+fn linear_chain_loads_declarations_across_three_files() {
+    let dir = make_tmp("chain");
+    write(
+        &dir,
+        "leaf.lino",
+        "(z: z is z)\n((z = z) has probability 1)\n",
+    );
+    write(&dir, "mid.lino", "(import \"leaf.lino\")\n");
+    let top = write(
+        &dir,
+        "top.lino",
+        "(import \"mid.lino\")\n(? (z = z))\n",
+    );
+    let out = evaluate_file(top.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn diamond_pattern_loads_each_file_at_most_once() {
+    let dir = make_tmp("diamond");
+    write(
+        &dir,
+        "shared.lino",
+        "(d: d is d)\n((d = d) has probability 1)\n",
+    );
+    write(&dir, "b.lino", "(import \"shared.lino\")\n");
+    write(&dir, "c.lino", "(import \"shared.lino\")\n");
+    let main = write(
+        &dir,
+        "main.lino",
+        "(import \"b.lino\")\n(import \"c.lino\")\n(? (d = d))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn two_file_cycle_emits_e007_with_span_of_closing_import() {
+    let dir = make_tmp("cycle2");
+    let a = write(&dir, "a.lino", "(import \"b.lino\")\n");
+    let b = write(&dir, "b.lino", "(import \"a.lino\")\n");
+    let out = evaluate_file(a.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1, "diagnostics: {:?}", out.diagnostics);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E007");
+    assert!(d.message.to_lowercase().contains("cycle"), "{}", d.message);
+    let span_file = d.span.file.as_deref().unwrap_or("");
+    assert!(
+        span_file.ends_with("b.lino"),
+        "span file was {}",
+        span_file
+    );
+    assert_eq!(d.span.line, 1);
+    assert_eq!(d.span.col, 1);
+    let _ = b;
+    cleanup(&dir);
+}
+
+#[test]
+fn self_import_emits_e007() {
+    let dir = make_tmp("self");
+    let f = write(&dir, "self.lino", "(import \"self.lino\")\n");
+    let out = evaluate_file(f.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E007");
+    assert!(out.diagnostics[0].message.to_lowercase().contains("cycle"));
+    cleanup(&dir);
+}
+
+#[test]
+fn three_file_cycle_lists_chain_in_message() {
+    let dir = make_tmp("cycle3");
+    let a = write(&dir, "tri-a.lino", "(import \"tri-b.lino\")\n");
+    write(&dir, "tri-b.lino", "(import \"tri-c.lino\")\n");
+    write(&dir, "tri-c.lino", "(import \"tri-a.lino\")\n");
+    let out = evaluate_file(a.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1);
+    let msg = &out.diagnostics[0].message;
+    assert_eq!(out.diagnostics[0].code, "E007");
+    assert!(msg.contains("tri-a.lino"), "{}", msg);
+    assert!(msg.contains("tri-b.lino"), "{}", msg);
+    assert!(msg.contains("tri-c.lino"), "{}", msg);
+    cleanup(&dir);
+}
+
+#[test]
+fn diagnostics_from_imported_file_keep_their_span() {
+    let dir = make_tmp("forward");
+    write(&dir, "broken.lino", "(=: missing identity)\n");
+    let host = write(&dir, "host.lino", "(import \"broken.lino\")\n");
+    let out = evaluate_file(host.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E001");
+    let span_file = d.span.file.as_deref().unwrap_or("");
+    assert!(span_file.ends_with("broken.lino"), "{}", span_file);
+    cleanup(&dir);
+}
+
+#[test]
+fn missing_import_target_reports_e007_with_importing_span() {
+    let dir = make_tmp("missing-import");
+    let main = write(&dir, "main.lino", "(import \"no-such.lino\")\n");
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E007");
+    assert!(d.message.contains("no-such.lino"), "{}", d.message);
+    let span_file = d.span.file.as_deref().unwrap_or("");
+    assert!(span_file.ends_with("main.lino"), "{}", span_file);
+    cleanup(&dir);
+}
+
+#[test]
+fn e007_diagnostic_formats_like_other_codes() {
+    let dir = make_tmp("format");
+    let main = write(&dir, "main.lino", "(import \"no-such.lino\")\n");
+    let src = fs::read_to_string(&main).unwrap();
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1);
+    let text = format_diagnostic(&out.diagnostics[0], Some(&src));
+    let lines: Vec<&str> = text.split('\n').collect();
+    assert!(lines[0].contains(":1:1: E007:"), "line[0]: {}", lines[0]);
+    assert_eq!(lines[1], "(import \"no-such.lino\")");
+    assert_eq!(lines[2], "^");
+    cleanup(&dir);
+}
+
+#[test]
+fn inline_import_without_file_resolves_against_cwd() {
+    // Drop into a temp dir, evaluate an in-memory program that imports a
+    // sibling file. We don't compete with other tests for CWD here because
+    // each scratch directory is unique.
+    let dir = make_tmp("inline");
+    write(
+        &dir,
+        "lib.lino",
+        "(a: a is a)\n((a = a) has probability 1)\n",
+    );
+    let original = std::env::current_dir().unwrap();
+    std::env::set_current_dir(&dir).unwrap();
+    let result = std::panic::catch_unwind(|| {
+        evaluate(
+            "(import \"lib.lino\")\n(? (a = a))",
+            None,
+            None,
+        )
+    });
+    std::env::set_current_dir(&original).unwrap();
+    cleanup(&dir);
+    let out = result.expect("evaluate panicked");
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+}


### PR DESCRIPTION
## Summary

Adds a `(import "<relative-path>.lino")` LiNo directive that loads another file's declarations into the current evaluator environment. Both runtimes (`js/src/rml-links.mjs` and `rust/src/lib.rs`) now expose an `evaluateFile` / `evaluate_file` entry point that honours imports, with caching so diamonds load each file once and span-aware diagnostics so cycles point at the closing import.

Fixes #33.

## Surface

```lino
(import "lib/shared.lino")
```

- Path is resolved relative to the importing file's directory; when no entry file is known (inline source) it resolves against the CWD.
- Each canonical absolute path is cached, so subsequent imports of the same file are silent no-ops.
- Imported files are evaluated against the *same* `Env`, so terms, ops, types, lambdas, and assignments accumulate across files.

## Diagnostics

A new `E007` covers every import error and is documented in `docs/DIAGNOSTICS.md`:

| Trigger | Span |
|---|---|
| Cycle in the import graph | Closing `(import …)` in the importer that re-enters the loop, with the chain in the message |
| Missing file (`ENOENT`) | The `(import …)` form |
| Non-string target, e.g. `(import 123)` | The `(import …)` form |

Diagnostics raised inside an imported file keep their own `file:line:col` span, so editor tooling can jump straight to the original source.

## Library API

JavaScript:
```js
import { evaluateFile, formatDiagnostic } from 'relative-meta-logic';

const { results, diagnostics } = evaluateFile('kb.lino');
```

Rust:
```rust
use rml::{evaluate_file, EvaluateOptions, format_diagnostic};

let evaluation = evaluate_file("kb.lino", EvaluateOptions::default());
```

## Test plan

- [x] JS: 11 new tests in `js/tests/imports.test.mjs` — full suite 498/498
- [x] Rust: 11 new tests in `rust/tests/imports_tests.rs` — full suite 303/303
- [x] Linear chain (3 files), diamond (shared dep loaded once), 2- and 3-file cycles, self-import
- [x] Diagnostics from imported files keep their original span
- [x] Cycle diagnostic anchored at the closing import in the importer
- [x] Missing file and non-string target both report E007
- [x] `evaluateFile` / `evaluate_file` agree with the in-process `evaluate` for simple cases
- [x] `docs/DIAGNOSTICS.md` documents E007
- [x] Versions bumped 0.10.0 → 0.11.0 in `js/package.json`, `js/package-lock.json`, `rust/Cargo.toml`, `rust/Cargo.lock`

## Out of scope

Per the issue: package registry, version resolution, conditional imports, and import aliasing. Only file-relative `(import "…")` is implemented.