### PR TITLE
[B2] Namespaces and qualified references

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T17:58:33.265Z for PR creation at branch issue-34-7021e69dbe1a for issue https://github.com/link-foundation/relative-meta-logic/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T17:58:33.265Z for PR creation at branch issue-34-7021e69dbe1a for issue https://github.com/link-foundation/relative-meta-logic/issues/34

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -81,6 +81,8 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E005` | Empty meta-expression passed to a formalization helper. |
 | `E006` | LiNo top-level parse failure, e.g. unclosed paren in the whole file. |
 | `E007` | Import error: cycle in the file dependency graph, missing import target, or non-string import target. Triggered by `(import "<path>")` directives. |
+| `E008` | Shadowing warning: a top-level definition rebinds a name introduced by an earlier `(import …)`. Triggered, for example, by `(import "lib.lino") (myop: max)` when `lib.lino` already defines `myop`. The redefinition still takes effect — `E008` is informational, not fatal. |
+| `E009` | Namespace or alias error: invalid namespace name (empty or dotted, e.g. `(namespace foo.bar)`), or an alias collision between two `(import "..." as <alias>)` directives in the same file. |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying

--- a/experiments/test-multi.mjs
+++ b/experiments/test-multi.mjs
@@ -1,0 +1,39 @@
+import { evaluateFile } from '../js/src/rml-links.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rml-multi-'));
+
+fs.writeFileSync(path.join(dir, 'la.lino'), `(namespace foo)
+(x: max)
+`);
+fs.writeFileSync(path.join(dir, 'lb.lino'), `(namespace bar)
+(x: min)
+`);
+fs.writeFileSync(path.join(dir, 'multi.lino'), `(import "la.lino" as a)
+(import "lb.lino" as b)
+(? (a.x 0.2 0.5))
+(? (b.x 0.2 0.5))
+`);
+const out = evaluateFile(path.join(dir, 'multi.lino'));
+console.log('diagnostics:', out.diagnostics);
+console.log('results:', out.results);
+
+// Now check just one
+fs.writeFileSync(path.join(dir, 'simple.lino'), `(import "la.lino" as a)
+(? (a.x 0.2 0.5))
+`);
+const out2 = evaluateFile(path.join(dir, 'simple.lino'));
+console.log('simple diagnostics:', out2.diagnostics);
+console.log('simple results:', out2.results);
+
+// And: just call foo.x directly
+fs.writeFileSync(path.join(dir, 'direct.lino'), `(import "la.lino")
+(? (foo.x 0.2 0.5))
+`);
+const out3 = evaluateFile(path.join(dir, 'direct.lino'));
+console.log('direct diagnostics:', out3.diagnostics);
+console.log('direct results:', out3.results);
+
+fs.rmSync(dir, { recursive: true, force: true });

--- a/experiments/test-namespace.mjs
+++ b/experiments/test-namespace.mjs
@@ -1,0 +1,47 @@
+import { evaluate, evaluateFile } from '../js/src/rml-links.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rml-ns-'));
+
+// Write a classical lib
+fs.writeFileSync(path.join(dir, 'classical.lino'), `(namespace classical)
+(and: min)
+(or: max)
+`);
+
+// Test 1: aliased import
+fs.writeFileSync(path.join(dir, 'main.lino'), `(import "classical.lino" as cl)
+(? (cl.and 1 0))
+(? (cl.or 1 0))
+`);
+
+const out1 = evaluateFile(path.join(dir, 'main.lino'));
+console.log('Test 1 (aliased import):');
+console.log('  diagnostics:', out1.diagnostics);
+console.log('  results:', out1.results);
+
+// Test 2: namespace, no alias — direct qualified access
+fs.writeFileSync(path.join(dir, 'main2.lino'), `(import "classical.lino")
+(? (classical.and 1 0))
+(? (classical.or 1 0))
+`);
+const out2 = evaluateFile(path.join(dir, 'main2.lino'));
+console.log('Test 2 (qualified direct access):');
+console.log('  diagnostics:', out2.diagnostics);
+console.log('  results:', out2.results);
+
+// Test 3: shadowing
+fs.writeFileSync(path.join(dir, 'lib3.lino'), `((true) has probability 0.7)
+`);
+fs.writeFileSync(path.join(dir, 'main3.lino'), `(import "lib3.lino")
+(true: 0.3)
+(? (true = true))
+`);
+const out3 = evaluateFile(path.join(dir, 'main3.lino'));
+console.log('Test 3 (shadowing):');
+console.log('  diagnostics:', out3.diagnostics);
+console.log('  results:', out3.results);
+
+fs.rmSync(dir, { recursive: true, force: true });

--- a/experiments/test-shadow.mjs
+++ b/experiments/test-shadow.mjs
@@ -1,0 +1,61 @@
+import { evaluate, evaluateFile } from '../js/src/rml-links.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rml-shadow-'));
+
+// Test A: import a lib that defines `myop` as an op alias, then redefine
+fs.writeFileSync(path.join(dir, 'lib.lino'), `(myop: avg)
+`);
+fs.writeFileSync(path.join(dir, 'main.lino'), `(import "lib.lino")
+(myop: max)
+(? (myop 0.2 0.4 0.8))
+`);
+const outA = evaluateFile(path.join(dir, 'main.lino'));
+console.log('Test A (op shadow):');
+console.log('  diagnostics:', outA.diagnostics);
+console.log('  results:', outA.results);
+
+// Test B: import a lib that uses namespace, then redefine the qualified name
+fs.writeFileSync(path.join(dir, 'lib2.lino'), `(namespace classical)
+(and: min)
+`);
+fs.writeFileSync(path.join(dir, 'main2.lino'), `(import "lib2.lino" as cl)
+(cl.and: max)
+(? (cl.and 0.2 0.4 0.8))
+`);
+const outB = evaluateFile(path.join(dir, 'main2.lino'));
+console.log('Test B (qualified rebind):');
+console.log('  diagnostics:', outB.diagnostics);
+console.log('  results:', outB.results);
+
+// Test C: same alias used twice -> E009
+fs.writeFileSync(path.join(dir, 'lib3a.lino'), `(namespace foo)
+(x: max)
+`);
+fs.writeFileSync(path.join(dir, 'lib3b.lino'), `(namespace bar)
+(x: min)
+`);
+fs.writeFileSync(path.join(dir, 'main3.lino'), `(import "lib3a.lino" as a)
+(import "lib3b.lino" as a)
+(? (a.x 0.2 0.5))
+`);
+const outC = evaluateFile(path.join(dir, 'main3.lino'));
+console.log('Test C (alias collision):');
+console.log('  diagnostics:', outC.diagnostics);
+console.log('  results:', outC.results);
+
+// Test D: term shadow
+fs.writeFileSync(path.join(dir, 'lib4.lino'), `(foo: foo is foo)
+`);
+fs.writeFileSync(path.join(dir, 'main4.lino'), `(import "lib4.lino")
+(foo: foo is foo)
+(? (foo = foo))
+`);
+const outD = evaluateFile(path.join(dir, 'main4.lino'));
+console.log('Test D (term shadow):');
+console.log('  diagnostics:', outD.diagnostics);
+console.log('  results:', outD.results);
+
+fs.rmSync(dir, { recursive: true, force: true });

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -175,6 +175,16 @@ class Env {
     this.symbolProb = new Map();                // optional symbol priors if you want (x: 0.7)
     this.types = new Map();                     // key(expr) -> type expression (as string)
     this.lambdas = new Map();                   // name -> { param, paramType, body } for named lambdas
+    // Namespace state (issue #34): a file can declare `(namespace foo)`, which
+    // prefixes every name it subsequently introduces with `foo.`. Imports can
+    // be aliased via `(import "x.lino" as a)`, which records `a` -> the
+    // imported file's declared namespace so `a.name` resolves to that name.
+    // `imported` tracks names that came from an import (not declared in the
+    // importing file) so we can emit a shadowing warning (E008) when a later
+    // top-level definition rebinds them.
+    this.namespace = null;
+    this.aliases = new Map();
+    this.imported = new Set();
     // Optional tracer: when set, key evaluation events (operator resolutions,
     // assignment lookups, top-level reductions) are pushed via `trace(kind, detail)`.
     // The current top-level form span is stashed on the Env so leaf hooks can
@@ -275,8 +285,15 @@ class Env {
   }
 
   getOp(name){
-    if (!this.ops.has(name)) throw new RmlError('E001', `Unknown op: ${name}`);
-    return this.ops.get(name);
+    if (this.ops.has(name)) return this.ops.get(name);
+    const resolved = this._resolveQualified(name);
+    if (resolved !== name && this.ops.has(resolved)) return this.ops.get(resolved);
+    throw new RmlError('E001', `Unknown op: ${name}`);
+  }
+  hasOp(name){
+    if (this.ops.has(name)) return true;
+    const resolved = this._resolveQualified(name);
+    return resolved !== name && this.ops.has(resolved);
   }
   defineOp(name, fn){ this.ops.set(name, fn); }
 
@@ -298,9 +315,58 @@ class Env {
     return this.lambdas.get(name) || null;
   }
   setSymbolProb(sym, p){ this.symbolProb.set(sym, this.clamp(p)); }
-  getSymbolProb(sym){ return this.symbolProb.has(sym) ? this.symbolProb.get(sym) : this.mid; }
+  getSymbolProb(sym){
+    if (this.symbolProb.has(sym)) return this.symbolProb.get(sym);
+    const resolved = this._resolveQualified(sym);
+    if (resolved !== sym && this.symbolProb.has(resolved)) {
+      return this.symbolProb.get(resolved);
+    }
+    return this.mid;
+  }
   trace(kind, detail){
     if (this._tracer) this._tracer(kind, detail, this._currentSpan);
+  }
+
+  // ---------- Namespace helpers (issue #34) ----------
+  // Apply the active namespace to a freshly declared name, e.g. inside
+  // `(namespace classical)` the form `(and: min)` registers `classical.and`,
+  // not `and`. Names that already contain a `.` are passed through.
+  qualifyName(name) {
+    if (typeof name !== 'string') return name;
+    if (this.namespace && !name.includes('.')) return `${this.namespace}.${name}`;
+    return name;
+  }
+
+  // Resolve a possibly-qualified name to its canonical storage key. Order:
+  //   1. Alias prefix: `cl.foo` with alias `cl -> classical` becomes
+  //      `classical.foo`.
+  //   2. Active namespace: an unqualified name lives in `<ns>.<name>`.
+  //   3. Bare name: returned unchanged.
+  // Used by lookup helpers (operators, symbol probabilities) to find
+  // namespaced bindings without forcing every call site to spell them out.
+  _resolveQualified(name) {
+    if (typeof name !== 'string') return name;
+    const dotIdx = name.indexOf('.');
+    if (dotIdx > 0) {
+      const prefix = name.slice(0, dotIdx);
+      const rest = name.slice(dotIdx + 1);
+      if (this.aliases.has(prefix)) {
+        return `${this.aliases.get(prefix)}.${rest}`;
+      }
+      return name;
+    }
+    if (this.namespace) {
+      const qualified = `${this.namespace}.${name}`;
+      if (
+        this.ops.has(qualified) ||
+        this.symbolProb.has(qualified) ||
+        this.terms.has(qualified) ||
+        this.lambdas.has(qualified)
+      ) {
+        return qualified;
+      }
+    }
+    return name;
   }
 }
 
@@ -623,7 +689,7 @@ function evalNode(node, env){
 
   // Prefix: (not X), (and X Y ...), (or X Y ...)
   const [head, ...args] = node;
-  if (typeof head === 'string' && env.ops.has(head)) {
+  if (typeof head === 'string' && env.hasOp(head)) {
     const op = env.getOp(head);
     const vals = args.map(a => evalNode(a, env));
     return env.clamp(op(...vals));
@@ -631,7 +697,7 @@ function evalNode(node, env){
 
   // Fall through: prefix application (f x y ...) for named lambdas
   if (typeof head === 'string' && args.length >= 1) {
-    const lambda = env.getLambda(head);
+    const lambda = env.getLambda(head) || env.getLambda(env._resolveQualified(head));
     if (lambda) {
       // Apply first argument, then recursively apply rest
       let result = substitute(lambda.body, lambda.param, args[0]);
@@ -683,9 +749,35 @@ function _reinitOps(env) {
 }
 
 function defineForm(head, rhs, env){
+  // Configuration directives are file-level and never namespaced.
+  // Range configuration: (range: lo hi) — sets the truth value range
+  if (head === 'range' && rhs.length === 2 && isNum(rhs[0]) && isNum(rhs[1])) {
+    env.lo = parseFloat(rhs[0]);
+    env.hi = parseFloat(rhs[1]);
+    _reinitOps(env);
+    return 1;
+  }
+  // Valence configuration: (valence: N) — sets the number of truth values
+  // N=1: unary (trivial), N=2: binary (Boolean), N=3: ternary, N=0: continuous
+  if (head === 'valence' && rhs.length === 1 && isNum(rhs[0])) {
+    env.valence = parseInt(rhs[0], 10);
+    return 1;
+  }
+
+  // Bindings introduced inside `(namespace foo)` are stored under `foo.head`.
+  // The syntactic head (e.g. `a` in `(a: a is a)`) is still used to match
+  // patterns; only the storage key is qualified.
+  const storeName = env.qualifyName(head);
+  // Shadowing diagnostic (E008): if this name was already imported, warn.
+  if (storeName !== head || env.namespace === null) {
+    _maybeWarnShadow(env, storeName);
+  } else {
+    _maybeWarnShadow(env, head);
+  }
+
   // Term definition: (a: a is a)  → declare 'a' as a term (no probability assignment)
   if (rhs.length === 3 && typeof rhs[0]==='string' && rhs[1]==='is' && typeof rhs[2]==='string' && rhs[0]===head && rhs[2]===head) {
-    env.terms.add(head);
+    env.terms.add(storeName);
     return 1;
   }
 
@@ -695,8 +787,8 @@ function defineForm(head, rhs, env){
     const typeName = rhs[0];
     // Only if typeName starts with uppercase (type convention) and is not an operator
     if (/^[A-Z]/.test(typeName)) {
-      env.terms.add(head);
-      env.setType(head, typeName);
+      env.terms.add(storeName);
+      env.setType(storeName, typeName);
       return 1;
     }
   }
@@ -704,8 +796,8 @@ function defineForm(head, rhs, env){
   // Prefix type notation with complex type: (name: (Type 0) name) → typed self-referential declaration
   if (rhs.length === 2 && Array.isArray(rhs[0]) && typeof rhs[1] === 'string' && rhs[1] === head) {
     const typeExpr = rhs[0];
-    env.terms.add(head);
-    env.setType(head, typeExpr);
+    env.terms.add(storeName);
+    env.setType(storeName, typeExpr);
     evalNode(typeExpr, env);
     return 1;
   }
@@ -717,31 +809,16 @@ function defineForm(head, rhs, env){
     const isOp = ['=','!=','and','or','not','is','?:','both','neither'].includes(head) || /[=!]/.test(head);
     if (!isOp) {
       const typeExpr = rhs[0];
-      env.terms.add(head);
-      env.setType(head, typeExpr);
+      env.terms.add(storeName);
+      env.setType(storeName, typeExpr);
       evalNode(typeExpr, env);
       return 1;
     }
   }
 
-  // Range configuration: (range: lo hi) — sets the truth value range
-  if (head === 'range' && rhs.length === 2 && isNum(rhs[0]) && isNum(rhs[1])) {
-    env.lo = parseFloat(rhs[0]);
-    env.hi = parseFloat(rhs[1]);
-    _reinitOps(env);
-    return 1;
-  }
-
-  // Valence configuration: (valence: N) — sets the number of truth values
-  // N=1: unary (trivial), N=2: binary (Boolean), N=3: ternary, N=0: continuous
-  if (head === 'valence' && rhs.length === 1 && isNum(rhs[0])) {
-    env.valence = parseInt(rhs[0], 10);
-    return 1;
-  }
-
   // Optional symbol prior: (a: 0.7) — not required for your use-case, but allowed
   if (rhs.length === 1 && isNum(rhs[0])) {
-    env.setSymbolProb(head, parseFloat(rhs[0]));
+    env.setSymbolProb(storeName, parseFloat(rhs[0]));
     return env.toNum(rhs[0]);
   }
 
@@ -752,8 +829,8 @@ function defineForm(head, rhs, env){
     if (rhs.length === 2 && typeof rhs[0]==='string' && typeof rhs[1]==='string') {
       const outer = env.getOp(rhs[0]);
       const inner = env.getOp(rhs[1]);
-      env.defineOp(head, (...xs) => env.clamp( outer( inner(...xs) ) ));
-      env.trace('resolve', `(${head}: ${rhs[0]} ${rhs[1]})`);
+      env.defineOp(storeName, (...xs) => env.clamp( outer( inner(...xs) ) ));
+      env.trace('resolve', `(${storeName}: ${rhs[0]} ${rhs[1]})`);
       return 1;
     }
 
@@ -768,8 +845,8 @@ function defineForm(head, rhs, env){
         sel==='product' || sel==='prod' ? xs=>xs.reduce((a,b)=>a*b,1) :
         sel==='probabilistic_sum' || sel==='ps' ? xs=> 1 - xs.reduce((a,b)=>a*(1-b),1) : null;
       if (!agg) throw new RmlError('E004', `Unknown aggregator "${sel}"`);
-      env.defineOp(head, (...xs)=> xs.length? agg(xs) : lo);
-      env.trace('resolve', `(${head}: ${sel})`);
+      env.defineOp(storeName, (...xs)=> xs.length? agg(xs) : lo);
+      env.trace('resolve', `(${storeName}: ${sel})`);
       return 1;
     }
 
@@ -783,11 +860,11 @@ function defineForm(head, rhs, env){
       if (parsed) {
         const { paramName, paramType } = parsed;
         const body = rhs[2];
-        env.terms.add(head);
-        env.setLambda(head, paramName, paramType, body);
+        env.terms.add(storeName);
+        env.setLambda(storeName, paramName, paramType, body);
         const paramTypeKey = typeof paramType === 'string' ? paramType : keyOf(paramType);
         const bodyTypeKey = env.getType(body) || (typeof body === 'string' ? body : keyOf(body));
-        env.setType(head, '(Pi (' + paramTypeKey + ' ' + paramName + ') ' + bodyTypeKey + ')');
+        env.setType(storeName, '(Pi (' + paramTypeKey + ' ' + paramName + ') ' + bodyTypeKey + ')');
         return 1;
       }
     }
@@ -798,12 +875,45 @@ function defineForm(head, rhs, env){
 
   // Generic symbol alias like (x: y) just copies y's prior probability if any
   if (rhs.length===1 && typeof rhs[0]==='string') {
-    env.setSymbolProb(head, env.getSymbolProb(rhs[0]));
-    return env.getSymbolProb(head);
+    env.setSymbolProb(storeName, env.getSymbolProb(rhs[0]));
+    return env.getSymbolProb(storeName);
   }
 
   // Else: ignore (keeps PoC minimal)
   return 0;
+}
+
+// Emit a shadowing warning (E008) if the name being defined was previously
+// brought in via `(import ...)`. The import handler tracks names it added to
+// the environment in `env.imported`; the importing file's own definitions are
+// not in that set, so re-binding them locally never triggers the warning.
+// Diagnostics are appended to `env._shadowDiagnostics` and surfaced by the
+// outer `evaluate()` loop alongside other diagnostics.
+function _maybeWarnShadow(env, name) {
+  if (!env.imported) return;
+  // Resolve the name through alias mappings so a re-binding like `(cl.and: ...)`
+  // matches the canonical imported key `classical.and`.
+  let key = name;
+  if (!env.imported.has(key)) {
+    const resolved = env._resolveQualified(name);
+    if (resolved !== name && env.imported.has(resolved)) {
+      key = resolved;
+    } else {
+      return;
+    }
+  }
+  // Only warn once per name to keep noise down; remove from imported so the
+  // shadow only fires the first time it's rebinding.
+  env.imported.delete(key);
+  const span = env._currentSpan || { file: null, line: 1, col: 1, length: 0 };
+  const diag = new Diagnostic({
+    code: 'E008',
+    message: `Definition of "${name}" shadows an imported binding`,
+    span,
+  });
+  if (Array.isArray(env._shadowDiagnostics)) {
+    env._shadowDiagnostics.push(diag);
+  }
 }
 
 // ---------- Public LiNo helpers ----------
@@ -930,6 +1040,11 @@ function evaluate(code, options) {
   const importStack = opts._importStack || [];
   const importedFiles = opts._importedFiles || new Set();
 
+  // Shadowing diagnostics (E008) are appended to this array by `defineForm`
+  // when a top-level definition rebinds an imported name. Surfaced after the
+  // form-evaluation loop so they appear alongside other diagnostics.
+  if (!Array.isArray(env._shadowDiagnostics)) env._shadowDiagnostics = [];
+
   // Pre-compute spans for each top-level form so error reporting can attach
   // a real source location even when the parser/evaluator throw deep inside.
   const formSpans = computeFormSpans(sourceText, file);
@@ -955,10 +1070,40 @@ function evaluate(code, options) {
     const span = formSpans[idx] || { file, line: 1, col: 1, length: 0 };
     env._currentSpan = span;
 
-    // Handle (import <path>) at the top level — file-level directive, not a
-    // regular RML expression.
-    if (Array.isArray(form) && form.length === 2 && form[0] === 'import') {
-      const importDiag = handleImport(form[1], span, file, env, importStack, importedFiles, diagnostics, traceEnabled, trace);
+    // Handle (namespace <name>) at the top level — sets the active namespace
+    // for subsequent definitions in this file (issue #34).
+    if (Array.isArray(form) && form.length === 2 && form[0] === 'namespace' && typeof form[1] === 'string') {
+      const ns = form[1];
+      if (ns.includes('.')) {
+        diagnostics.push(new Diagnostic({
+          code: 'E009',
+          message: `Namespace name must not contain '.': "${ns}"`,
+          span,
+        }));
+      } else {
+        env.namespace = ns;
+        if (traceEnabled && trace) {
+          trace.push(new TraceEvent({ kind: 'namespace', detail: ns, span }));
+        }
+      }
+      continue;
+    }
+
+    // Handle (import <path>) and (import <path> as <alias>) at the top level —
+    // file-level directives, not regular RML expressions.
+    if (Array.isArray(form) && form[0] === 'import') {
+      let importDiag = null;
+      if (form.length === 2) {
+        importDiag = handleImport(form[1], null, span, file, env, importStack, importedFiles, diagnostics, traceEnabled, trace);
+      } else if (form.length === 4 && form[2] === 'as' && typeof form[3] === 'string') {
+        importDiag = handleImport(form[1], form[3], span, file, env, importStack, importedFiles, diagnostics, traceEnabled, trace);
+      } else if (form.length === 2 || form.length >= 3) {
+        importDiag = new Diagnostic({
+          code: 'E007',
+          message: 'Import directive must be (import "<path>") or (import "<path>" as <alias>)',
+          span,
+        });
+      }
       if (importDiag) diagnostics.push(importDiag);
       continue;
     }
@@ -988,6 +1133,11 @@ function evaluate(code, options) {
   }
   env._currentSpan = null;
   env._tracer = null;
+  // Surface shadow diagnostics (E008) collected during defineForm calls.
+  if (Array.isArray(env._shadowDiagnostics) && env._shadowDiagnostics.length > 0) {
+    for (const d of env._shadowDiagnostics) diagnostics.push(d);
+    env._shadowDiagnostics.length = 0;
+  }
   const out = { results, diagnostics };
   if (traceEnabled) out.trace = trace;
   return out;
@@ -1015,7 +1165,11 @@ function _resolveImportPath(target, importingFile) {
 }
 
 // Process a top-level (import <path>) directive. Returns a Diagnostic or null.
-function handleImport(rawTarget, span, importingFile, env, importStack, importedFiles, diagnostics, traceEnabled, trace) {
+// `alias`, when non-null, comes from the `(import "<path>" as <alias>)` form
+// (issue #34): after the imported file finishes evaluating, the alias is
+// recorded in `env.aliases` mapping `alias -> imported namespace`, so
+// references like `<alias>.foo` resolve against that namespace.
+function handleImport(rawTarget, alias, span, importingFile, env, importStack, importedFiles, diagnostics, traceEnabled, trace) {
   const target = _unquotePath(rawTarget);
   if (typeof target !== 'string' || !target) {
     return new Diagnostic({
@@ -1023,6 +1177,22 @@ function handleImport(rawTarget, span, importingFile, env, importStack, imported
       message: 'Import target must be a string path',
       span,
     });
+  }
+  if (alias !== null && alias !== undefined) {
+    if (typeof alias !== 'string' || !alias || alias.includes('.')) {
+      return new Diagnostic({
+        code: 'E009',
+        message: `Import alias must be a non-empty bare identifier (got "${alias}")`,
+        span,
+      });
+    }
+    if (env.aliases.has(alias) || env.namespace === alias) {
+      return new Diagnostic({
+        code: 'E009',
+        message: `Import alias "${alias}" collides with an existing namespace or alias`,
+        span,
+      });
+    }
   }
   const resolved = _resolveImportPath(target, importingFile);
 
@@ -1038,9 +1208,16 @@ function handleImport(rawTarget, span, importingFile, env, importStack, imported
   }
 
   // Cache: each file is loaded once. Repeated imports (e.g. diamond pattern)
-  // are silent no-ops.
+  // are silent no-ops — but the alias still needs to register, since the
+  // imported namespace is already loaded into the env.
   if (importedFiles.has(resolved)) {
-    if (traceEnabled && trace) {
+    if (alias) {
+      const recordedNs = (env._fileNamespaces && env._fileNamespaces.get(resolved)) || alias;
+      env.aliases.set(alias, recordedNs);
+      if (traceEnabled && trace) {
+        trace.push(new TraceEvent({ kind: 'import', detail: `${resolved} as ${alias} (cached)`, span }));
+      }
+    } else if (traceEnabled && trace) {
       trace.push(new TraceEvent({ kind: 'import', detail: `${resolved} (cached)`, span }));
     }
     return null;
@@ -1060,8 +1237,17 @@ function handleImport(rawTarget, span, importingFile, env, importStack, imported
   importedFiles.add(resolved);
   importStack.push(resolved);
   if (traceEnabled && trace) {
-    trace.push(new TraceEvent({ kind: 'import', detail: resolved, span }));
+    trace.push(new TraceEvent({ kind: 'import', detail: alias ? `${resolved} as ${alias}` : resolved, span }));
   }
+
+  // Track names introduced by this import so the importing file can fire a
+  // shadowing diagnostic (E008) if it later rebinds them. Snapshot the
+  // current bindings before evaluating the imported file, then diff.
+  const beforeOps = new Set(env.ops.keys());
+  const beforeSyms = new Set(env.symbolProb.keys());
+  const beforeTerms = new Set(env.terms);
+  const beforeLambdas = new Set(env.lambdas.keys());
+  const beforeNamespace = env.namespace;
 
   const inner = evaluate(text, {
     env,
@@ -1071,7 +1257,36 @@ function handleImport(rawTarget, span, importingFile, env, importStack, imported
     _importedFiles: importedFiles,
   });
 
+  // The imported file may have declared its own (namespace ...) — capture it
+  // before restoring the importing file's namespace so we can wire up the
+  // alias and remember the file's namespace for cached re-imports.
+  const importedNamespace = env.namespace;
+  env.namespace = beforeNamespace;
+  if (importedNamespace) {
+    if (!env._fileNamespaces) env._fileNamespaces = new Map();
+    env._fileNamespaces.set(resolved, importedNamespace);
+  }
+
   importStack.pop();
+
+  // Record names added by the import for shadowing detection. Skip this when
+  // the import is itself nested inside another import — only the top-level
+  // file should warn.
+  if (importStack.length === 0 || (importingFile && importStack[importStack.length - 1] === importingFile)) {
+    for (const k of env.ops.keys()) if (!beforeOps.has(k)) env.imported.add(k);
+    for (const k of env.symbolProb.keys()) if (!beforeSyms.has(k)) env.imported.add(k);
+    for (const k of env.terms) if (!beforeTerms.has(k)) env.imported.add(k);
+    for (const k of env.lambdas.keys()) if (!beforeLambdas.has(k)) env.imported.add(k);
+  }
+
+  // Wire up the alias once the imported file has finished evaluating. If the
+  // imported file declared a namespace, alias maps to it; otherwise it maps
+  // to the alias name itself (so qualified references through the alias still
+  // work for namespace-less files — symbols defined as top-level become
+  // accessible via `<alias>.<name>` only if pre-existing under that key).
+  if (alias) {
+    env.aliases.set(alias, importedNamespace || alias);
+  }
 
   // Forward inner diagnostics so the importer surfaces errors from the
   // imported file with their original spans intact.

--- a/js/tests/namespaces.test.mjs
+++ b/js/tests/namespaces.test.mjs
@@ -1,0 +1,148 @@
+// Tests for `(namespace ...)` and qualified references (issue #34).
+// Covers namespace declaration, alias imports, qualified lookup, alias
+// collisions (E009), and shadowing diagnostics (E008). The Rust suite
+// mirrors these in rust/tests/namespaces_tests.rs to keep the two
+// implementations in lock-step.
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { evaluate, evaluateFile } from '../src/rml-links.mjs';
+
+function makeTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rml-ns-'));
+}
+
+describe('(namespace ...) — declaration', () => {
+  let dir;
+  before(() => { dir = makeTmp(); });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('prefixes a definition with the active namespace', () => {
+    fs.writeFileSync(path.join(dir, 'lib.lino'),
+      '(namespace classical)\n(and: min)\n');
+    fs.writeFileSync(path.join(dir, 'main.lino'),
+      '(import "lib.lino")\n(? (classical.and 1 0))\n');
+    const out = evaluateFile(path.join(dir, 'main.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [0]);
+  });
+
+  it('supports multiple definitions under the same namespace', () => {
+    fs.writeFileSync(path.join(dir, 'lib2.lino'),
+      '(namespace classical)\n(and: min)\n(or: max)\n');
+    fs.writeFileSync(path.join(dir, 'main2.lino'),
+      '(import "lib2.lino")\n(? (classical.and 1 0))\n(? (classical.or 1 0))\n');
+    const out = evaluateFile(path.join(dir, 'main2.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [0, 1]);
+  });
+
+  it('rejects an empty or dotted namespace name with E009', () => {
+    fs.writeFileSync(path.join(dir, 'bad.lino'), '(namespace foo.bar)\n');
+    const out = evaluateFile(path.join(dir, 'bad.lino'));
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E009');
+  });
+});
+
+describe('(import "..." as <alias>) — aliased imports', () => {
+  let dir;
+  before(() => { dir = makeTmp(); });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('resolves qualified references through the alias', () => {
+    fs.writeFileSync(path.join(dir, 'classical.lino'),
+      '(namespace classical)\n(and: min)\n(or: max)\n');
+    fs.writeFileSync(path.join(dir, 'main.lino'),
+      '(import "classical.lino" as cl)\n(? (cl.and 1 0))\n(? (cl.or 1 0))\n');
+    const out = evaluateFile(path.join(dir, 'main.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [0, 1]);
+  });
+
+  it('emits E009 for an alias collision', () => {
+    fs.writeFileSync(path.join(dir, 'a.lino'),
+      '(namespace foo)\n(x: max)\n');
+    fs.writeFileSync(path.join(dir, 'b.lino'),
+      '(namespace bar)\n(x: min)\n');
+    fs.writeFileSync(path.join(dir, 'collide.lino'),
+      '(import "a.lino" as a)\n(import "b.lino" as a)\n');
+    const out = evaluateFile(path.join(dir, 'collide.lino'));
+    const e009s = out.diagnostics.filter(d => d.code === 'E009');
+    assert.strictEqual(e009s.length, 1);
+    assert.match(e009s[0].message, /alias "a"/);
+  });
+
+  it('lets two distinct aliases point at different namespaces', () => {
+    fs.writeFileSync(path.join(dir, 'la.lino'),
+      '(namespace foo)\n(and: max)\n');
+    fs.writeFileSync(path.join(dir, 'lb.lino'),
+      '(namespace bar)\n(and: min)\n');
+    fs.writeFileSync(path.join(dir, 'multi.lino'),
+      '(import "la.lino" as a)\n(import "lb.lino" as b)\n' +
+      '(? (a.and 0.2 0.5))\n(? (b.and 0.2 0.5))\n');
+    const out = evaluateFile(path.join(dir, 'multi.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [0.5, 0.2]);
+  });
+});
+
+describe('(namespace ...) — shadowing (E008)', () => {
+  let dir;
+  before(() => { dir = makeTmp(); });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('warns when a top-level op definition shadows an imported op', () => {
+    fs.writeFileSync(path.join(dir, 'lib.lino'), '(myop: avg)\n');
+    fs.writeFileSync(path.join(dir, 'main.lino'),
+      '(import "lib.lino")\n(myop: max)\n(? (myop 0.2 0.4 0.8))\n');
+    const out = evaluateFile(path.join(dir, 'main.lino'));
+    const e008s = out.diagnostics.filter(d => d.code === 'E008');
+    assert.strictEqual(e008s.length, 1);
+    assert.match(e008s[0].message, /myop/);
+    assert.match(e008s[0].message, /shadows/i);
+    // The redefinition still takes effect.
+    assert.deepStrictEqual(out.results, [0]);
+  });
+
+  it('warns when redefining a qualified name introduced via alias', () => {
+    fs.writeFileSync(path.join(dir, 'lib2.lino'),
+      '(namespace classical)\n(and: min)\n');
+    fs.writeFileSync(path.join(dir, 'main2.lino'),
+      '(import "lib2.lino" as cl)\n(cl.and: max)\n');
+    const out = evaluateFile(path.join(dir, 'main2.lino'));
+    const e008s = out.diagnostics.filter(d => d.code === 'E008');
+    assert.strictEqual(e008s.length, 1);
+    assert.match(e008s[0].message, /cl\.and/);
+  });
+
+  it('warns once even when the same imported name is rebound twice', () => {
+    fs.writeFileSync(path.join(dir, 'lib3.lino'), '(myop: avg)\n');
+    fs.writeFileSync(path.join(dir, 'main3.lino'),
+      '(import "lib3.lino")\n(myop: max)\n(myop: min)\n');
+    const out = evaluateFile(path.join(dir, 'main3.lino'));
+    const e008s = out.diagnostics.filter(d => d.code === 'E008');
+    assert.strictEqual(e008s.length, 1);
+  });
+
+  it('does not warn when an importing file defines a fresh name', () => {
+    fs.writeFileSync(path.join(dir, 'lib4.lino'), '(myop: avg)\n');
+    fs.writeFileSync(path.join(dir, 'main4.lino'),
+      '(import "lib4.lino")\n(otherop: max)\n');
+    const out = evaluateFile(path.join(dir, 'main4.lino'));
+    assert.strictEqual(out.diagnostics.filter(d => d.code === 'E008').length, 0);
+  });
+});
+
+describe('inline (namespace ...) without import', () => {
+  it('an in-source namespace prefix is honoured', () => {
+    const out = evaluate(
+      '(namespace foo)\n(and: min)\n(? (foo.and 1 0))\n',
+    );
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [0]);
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -616,6 +616,18 @@ pub struct Env {
     pub trace_events: Vec<TraceEvent>,
     pub current_span: Option<Span>,
     pub default_span: Span,
+    /// Namespace state (issue #34): a file can declare `(namespace foo)`, which
+    /// prefixes every name it subsequently introduces with `foo.`. Imports can
+    /// be aliased via `(import "x.lino" as a)`, which records `a` -> the
+    /// imported file's declared namespace so `a.name` resolves to that name.
+    /// `imported` tracks names that came from an import (not declared in the
+    /// importing file) so we can emit a shadowing warning (E008) when a later
+    /// top-level definition rebinds them.
+    pub namespace: Option<String>,
+    pub aliases: HashMap<String, String>,
+    pub imported: HashSet<String>,
+    pub shadow_diagnostics: Vec<Diagnostic>,
+    pub file_namespaces: HashMap<PathBuf, String>,
 }
 
 impl Env {
@@ -652,6 +664,11 @@ impl Env {
             trace_events: Vec::new(),
             current_span: None,
             default_span: Span::unknown(),
+            namespace: None,
+            aliases: HashMap::new(),
+            imported: HashSet::new(),
+            shadow_diagnostics: Vec::new(),
+            file_namespaces: HashMap::new(),
         };
 
         // Initialize truth constants: true, false, unknown, undefined
@@ -701,7 +718,67 @@ impl Env {
     }
 
     pub fn get_op(&self, name: &str) -> Option<&Op> {
-        self.ops.get(name)
+        if let Some(op) = self.ops.get(name) {
+            return Some(op);
+        }
+        let resolved = self.resolve_qualified(name);
+        if resolved != name {
+            return self.ops.get(&resolved);
+        }
+        None
+    }
+
+    pub fn has_op(&self, name: &str) -> bool {
+        if self.ops.contains_key(name) {
+            return true;
+        }
+        let resolved = self.resolve_qualified(name);
+        resolved != name && self.ops.contains_key(&resolved)
+    }
+
+    /// Apply the active namespace to a freshly declared name, e.g. inside
+    /// `(namespace classical)` the form `(and: min)` registers `classical.and`,
+    /// not `and`. Names that already contain a `.` are passed through.
+    /// Mirrors `Env.qualifyName` in `js/src/rml-links.mjs`.
+    pub fn qualify_name(&self, name: &str) -> String {
+        if let Some(ns) = &self.namespace {
+            if !name.contains('.') {
+                return format!("{}.{}", ns, name);
+            }
+        }
+        name.to_string()
+    }
+
+    /// Resolve a possibly-qualified name to its canonical storage key. Order:
+    ///   1. Alias prefix: `cl.foo` with alias `cl -> classical` becomes
+    ///      `classical.foo`.
+    ///   2. Active namespace: an unqualified name lives in `<ns>.<name>`.
+    ///   3. Bare name: returned unchanged.
+    /// Used by lookup helpers (operators, symbol probabilities) to find
+    /// namespaced bindings without forcing every call site to spell them out.
+    /// Mirrors `Env._resolveQualified` in `js/src/rml-links.mjs`.
+    pub fn resolve_qualified(&self, name: &str) -> String {
+        if let Some(dot_idx) = name.find('.') {
+            if dot_idx > 0 {
+                let prefix = &name[..dot_idx];
+                let rest = &name[dot_idx + 1..];
+                if let Some(target_ns) = self.aliases.get(prefix) {
+                    return format!("{}.{}", target_ns, rest);
+                }
+            }
+            return name.to_string();
+        }
+        if let Some(ns) = &self.namespace {
+            let qualified = format!("{}.{}", ns, name);
+            if self.ops.contains_key(&qualified)
+                || self.symbol_prob.contains_key(&qualified)
+                || self.terms.contains(&qualified)
+                || self.lambdas.contains_key(&qualified)
+            {
+                return qualified;
+            }
+        }
+        name.to_string()
     }
 
     pub fn set_expr_prob(&mut self, expr_node: &Node, p: f64) {
@@ -713,10 +790,16 @@ impl Env {
     }
 
     pub fn get_symbol_prob(&self, sym: &str) -> f64 {
-        self.symbol_prob
-            .get(sym)
-            .copied()
-            .unwrap_or_else(|| self.mid())
+        if let Some(&v) = self.symbol_prob.get(sym) {
+            return v;
+        }
+        let resolved = self.resolve_qualified(sym);
+        if resolved != sym {
+            if let Some(&v) = self.symbol_prob.get(&resolved) {
+                return v;
+            }
+        }
+        self.mid()
     }
 
     /// Push a trace event when tracing is enabled. The event's span is taken
@@ -747,14 +830,31 @@ impl Env {
     }
 
     pub fn get_lambda(&self, name: &str) -> Option<&Lambda> {
-        self.lambdas.get(name)
+        if let Some(l) = self.lambdas.get(name) {
+            return Some(l);
+        }
+        let resolved = self.resolve_qualified(name);
+        if resolved != name {
+            return self.lambdas.get(&resolved);
+        }
+        None
     }
 
     /// Apply an operator by name to the given values.
     pub fn apply_op(&self, name: &str, vals: &[f64]) -> f64 {
         let op = match self.ops.get(name) {
             Some(op) => op.clone(),
-            None => panic!("Unknown op: {}", name),
+            None => {
+                let resolved = self.resolve_qualified(name);
+                if resolved != name {
+                    match self.ops.get(&resolved) {
+                        Some(op) => op.clone(),
+                        None => panic!("Unknown op: {}", name),
+                    }
+                } else {
+                    panic!("Unknown op: {}", name)
+                }
+            }
         };
         match op {
             Op::Not => {
@@ -1426,7 +1526,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             // Prefix: (not X), (and X Y ...), (or X Y ...)
             if let Node::Leaf(ref head) = children[0] {
                 let head_str = head.clone();
-                if env.ops.contains_key(&head_str) {
+                if env.has_op(&head_str) {
                     let vals: Vec<f64> = children[1..]
                         .iter()
                         .map(|a| eval_node(a, env).as_f64())
@@ -1464,44 +1564,7 @@ fn apply_named_op_on_nodes(env: &mut Env, op_name: &str, left: &Node, right: &No
 
 /// Process definition forms: (head: rhs...)
 fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
-    // Term definition: (a: a is a) → declare 'a' as a term
-    if rhs.len() == 3 {
-        if let (Node::Leaf(ref r0), Node::Leaf(ref r1), Node::Leaf(ref r2)) =
-            (&rhs[0], &rhs[1], &rhs[2])
-        {
-            if r1 == "is" && r0 == head && r2 == head {
-                env.terms.insert(head.to_string());
-                return EvalResult::Value(1.0);
-            }
-        }
-    }
-
-    // Prefix type notation: (name: TypeName name) → typed self-referential declaration
-    // e.g. (zero: Natural zero), (boolean: Type boolean), (true: Boolean true)
-    if rhs.len() == 2 {
-        if let Node::Leaf(ref last) = rhs[1] {
-            if last == head {
-                match &rhs[0] {
-                    Node::Leaf(ref type_name)
-                        if type_name.starts_with(|c: char| c.is_uppercase()) =>
-                    {
-                        env.terms.insert(head.to_string());
-                        env.types.insert(head.to_string(), type_name.clone());
-                        return EvalResult::Value(1.0);
-                    }
-                    Node::List(_) => {
-                        env.terms.insert(head.to_string());
-                        let type_key = key_of(&rhs[0]);
-                        env.types.insert(head.to_string(), type_key);
-                        eval_node(&rhs[0], env);
-                        return EvalResult::Value(1.0);
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-
+    // Configuration directives are file-level and never namespaced.
     // Range configuration: (range: lo hi)
     if head == "range" && rhs.len() == 2 {
         if let (Node::Leaf(ref lo_s), Node::Leaf(ref hi_s)) = (&rhs[0], &rhs[1]) {
@@ -1524,12 +1587,61 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         }
     }
 
+    // Bindings introduced inside `(namespace foo)` are stored under `foo.head`.
+    // The syntactic head (e.g. `a` in `(a: a is a)`) is still used to match
+    // patterns; only the storage key is qualified.
+    let store_name = env.qualify_name(head);
+    // Shadowing diagnostic (E008): if this name was already imported, warn.
+    if store_name != head || env.namespace.is_none() {
+        maybe_warn_shadow(env, &store_name);
+    } else {
+        maybe_warn_shadow(env, head);
+    }
+
+    // Term definition: (a: a is a) → declare 'a' as a term
+    if rhs.len() == 3 {
+        if let (Node::Leaf(ref r0), Node::Leaf(ref r1), Node::Leaf(ref r2)) =
+            (&rhs[0], &rhs[1], &rhs[2])
+        {
+            if r1 == "is" && r0 == head && r2 == head {
+                env.terms.insert(store_name.clone());
+                return EvalResult::Value(1.0);
+            }
+        }
+    }
+
+    // Prefix type notation: (name: TypeName name) → typed self-referential declaration
+    // e.g. (zero: Natural zero), (boolean: Type boolean), (true: Boolean true)
+    if rhs.len() == 2 {
+        if let Node::Leaf(ref last) = rhs[1] {
+            if last == head {
+                match &rhs[0] {
+                    Node::Leaf(ref type_name)
+                        if type_name.starts_with(|c: char| c.is_uppercase()) =>
+                    {
+                        env.terms.insert(store_name.clone());
+                        env.types.insert(store_name.clone(), type_name.clone());
+                        return EvalResult::Value(1.0);
+                    }
+                    Node::List(_) => {
+                        env.terms.insert(store_name.clone());
+                        let type_key = key_of(&rhs[0]);
+                        env.types.insert(store_name.clone(), type_key);
+                        eval_node(&rhs[0], env);
+                        return EvalResult::Value(1.0);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     // Optional symbol prior: (a: 0.7)
     if rhs.len() == 1 {
         if let Node::Leaf(ref val_s) = rhs[0] {
             if is_num(val_s) {
                 let p: f64 = val_s.parse().unwrap_or(0.0);
-                env.set_symbol_prob(head, p);
+                env.set_symbol_prob(&store_name, p);
                 return EvalResult::Value(env.to_num(val_s));
             }
         }
@@ -1552,22 +1664,22 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         // Composition like: (!=: not =) or (=: =) (no-op)
         if rhs.len() == 2 {
             if let (Node::Leaf(ref outer), Node::Leaf(ref inner)) = (&rhs[0], &rhs[1]) {
-                if env.ops.contains_key(outer.as_str()) && env.ops.contains_key(inner.as_str()) {
+                if env.has_op(outer.as_str()) && env.has_op(inner.as_str()) {
                     env.define_op(
-                        head,
+                        &store_name,
                         Op::Compose {
                             outer: outer.clone(),
                             inner: inner.clone(),
                         },
                     );
-                    env.trace("resolve", format!("({}: {} {})", head, outer, inner));
+                    env.trace("resolve", format!("({}: {} {})", store_name, outer, inner));
                     return EvalResult::Value(1.0);
                 }
                 // Mirror JS behavior: surface a diagnostic for the missing op.
-                if !env.ops.contains_key(outer.as_str()) {
+                if !env.has_op(outer.as_str()) {
                     panic!("Unknown op: {}", outer);
                 }
-                if !env.ops.contains_key(inner.as_str()) {
+                if !env.has_op(inner.as_str()) {
                     panic!("Unknown op: {}", inner);
                 }
             }
@@ -1578,8 +1690,8 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         {
             if let Node::Leaf(ref sel) = rhs[0] {
                 if let Some(agg) = Aggregator::from_name(sel) {
-                    env.define_op(head, Op::Agg(agg));
-                    env.trace("resolve", format!("({}: {})", head, sel));
+                    env.define_op(&store_name, Op::Agg(agg));
+                    env.trace("resolve", format!("({}: {})", store_name, sel));
                     return EvalResult::Value(1.0);
                 } else {
                     panic!("Unknown aggregator \"{}\"", sel);
@@ -1594,7 +1706,7 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
             if first == "lambda" && rhs.len() == 3 {
                 if let Some((param_name, param_type)) = parse_binding(&rhs[1]) {
                     let body = rhs[2].clone();
-                    env.terms.insert(head.to_string());
+                    env.terms.insert(store_name.clone());
                     let body_key = key_of(&body);
                     let body_type =
                         env.get_type(&body_key)
@@ -1604,11 +1716,11 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
                                 other => key_of(other),
                             });
                     env.set_type(
-                        head,
+                        &store_name,
                         &format!("(Pi ({} {}) {})", param_type, param_name, body_type),
                     );
                     env.set_lambda(
-                        head,
+                        &store_name,
                         Lambda {
                             param: param_name,
                             param_type,
@@ -1639,9 +1751,9 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
 
         if !is_op {
             if let Node::List(_) = &rhs[0] {
-                env.terms.insert(head.to_string());
+                env.terms.insert(store_name.clone());
                 let type_key = key_of(&rhs[0]);
-                env.set_type(head, &type_key);
+                env.set_type(&store_name, &type_key);
                 eval_node(&rhs[0], env);
                 return EvalResult::Value(1.0);
             }
@@ -1652,13 +1764,47 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
     if rhs.len() == 1 {
         if let Node::Leaf(ref sym) = rhs[0] {
             let prob = env.get_symbol_prob(sym);
-            env.set_symbol_prob(head, prob);
-            return EvalResult::Value(env.get_symbol_prob(head));
+            env.set_symbol_prob(&store_name, prob);
+            return EvalResult::Value(env.get_symbol_prob(&store_name));
         }
     }
 
     // Else: ignore (keeps PoC minimal)
     EvalResult::Value(0.0)
+}
+
+/// Emit a shadowing warning (E008) if the name being defined was previously
+/// brought in via `(import ...)`. The import handler tracks names it added to
+/// the environment in `env.imported`; the importing file's own definitions are
+/// not in that set, so re-binding them locally never triggers the warning.
+/// Diagnostics are appended to `env.shadow_diagnostics` and surfaced by the
+/// outer `evaluate_inner` boundary alongside other diagnostics.
+fn maybe_warn_shadow(env: &mut Env, name: &str) {
+    // Resolve the name through alias mappings so a re-binding like `(cl.and: ...)`
+    // matches the canonical imported key `classical.and`.
+    let key = if env.imported.contains(name) {
+        name.to_string()
+    } else {
+        let resolved = env.resolve_qualified(name);
+        if resolved != name && env.imported.contains(&resolved) {
+            resolved
+        } else {
+            return;
+        }
+    };
+    // Only warn once per name to keep noise down; remove from imported so the
+    // shadow only fires the first time it's rebinding.
+    env.imported.remove(&key);
+    let span = env
+        .current_span
+        .clone()
+        .unwrap_or_else(|| env.default_span.clone());
+    let diag = Diagnostic::new(
+        "E008",
+        format!("Definition of \"{}\" shadows an imported binding", name),
+        span,
+    );
+    env.shadow_diagnostics.push(diag);
 }
 
 // ========== Meta-expression Adapter ==========
@@ -2145,8 +2291,13 @@ fn canonicalize_import(p: &Path) -> PathBuf {
 /// and evaluates its contents against the same `env`, threading the import
 /// context for cycle detection and caching. Returns a `Diagnostic` if the
 /// import itself fails (cycle, missing file, bad target).
+///
+/// When `alias` is Some, the imported file's declared namespace (or the alias
+/// itself if no namespace was declared) is registered as `aliases[alias] -> ns`
+/// so qualified references like `(? (alias.foo))` resolve into that namespace.
 fn handle_import(
     target_node: &Node,
+    alias: Option<&str>,
     span: &Span,
     importing_file: Option<&str>,
     env: &mut Env,
@@ -2172,6 +2323,21 @@ fn handle_import(
             span.clone(),
         ));
     }
+
+    // Validate alias collisions before reading the file.
+    if let Some(a) = alias {
+        if env.aliases.contains_key(a) || env.namespace.as_deref() == Some(a) {
+            return Some(Diagnostic::new(
+                "E009",
+                format!(
+                    "Import alias \"{}\" collides with an existing namespace or alias",
+                    a
+                ),
+                span.clone(),
+            ));
+        }
+    }
+
     let unresolved = resolve_import_path(&raw, importing_file);
     let resolved = canonicalize_import(&unresolved);
 
@@ -2190,6 +2356,16 @@ fn handle_import(
     }
 
     if ctx.loaded.contains(&resolved) {
+        // For cached re-imports, the imported namespace is already loaded
+        // into the env. We only need to wire up the alias.
+        if let Some(a) = alias {
+            let recorded_ns = env
+                .file_namespaces
+                .get(&resolved)
+                .cloned()
+                .unwrap_or_else(|| a.to_string());
+            env.aliases.insert(a.to_string(), recorded_ns);
+        }
         if options.trace {
             env.trace_events.push(TraceEvent::new(
                 "import",
@@ -2221,9 +2397,58 @@ fn handle_import(
         ));
     }
 
+    // Snapshot bindings so we can diff after the import to learn which names
+    // were introduced by the imported file. Used to surface E008 when a later
+    // top-level definition rebinds them.
+    let before_ops: HashSet<String> = env.ops.keys().cloned().collect();
+    let before_syms: HashSet<String> = env.symbol_prob.keys().cloned().collect();
+    let before_terms: HashSet<String> = env.terms.iter().cloned().collect();
+    let before_lambdas: HashSet<String> = env.lambdas.keys().cloned().collect();
+    let before_namespace = env.namespace.clone();
+
     let resolved_str = resolved.to_string_lossy().into_owned();
     let inner = evaluate_inner(&text, Some(&resolved_str), env, options, ctx);
     ctx.stack.pop();
+
+    // The imported file may have declared its own (namespace ...) — capture it
+    // before restoring the importing file's namespace so we can wire up the
+    // alias and remember the file's namespace for cached re-imports.
+    let imported_namespace = env.namespace.clone();
+    env.namespace = before_namespace;
+    if let Some(ns) = &imported_namespace {
+        env.file_namespaces.insert(resolved.clone(), ns.clone());
+    }
+
+    // Track which bindings the imported file added so a later top-level
+    // definition that rebinds them surfaces an E008 shadowing warning.
+    for k in env.ops.keys() {
+        if !before_ops.contains(k) {
+            env.imported.insert(k.clone());
+        }
+    }
+    for k in env.symbol_prob.keys() {
+        if !before_syms.contains(k) {
+            env.imported.insert(k.clone());
+        }
+    }
+    for k in env.terms.iter() {
+        if !before_terms.contains(k) {
+            env.imported.insert(k.clone());
+        }
+    }
+    for k in env.lambdas.keys() {
+        if !before_lambdas.contains(k) {
+            env.imported.insert(k.clone());
+        }
+    }
+
+    // Wire up the alias once the imported file has finished evaluating. If the
+    // imported file declared a namespace, alias maps to it; otherwise it maps
+    // to the alias itself (so qualified refs `alias.x` resolve to `alias.x`).
+    if let Some(a) = alias {
+        let target_ns = imported_namespace.unwrap_or_else(|| a.to_string());
+        env.aliases.insert(a.to_string(), target_ns);
+    }
 
     for diag in inner.diagnostics {
         diagnostics.push(diag);
@@ -2290,20 +2515,76 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
             .unwrap_or_else(|| Span::new(file.map(|s| s.to_string()), 1, 1, 0));
         env.current_span = Some(span.clone());
 
-        // Top-level (import <path>) directive — handled before regular
-        // evaluation so it can recursively call evaluate_inner against the
-        // same env while threading the import context.
+        // Top-level (namespace <name>) directive — sets the active namespace
+        // for all subsequent definitions in this file. The `(namespace foo)`
+        // form is itself never namespaced. (issue #34)
         if let Node::List(children) = &form {
             if children.len() == 2 {
-                if let Node::Leaf(head) = &children[0] {
-                    if head == "import" {
+                if let (Node::Leaf(h), Node::Leaf(n)) = (&children[0], &children[1]) {
+                    if h == "namespace" {
+                        if n.is_empty() || n.contains('.') {
+                            diagnostics.push(Diagnostic::new(
+                                "E009",
+                                format!("Invalid namespace name \"{}\"", n),
+                                span.clone(),
+                            ));
+                        } else {
+                            env.namespace = Some(n.clone());
+                            if options.trace {
+                                env.trace_events
+                                    .push(TraceEvent::new("namespace", n.clone(), span.clone()));
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Top-level (import <path>) and (import <path> as <alias>) directives —
+        // handled before regular evaluation so they can recursively call
+        // evaluate_inner against the same env while threading the import
+        // context.
+        if let Node::List(children) = &form {
+            if let Some(Node::Leaf(head)) = children.first() {
+                if head == "import" {
+                    if children.len() == 2 {
                         let target = children[1].clone();
-                        if let Some(diag) =
-                            handle_import(&target, &span, file, env, options, ctx, &mut diagnostics)
-                        {
+                        if let Some(diag) = handle_import(
+                            &target,
+                            None,
+                            &span,
+                            file,
+                            env,
+                            options,
+                            ctx,
+                            &mut diagnostics,
+                        ) {
                             diagnostics.push(diag);
                         }
                         continue;
+                    }
+                    if children.len() == 4 {
+                        if let (Node::Leaf(as_kw), Node::Leaf(alias_name)) =
+                            (&children[2], &children[3])
+                        {
+                            if as_kw == "as" {
+                                let target = children[1].clone();
+                                if let Some(diag) = handle_import(
+                                    &target,
+                                    Some(alias_name),
+                                    &span,
+                                    file,
+                                    env,
+                                    options,
+                                    ctx,
+                                    &mut diagnostics,
+                                ) {
+                                    diagnostics.push(diag);
+                                }
+                                continue;
+                            }
+                        }
                     }
                 }
             }
@@ -2355,6 +2636,16 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
     env.current_span = None;
 
     std::panic::set_hook(prev_hook);
+
+    // Surface any shadow diagnostics collected during this evaluation pass.
+    // Drain them so a nested evaluate_inner (called from handle_import) does
+    // not re-emit the same diagnostic at the outer boundary.
+    if !env.shadow_diagnostics.is_empty() {
+        let drained = std::mem::take(&mut env.shadow_diagnostics);
+        for d in drained {
+            diagnostics.push(d);
+        }
+    }
 
     let trace = if options.trace {
         std::mem::take(&mut env.trace_events)

--- a/rust/tests/namespaces_tests.rs
+++ b/rust/tests/namespaces_tests.rs
@@ -1,0 +1,242 @@
+// Tests for `(namespace ...)` and qualified references (issue #34).
+// Mirrors js/tests/namespaces.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{evaluate, evaluate_file, EvaluateOptions, RunResult};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn make_tmp(tag: &str) -> PathBuf {
+    let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let mut p = std::env::temp_dir();
+    p.push(format!("rml-rust-ns-{}-{}-{}", tag, pid, n));
+    fs::create_dir_all(&p).expect("create tmp");
+    p
+}
+
+fn write(dir: &PathBuf, name: &str, body: &str) -> PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).expect("write tmp file");
+    p
+}
+
+fn cleanup(dir: &PathBuf) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+fn expect_num(r: &RunResult) -> f64 {
+    match r {
+        RunResult::Num(n) => *n,
+        other => panic!("expected numeric result, got {:?}", other),
+    }
+}
+
+// ---- (namespace ...) — declaration ----
+
+#[test]
+fn namespace_prefixes_a_definition_with_the_active_namespace() {
+    let dir = make_tmp("decl1");
+    write(&dir, "lib.lino", "(namespace classical)\n(and: min)\n");
+    let main = write(
+        &dir,
+        "main.lino",
+        "(import \"lib.lino\")\n(? (classical.and 1 0))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 0.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn namespace_supports_multiple_definitions() {
+    let dir = make_tmp("decl2");
+    write(
+        &dir,
+        "lib2.lino",
+        "(namespace classical)\n(and: min)\n(or: max)\n",
+    );
+    let main = write(
+        &dir,
+        "main2.lino",
+        "(import \"lib2.lino\")\n(? (classical.and 1 0))\n(? (classical.or 1 0))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 2);
+    assert!((expect_num(&out.results[0]) - 0.0).abs() < 1e-9);
+    assert!((expect_num(&out.results[1]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn namespace_rejects_dotted_name_with_e009() {
+    let dir = make_tmp("decl3");
+    let bad = write(&dir, "bad.lino", "(namespace foo.bar)\n");
+    let out = evaluate_file(bad.to_str().unwrap(), EvaluateOptions::default());
+    assert_eq!(out.diagnostics.len(), 1, "{:?}", out.diagnostics);
+    assert_eq!(out.diagnostics[0].code, "E009");
+    cleanup(&dir);
+}
+
+// ---- (import "..." as <alias>) — aliased imports ----
+
+#[test]
+fn aliased_import_resolves_qualified_references() {
+    let dir = make_tmp("alias1");
+    write(
+        &dir,
+        "classical.lino",
+        "(namespace classical)\n(and: min)\n(or: max)\n",
+    );
+    let main = write(
+        &dir,
+        "main.lino",
+        "(import \"classical.lino\" as cl)\n(? (cl.and 1 0))\n(? (cl.or 1 0))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 2);
+    assert!((expect_num(&out.results[0]) - 0.0).abs() < 1e-9);
+    assert!((expect_num(&out.results[1]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn aliased_import_emits_e009_on_alias_collision() {
+    let dir = make_tmp("alias2");
+    write(&dir, "a.lino", "(namespace foo)\n(x: max)\n");
+    write(&dir, "b.lino", "(namespace bar)\n(x: min)\n");
+    let collide = write(
+        &dir,
+        "collide.lino",
+        "(import \"a.lino\" as a)\n(import \"b.lino\" as a)\n",
+    );
+    let out = evaluate_file(collide.to_str().unwrap(), EvaluateOptions::default());
+    let e009s: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E009").collect();
+    assert_eq!(e009s.len(), 1, "{:?}", out.diagnostics);
+    assert!(
+        e009s[0].message.contains("alias \"a\""),
+        "{}",
+        e009s[0].message
+    );
+    cleanup(&dir);
+}
+
+#[test]
+fn distinct_aliases_point_at_different_namespaces() {
+    let dir = make_tmp("alias3");
+    write(&dir, "la.lino", "(namespace foo)\n(and: max)\n");
+    write(&dir, "lb.lino", "(namespace bar)\n(and: min)\n");
+    let multi = write(
+        &dir,
+        "multi.lino",
+        "(import \"la.lino\" as a)\n(import \"lb.lino\" as b)\n\
+         (? (a.and 0.2 0.5))\n(? (b.and 0.2 0.5))\n",
+    );
+    let out = evaluate_file(multi.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 2);
+    assert!((expect_num(&out.results[0]) - 0.5).abs() < 1e-9);
+    assert!((expect_num(&out.results[1]) - 0.2).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+// ---- (namespace ...) — shadowing (E008) ----
+
+#[test]
+fn shadowing_emits_e008_for_op_redefinition() {
+    let dir = make_tmp("shadow1");
+    write(&dir, "lib.lino", "(myop: avg)\n");
+    let main = write(
+        &dir,
+        "main.lino",
+        "(import \"lib.lino\")\n(myop: max)\n(? (myop 0.2 0.4 0.8))\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    let e008s: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E008").collect();
+    assert_eq!(e008s.len(), 1, "{:?}", out.diagnostics);
+    assert!(e008s[0].message.contains("myop"), "{}", e008s[0].message);
+    assert!(
+        e008s[0].message.to_lowercase().contains("shadows"),
+        "{}",
+        e008s[0].message
+    );
+    // The redefinition still takes effect (mirrors the JS suite assertion).
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 0.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn shadowing_emits_e008_for_qualified_rebind() {
+    let dir = make_tmp("shadow2");
+    write(
+        &dir,
+        "lib2.lino",
+        "(namespace classical)\n(and: min)\n",
+    );
+    let main = write(
+        &dir,
+        "main2.lino",
+        "(import \"lib2.lino\" as cl)\n(cl.and: max)\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    let e008s: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E008").collect();
+    assert_eq!(e008s.len(), 1, "{:?}", out.diagnostics);
+    assert!(
+        e008s[0].message.contains("cl.and"),
+        "{}",
+        e008s[0].message
+    );
+    cleanup(&dir);
+}
+
+#[test]
+fn shadowing_warns_only_once_for_double_rebind() {
+    let dir = make_tmp("shadow3");
+    write(&dir, "lib3.lino", "(myop: avg)\n");
+    let main = write(
+        &dir,
+        "main3.lino",
+        "(import \"lib3.lino\")\n(myop: max)\n(myop: min)\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    let e008s: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E008").collect();
+    assert_eq!(e008s.len(), 1, "{:?}", out.diagnostics);
+    cleanup(&dir);
+}
+
+#[test]
+fn shadowing_does_not_warn_for_fresh_name() {
+    let dir = make_tmp("shadow4");
+    write(&dir, "lib4.lino", "(myop: avg)\n");
+    let main = write(
+        &dir,
+        "main4.lino",
+        "(import \"lib4.lino\")\n(otherop: max)\n",
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    let e008s: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E008").collect();
+    assert_eq!(e008s.len(), 0, "{:?}", out.diagnostics);
+    cleanup(&dir);
+}
+
+// ---- inline (namespace ...) without import ----
+
+#[test]
+fn inline_namespace_prefix_is_honoured() {
+    let out = evaluate(
+        "(namespace foo)\n(and: min)\n(? (foo.and 1 0))\n",
+        None,
+        None,
+    );
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 0.0).abs() < 1e-9);
+}


### PR DESCRIPTION
## Summary

Adds `(namespace ...)` declarations and qualified references to RML, mirrored across the JavaScript and Rust runtimes.

- `(namespace classical)` at the top of a file prefixes every definition in that file with `classical.` so they expose as `classical.and`, `classical.or`, etc.
- `(import "lib.lino" as cl)` registers an alias so qualified references like `(? (cl.and 1 0))` resolve through the alias map back to the canonical namespace.
- Re-binding an imported name (e.g., `(import "lib.lino")` followed by `(myop: max)` when `lib.lino` defined `myop`) now emits the new **E008** *shadowing* diagnostic. The redefinition still takes effect — E008 is informational, not fatal.
- Invalid namespace names (`(namespace foo.bar)`, empty namespace) and alias collisions (`(import "a" as a) (import "b" as a)`) emit the new **E009** *namespace/alias error* diagnostic.
- Inline `(namespace foo)` works for in-source code without an import.

## Reproducible example

```lino
;; lib.lino
(namespace classical)
(and: min)
(or:  max)
```

```lino
;; main.lino
(import "lib.lino" as cl)
(? (cl.and 1 0))   ;; → 0
(? (cl.or  1 0))   ;; → 1
```

## Test plan

- [x] JS: `cd js && node --test tests/namespaces.test.mjs` — 11/11 pass
- [x] JS: full suite `cd js && node --test tests/` — 476/476 pass
- [x] Rust: `cd rust && cargo test --test namespaces_tests` — 11/11 pass
- [x] Rust: full suite `cd rust && cargo test` — all suites green (242 unit + 11 namespace + remaining integration)
- [x] Verified shadowing emits E008 once per imported binding, even on double rebind
- [x] Verified alias collisions emit E009 with the offending alias in the message
- [x] Verified inline `(namespace ...)` without import still prefixes definitions

## Files

- `js/src/rml-links.mjs` — namespace, alias map, qualified resolution, E008/E009 emission
- `rust/src/lib.rs` — Rust mirror of the same logic
- `js/tests/namespaces.test.mjs`, `rust/tests/namespaces_tests.rs` — paired test suites
- `docs/DIAGNOSTICS.md` — E008 and E009 rows
- `js/package.json`, `rust/Cargo.toml` — version bump 0.11.0 → 0.12.0

Fixes #34