### PR TITLE
[C1] Proof-producing evaluator

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T18:46:24.144Z for PR creation at branch issue-35-aa8178921c5a for issue https://github.com/link-foundation/relative-meta-logic/issues/35

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T18:46:24.144Z for PR creation at branch issue-35-aa8178921c5a for issue https://github.com/link-foundation/relative-meta-logic/issues/35

--- a/experiments/test-proofs.mjs
+++ b/experiments/test-proofs.mjs
@@ -1,0 +1,69 @@
+// Quick smoke test for the proof-producing evaluator (issue #35).
+// Exercises: structural equality, assigned probability, arithmetic,
+// and-or composition, type witnesses, and the round-trip property.
+
+import {
+  evaluate,
+  buildProof,
+  keyOf,
+  parseOne,
+  tokenizeOne,
+  isStructurallySame,
+} from '../js/src/rml-links.mjs';
+
+function show(label, src, opts) {
+  const out = evaluate(src, opts);
+  console.log(`\n=== ${label} ===`);
+  console.log(`source: ${src.replace(/\n/g, ' | ')}`);
+  console.log(`results:    ${JSON.stringify(out.results)}`);
+  console.log(`proofs:     ${JSON.stringify(out.proofs)}`);
+  if (Array.isArray(out.proofs)) {
+    out.proofs.forEach((p, i) => {
+      if (!p) {
+        console.log(`  proof[${i}]: <none>`);
+        return;
+      }
+      const printed = keyOf(p);
+      const reparsed = parseOne(tokenizeOne(printed));
+      const ok = isStructurallySame(p, reparsed) ? 'OK' : 'MISMATCH';
+      console.log(`  proof[${i}] (${ok}): ${printed}`);
+    });
+  }
+  if (out.diagnostics && out.diagnostics.length) {
+    console.log(`diagnostics: ${out.diagnostics.map(d => `${d.code} ${d.message}`).join('; ')}`);
+  }
+  return out;
+}
+
+// 1. Structural equality from the issue example.
+show('issue example: (? (a = a) with proof)', '(a: a is a)\n(? (a = a) with proof)');
+
+// 2. Same query under the global flag, no inline keyword.
+show('global withProofs', '(a: a is a)\n(? (a = a))', { withProofs: true });
+
+// 3. Assigned-probability lookup.
+show('assigned equality', '((a = a) has probability 0.7)\n(? (a = a))', { withProofs: true });
+
+// 4. Arithmetic.
+show('arithmetic +', '(? (1 + 2))', { withProofs: true });
+
+// 5. And/or composition.
+show('and/or composition',
+  ['(a: a is a)', '(b: b is b)',
+   '((a = a) has probability 1)', '((b = b) has probability 0)',
+   '(? ((a = a) and (b = b)))'].join('\n'),
+  { withProofs: true });
+
+// 6. Composite both/neither.
+show('composite both', '(? (both 1 and 0 and 1))', { withProofs: true });
+
+// 7. Mixed: bare query + with-proof query in the same file.
+show('mixed bare + with proof',
+  '(? (1 + 1))\n(? (2 * 2) with proof)');
+
+// 8. Negation (prefix operator).
+show('prefix not', '(? (not 1))', { withProofs: true });
+
+// 9. No proofs requested: must keep original {results, diagnostics} shape.
+const noProofs = evaluate('(? 1)', {});
+console.log(`\n=== no proofs ===\nshape: ${Object.keys(noProofs).join(',')}`);

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -464,6 +464,169 @@ function formatTraceValue(v) {
   return s;
 }
 
+// ---------- Proof derivations (issue #35) ----------
+// A derivation is a Node tree of the form `(by <rule> <subderivation>...)`,
+// expressed as a JS array so it round-trips through the existing `keyOf`
+// (print) / `parseOne(tokenizeOne(...))` (parse) helpers without needing a
+// new format. `buildProof` is invoked by `evaluate()` (and the inline
+// `(? expr with proof)` query form) once a top-level form has been
+// evaluated; it walks the same structural cases as `evalNode` to attach the
+// rule that fired at each step.
+//
+// The walker is intentionally read-only — it never mutates the env beyond
+// the lookups that `evalNode` would have performed during evaluation, so
+// enabling proofs cannot change query results. Sub-derivations recurse
+// through `buildProof` so every sub-expression carries its own witness
+// rather than collapsing into the literal value.
+function _wrap(rule, ...subs) {
+  return ['by', rule, ...subs];
+}
+
+// Pretty-print a numeric value the same way `formatTraceValue` does so
+// proof-result links such as `(eq L R 1)` stay stable across runs.
+function _proofValue(v) {
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    const s = formatTraceValue(v);
+    return s;
+  }
+  return String(v);
+}
+
+function buildProof(node, env) {
+  // Literals
+  if (typeof node === 'string') {
+    if (isNum(node)) {
+      return _wrap('literal', node);
+    }
+    // Bare symbol: either a declared term/symbol prior or unknown — both are
+    // axiomatic at this level so we record the symbol as a leaf witness.
+    return _wrap('symbol', node);
+  }
+
+  if (!Array.isArray(node)) return _wrap('literal', String(node));
+
+  // Definitions and operator redefs: (head: ...)
+  if (typeof node[0] === 'string' && node[0].endsWith(':')) {
+    return _wrap('definition', node);
+  }
+
+  // Assignment: ((expr) has probability p)
+  if (node.length === 4 && node[1] === 'has' && node[2] === 'probability' && isNum(node[3])) {
+    return _wrap('assigned-probability', node[0], node[3]);
+  }
+
+  // Range / valence configuration directives.
+  if (node.length === 3 && node[0] === 'range' && isNum(node[1]) && isNum(node[2])) {
+    return _wrap('configuration', 'range', node[1], node[2]);
+  }
+  if (node.length === 2 && node[0] === 'valence' && isNum(node[1])) {
+    return _wrap('configuration', 'valence', node[1]);
+  }
+
+  // Query: (? expr) and the per-query proof form (? expr with proof)
+  if (node[0] === '?') {
+    const inner = _stripWithProof(node.slice(1));
+    const target = inner.length === 1 ? inner[0] : inner;
+    return _wrap('query', buildProof(target, env));
+  }
+
+  // Infix arithmetic: (A + B), (A - B), (A * B), (A / B)
+  if (node.length === 3 && typeof node[1] === 'string' && ['+','-','*','/'].includes(node[1])) {
+    const ruleByOp = { '+': 'sum', '-': 'difference', '*': 'product', '/': 'quotient' };
+    return _wrap(ruleByOp[node[1]], buildProof(node[0], env), buildProof(node[2], env));
+  }
+
+  // Infix AND/OR/BOTH/NEITHER
+  if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='and' || node[1]==='or' || node[1]==='both' || node[1]==='neither')) {
+    return _wrap(node[1], buildProof(node[0], env), buildProof(node[2], env));
+  }
+
+  // Composite both/neither chains: (both A and B [and C ...]), (neither A nor B [nor C ...])
+  if (node.length >= 4 && typeof node[0] === 'string' && (node[0]==='both' || node[0]==='neither')) {
+    const sep = node[0]==='both' ? 'and' : 'nor';
+    let valid = node.length % 2 === 0;
+    if (valid) {
+      for (let i = 2; i < node.length; i += 2) {
+        if (node[i] !== sep) { valid = false; break; }
+      }
+    }
+    if (valid) {
+      const subs = [];
+      for (let i = 1; i < node.length; i += 2) subs.push(buildProof(node[i], env));
+      return _wrap(node[0], ...subs);
+    }
+  }
+
+  // Infix equality / inequality: (L = R), (L != R)
+  if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='=' || node[1]==='!=')) {
+    const L = node[0];
+    const R = node[2];
+    const kPrefix = keyOf(['=', L, R]);
+    const kInfix = keyOf([L, '=', R]);
+    let rule;
+    if (env.assign.has(kPrefix) || env.assign.has(kInfix)) {
+      rule = node[1] === '!=' ? 'assigned-inequality' : 'assigned-equality';
+    } else if (isStructurallySame(L, R)) {
+      rule = node[1] === '!=' ? 'structural-inequality' : 'structural-equality';
+    } else {
+      rule = node[1] === '!=' ? 'numeric-inequality' : 'numeric-equality';
+    }
+    // Sub-derivations of equality preserve the original operands as links
+    // so the witness reads (by structural-equality (a a)) per the issue.
+    return _wrap(rule, [L, R]);
+  }
+
+  // ---------- Type system witnesses ----------
+  if (node.length === 2 && node[0] === 'Type') {
+    return _wrap('type-universe', node[1]);
+  }
+  if (node.length === 1 && node[0] === 'Prop') {
+    return _wrap('prop');
+  }
+  if (node.length === 3 && node[0] === 'Pi') {
+    return _wrap('pi-formation', node[1], node[2]);
+  }
+  if (node.length === 3 && node[0] === 'lambda') {
+    return _wrap('lambda-formation', node[1], node[2]);
+  }
+  if (node.length === 3 && node[0] === 'apply') {
+    return _wrap('beta-reduction', buildProof(node[1], env), buildProof(node[2], env));
+  }
+  if (node.length === 3 && node[0] === 'type' && node[1] === 'of') {
+    return _wrap('type-query', node[2]);
+  }
+  if (node.length === 3 && node[1] === 'of') {
+    return _wrap('type-check', node[0], node[2]);
+  }
+
+  // Prefix operator: (op X Y ...)
+  const head = node[0];
+  if (typeof head === 'string' && env.hasOp(head)) {
+    return _wrap(head, ...node.slice(1).map(arg => buildProof(arg, env)));
+  }
+
+  // Fallback for prefix application of named lambdas / unrecognised heads.
+  return _wrap('reduce', node);
+}
+
+// Strip an optional `with proof` suffix from a query body. Both
+// `(? expr with proof)` and `(? (expr) with proof)` are accepted.
+function _stripWithProof(parts) {
+  if (parts.length >= 3 && parts[parts.length - 2] === 'with' && parts[parts.length - 1] === 'proof') {
+    return parts.slice(0, -2);
+  }
+  return parts;
+}
+
+// Detect whether a query body explicitly requested a proof via the inline
+// `with proof` keyword pair. Used to populate the per-query proof slot even
+// when the global `withProofs` option is off.
+function _queryRequestsProof(node) {
+  if (!Array.isArray(node) || node[0] !== '?') return false;
+  const parts = node.slice(1);
+  return parts.length >= 3 && parts[parts.length - 2] === 'with' && parts[parts.length - 1] === 'proof';
+}
+
 // Evaluate a node in arithmetic context — numeric literals are NOT clamped to the logic range.
 function evalArith(node, env){
   if (typeof node === 'string' && isNum(node)) return parseFloat(node);
@@ -511,9 +674,15 @@ function evalNode(node, env){
     return 1;
   }
 
-  // Query: (? expr)
+  // Query: (? expr) with optional `with proof` suffix (issue #35).
+  // The suffix is a per-query opt-in for derivation output; the actual proof
+  // is built by `buildProof` in `evaluate()`. Stripping it here keeps the
+  // legacy evaluation path unchanged regardless of whether proofs are
+  // requested.
   if (node[0] === '?') {
-    const v = evalNode(node[1], env);
+    const parts = _stripWithProof(node.slice(1));
+    const target = parts.length === 1 ? parts[0] : parts;
+    const v = evalNode(target, env);
     // If inner result is already a query (e.g. from (type of x)), pass it through
     if (v && typeof v === 'object' && v.query) return v;
     return { query:true, value: env.clamp(v) };
@@ -1033,6 +1202,14 @@ function evaluate(code, options) {
       trace.push(new TraceEvent({ kind, detail, span: span || { file, line: 1, col: 1, length: 0 } }));
     };
   }
+  // Proof mode (issue #35): when `withProofs` is true every query result is
+  // accompanied by a derivation tree at the same index in `proofs`. The
+  // inline `(? expr with proof)` form opts in per-query without flipping the
+  // global flag — in that case `proofs` is still populated, but bare queries
+  // that did not ask for a witness get `null` so the array stays
+  // index-aligned with `results`.
+  const proofsEnabled = !!opts.withProofs;
+  let proofs = proofsEnabled ? [] : null;
 
   // Import context: a stack of canonical paths currently being loaded (cycle
   // detection) and a set of canonical paths already loaded into this env
@@ -1059,6 +1236,7 @@ function evaluate(code, options) {
     diagnostics.push(diag);
     const out = { results, diagnostics };
     if (traceEnabled) out.trace = trace;
+    if (proofs !== null) out.proofs = proofs;
     return out;
   }
 
@@ -1123,6 +1301,27 @@ function evaluate(code, options) {
       }
       if (res && res.query) {
         results.push(res.value);
+        // Per-query proof: the global `withProofs` flag forces a proof for
+        // every query; the inline `with proof` keyword pair opts a single
+        // query in without the global flag. Lazily allocate the proofs
+        // array on first per-query opt-in so callers that never use
+        // proofs still get the original `{results, diagnostics}` shape.
+        const wantsProof = proofsEnabled || _queryRequestsProof(form);
+        if (wantsProof) {
+          if (proofs === null) {
+            // Backfill nulls for any prior bare queries so indexes align.
+            proofs = results.slice(0, -1).map(() => null);
+          }
+          // Strip the surrounding (? ...) so the proof attaches to the
+          // queried expression directly; this matches the issue example
+          // `(by structural-equality (a a))` rather than nesting under
+          // `(by query ...)`.
+          const inner = _stripWithProof(form.slice(1));
+          const target = inner.length === 1 ? inner[0] : inner;
+          proofs.push(buildProof(target, env));
+        } else if (proofs !== null) {
+          proofs.push(null);
+        }
       }
     } catch (err) {
       const diagSpan = (err && err.span) || span;
@@ -1140,6 +1339,7 @@ function evaluate(code, options) {
   }
   const out = { results, diagnostics };
   if (traceEnabled) out.trace = trace;
+  if (proofs !== null) out.proofs = proofs;
   return out;
 }
 
@@ -1582,6 +1782,7 @@ export {
   parseOne,
   Env,
   evalNode,
+  buildProof,
   quantize,
   decRound,
   keyOf,

--- a/js/tests/proofs.test.mjs
+++ b/js/tests/proofs.test.mjs
@@ -1,0 +1,223 @@
+// Tests for the proof-producing evaluator (issue #35).
+// Covers the global `withProofs` option, the inline `(? expr with proof)`
+// keyword pair, derivation shape per built-in operator, the
+// `parse(print(proof)) == proof` round-trip, and backwards compatibility
+// of the `{results, diagnostics}` shape when proofs are not requested.
+// Mirrored by `rust/tests/proofs_tests.rs` so any drift between the two
+// implementations fails both suites.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  evaluate,
+  buildProof,
+  keyOf,
+  parseOne,
+  tokenizeOne,
+  isStructurallySame,
+  Env,
+} from '../src/rml-links.mjs';
+
+// Round-trip a derivation through print -> tokenize -> parse and assert
+// the resulting AST is structurally identical to the original. This is the
+// acceptance criterion from the issue: "round-trip parse(print(D)) == D".
+function assertRoundTrip(proof) {
+  const printed = keyOf(proof);
+  const reparsed = parseOne(tokenizeOne(printed));
+  assert.ok(
+    isStructurallySame(proof, reparsed),
+    `proof did not round-trip: ${printed}`,
+  );
+}
+
+describe('evaluate() returns proofs only when requested', () => {
+  it('omits the proofs key when neither flag nor inline keyword is used', () => {
+    const out = evaluate('(? 1)');
+    assert.deepStrictEqual(Object.keys(out).sort(), ['diagnostics', 'results']);
+    assert.strictEqual(out.proofs, undefined);
+  });
+
+  it('returns a proofs array when withProofs is true', () => {
+    const out = evaluate('(? 1)', { withProofs: true });
+    assert.ok(Array.isArray(out.proofs));
+    assert.strictEqual(out.proofs.length, 1);
+    assert.ok(out.proofs[0]);
+  });
+
+  it('returns a proofs array when an inline (? ... with proof) is present', () => {
+    const out = evaluate('(? 1)\n(? 2 with proof)');
+    assert.ok(Array.isArray(out.proofs));
+    assert.strictEqual(out.proofs.length, 2);
+    // First query did not opt in -> null; second one did.
+    assert.strictEqual(out.proofs[0], null);
+    assert.ok(out.proofs[1]);
+  });
+});
+
+describe('issue example reproduction', () => {
+  it('produces the canonical (by structural-equality (a a)) witness', () => {
+    const out = evaluate('(a: a is a)\n(? (a = a) with proof)');
+    assert.deepStrictEqual(out.results, [1]);
+    assert.strictEqual(out.proofs.length, 1);
+    assert.strictEqual(keyOf(out.proofs[0]), '(by structural-equality (a a))');
+    assertRoundTrip(out.proofs[0]);
+  });
+
+  it('produces the same witness under the global flag', () => {
+    const out = evaluate('(a: a is a)\n(? (a = a))', { withProofs: true });
+    assert.deepStrictEqual(out.results, [1]);
+    assert.strictEqual(keyOf(out.proofs[0]), '(by structural-equality (a a))');
+  });
+});
+
+describe('per-rule witness shapes', () => {
+  it('records assigned-equality when an equality has been assigned a probability', () => {
+    const src = '((a = a) has probability 0.7)\n(? (a = a))';
+    const out = evaluate(src, { withProofs: true });
+    assert.deepStrictEqual(out.results, [0.7]);
+    assert.strictEqual(keyOf(out.proofs[0]), '(by assigned-equality (a a))');
+    assertRoundTrip(out.proofs[0]);
+  });
+
+  it('records assigned-inequality on (? (L != R)) when L=R has an assignment', () => {
+    const src = '((a = a) has probability 0.7)\n(? (a != a))';
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(keyOf(out.proofs[0]), '(by assigned-inequality (a a))');
+    assertRoundTrip(out.proofs[0]);
+  });
+
+  it('records numeric-equality when no assignment exists and operands differ', () => {
+    // 1 = 2 is false (rule fires regardless of clamped truth value).
+    const out = evaluate('(? (1 = 2))', { withProofs: true });
+    assert.strictEqual(keyOf(out.proofs[0]), '(by numeric-equality (1 2))');
+    assertRoundTrip(out.proofs[0]);
+  });
+
+  it('records sum / difference / product / quotient for arithmetic', () => {
+    const src = '(? (1 + 2))\n(? (5 - 2))\n(? (3 * 4))\n(? (8 / 2))';
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(out.results.length, 4);
+    const rules = out.proofs.map(p => p[1]);
+    assert.deepStrictEqual(rules, ['sum', 'difference', 'product', 'quotient']);
+    out.proofs.forEach(assertRoundTrip);
+  });
+
+  it('records and / or for binary infix logic', () => {
+    const src = '(? (1 and 0))\n(? (1 or 0))';
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(out.proofs[0][1], 'and');
+    assert.strictEqual(out.proofs[1][1], 'or');
+    out.proofs.forEach(assertRoundTrip);
+  });
+
+  it('records both / neither for composite chains', () => {
+    const src = '(? (both 1 and 0 and 1))\n(? (neither 0 nor 0))';
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(out.proofs[0][1], 'both');
+    assert.strictEqual(out.proofs[0].length, 5); // (by both s1 s2 s3)
+    assert.strictEqual(out.proofs[1][1], 'neither');
+    out.proofs.forEach(assertRoundTrip);
+  });
+
+  it('records prefix operator names for (not X), (and X Y), (or X Y)', () => {
+    const src = '(? (not 1))\n(? (and 1 1))\n(? (or 0 1))';
+    const out = evaluate(src, { withProofs: true });
+    assert.deepStrictEqual(
+      out.proofs.map(p => p[1]),
+      ['not', 'and', 'or'],
+    );
+    out.proofs.forEach(assertRoundTrip);
+  });
+
+  it('records assigned-probability for top-level ((expr) has probability p)', () => {
+    const env = new Env();
+    const proof = buildProof(
+      [['a', '=', 'a'], 'has', 'probability', '0.5'],
+      env,
+    );
+    assert.strictEqual(keyOf(proof), '(by assigned-probability (a = a) 0.5)');
+    assertRoundTrip(proof);
+  });
+
+  it('records type-universe / prop / pi-formation / lambda-formation', () => {
+    const env = new Env();
+    const u = buildProof(['Type', '0'], env);
+    assert.strictEqual(keyOf(u), '(by type-universe 0)');
+    assertRoundTrip(u);
+
+    const p = buildProof(['Prop'], env);
+    assert.strictEqual(keyOf(p), '(by prop)');
+    assertRoundTrip(p);
+
+    const pi = buildProof(['Pi', ['x:', 'A'], 'B'], env);
+    assert.strictEqual(keyOf(pi), '(by pi-formation (x: A) B)');
+    assertRoundTrip(pi);
+
+    const lam = buildProof(['lambda', ['x:', 'A'], 'x'], env);
+    assert.strictEqual(keyOf(lam), '(by lambda-formation (x: A) x)');
+    assertRoundTrip(lam);
+  });
+});
+
+describe('proofs are index-aligned with results', () => {
+  it('emits null for bare queries that did not opt in (inline mode only)', () => {
+    const src = '(? 1)\n(? 0 with proof)\n(? 1)';
+    const out = evaluate(src);
+    assert.strictEqual(out.results.length, 3);
+    assert.strictEqual(out.proofs.length, 3);
+    assert.strictEqual(out.proofs[0], null);
+    assert.ok(out.proofs[1]);
+    assert.strictEqual(out.proofs[2], null);
+  });
+
+  it('produces a proof for every query when withProofs is true', () => {
+    const src = '(a: a is a)\n(? 1)\n(? (1 + 0))\n(? (a = a))';
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(out.results.length, 3);
+    assert.strictEqual(out.proofs.length, 3);
+    out.proofs.forEach(p => {
+      assert.ok(p);
+      assertRoundTrip(p);
+    });
+  });
+});
+
+describe('proofs do not affect query results or diagnostics', () => {
+  it('produces identical results and diagnostics with and without proofs', () => {
+    const src = [
+      '(a: a is a)',
+      '(b: b is b)',
+      '((a = a) has probability 1)',
+      '((b = b) has probability 0)',
+      '(? ((a = a) and (b = b)))',
+    ].join('\n');
+    const plain = evaluate(src);
+    const proven = evaluate(src, { withProofs: true });
+    assert.deepStrictEqual(plain.results, proven.results);
+    assert.deepStrictEqual(plain.diagnostics, proven.diagnostics);
+  });
+});
+
+describe('round-trip property holds for every produced proof', () => {
+  it('survives parse(print(proof)) for a representative bundle of operators', () => {
+    const src = [
+      '(a: a is a)',
+      '((a = a) has probability 0.7)',
+      '(? (a = a))',
+      '(? (1 + 2))',
+      '(? (5 - 2))',
+      '(? (3 * 4))',
+      '(? (8 / 2))',
+      '(? (not 1))',
+      '(? (1 and 0))',
+      '(? (0 or 1))',
+      '(? (both 1 and 1 and 0))',
+      '(? (neither 0 nor 0))',
+      '(? (1 = 2))',
+      '(? (1 != 2))',
+    ].join('\n');
+    const out = evaluate(src, { withProofs: true });
+    assert.strictEqual(out.proofs.length, out.results.length);
+    out.proofs.forEach(assertRoundTrip);
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -73,19 +73,31 @@ impl Diagnostic {
 /// any diagnostics emitted while parsing/evaluating. When tracing is enabled
 /// via `evaluate_with_options`, `trace` carries the deterministic sequence of
 /// `TraceEvent` values recorded during evaluation; otherwise it is empty.
+/// When proof production is enabled (via `EvaluateOptions::with_proofs` or
+/// any per-query `(? expr with proof)` keyword), `proofs[i]` carries a
+/// derivation tree for `results[i]`; bare queries that did not request a
+/// witness get `None` so the vec stays index-aligned with `results`.
+/// Mirrors the JavaScript `{results, diagnostics, trace, proofs}` shape.
 #[derive(Debug, Clone, Default)]
 pub struct EvaluateResult {
     pub results: Vec<RunResult>,
     pub diagnostics: Vec<Diagnostic>,
     pub trace: Vec<TraceEvent>,
+    pub proofs: Vec<Option<Node>>,
 }
 
 /// Options for `evaluate_with_options` — bundles environment settings with
-/// runtime flags like `trace`. Keeps `evaluate()` backwards compatible.
+/// runtime flags like `trace` and `with_proofs`. Keeps `evaluate()`
+/// backwards compatible.
 #[derive(Debug, Clone, Default)]
 pub struct EvaluateOptions {
     pub env: Option<EnvOptions>,
     pub trace: bool,
+    /// When true, every query result is accompanied by a derivation tree at
+    /// the same index in `EvaluateResult.proofs`. The inline
+    /// `(? expr with proof)` keyword pair opts in per-query without flipping
+    /// this global flag.
+    pub with_proofs: bool,
 }
 
 // ========== Trace events ==========
@@ -1129,6 +1141,319 @@ fn eval_arith(node: &Node, env: &mut Env) -> f64 {
     eval_node(node, env).as_f64()
 }
 
+// ========== Proof derivations (issue #35) ==========
+// A derivation is a Node tree of the form `(by <rule> <subderivation>...)`.
+// Building it on the same `Node` type as the AST means the existing
+// `key_of` (print) and `parse_one(tokenize_one(...))` (parse) helpers give
+// the round-trip property `parse(print(proof)) == proof` for free, without
+// needing a separate proof format. Mirrors `buildProof` in
+// `js/src/rml-links.mjs` so cross-runtime proofs match exactly.
+//
+// The walker is intentionally read-only — it never mutates the env beyond
+// the lookups that `eval_node` would have performed during evaluation, so
+// enabling proofs cannot change query results. Sub-derivations recurse
+// through `build_proof` so every sub-expression carries its own witness
+// rather than collapsing into the literal value.
+fn wrap_proof(rule: &str, subs: Vec<Node>) -> Node {
+    let mut out = Vec::with_capacity(subs.len() + 2);
+    out.push(Node::Leaf("by".to_string()));
+    out.push(Node::Leaf(rule.to_string()));
+    out.extend(subs);
+    Node::List(out)
+}
+
+fn leaf(s: &str) -> Node {
+    Node::Leaf(s.to_string())
+}
+
+/// Strip an optional trailing `with proof` from a query body. Both
+/// `(? expr with proof)` and `(? (expr) with proof)` are accepted. Mirrors
+/// `_stripWithProof` in the JavaScript implementation.
+fn strip_with_proof(parts: &[Node]) -> &[Node] {
+    if parts.len() >= 3 {
+        if let (Node::Leaf(w), Node::Leaf(p)) =
+            (&parts[parts.len() - 2], &parts[parts.len() - 1])
+        {
+            if w == "with" && p == "proof" {
+                return &parts[..parts.len() - 2];
+            }
+        }
+    }
+    parts
+}
+
+/// Detect whether a top-level `(? ...)` form explicitly requested a proof
+/// via the inline `with proof` keyword pair. Used to populate the per-query
+/// proof slot even when the global `with_proofs` option is off. Mirrors
+/// `_queryRequestsProof` in the JavaScript implementation.
+fn query_requests_proof(node: &Node) -> bool {
+    if let Node::List(children) = node {
+        if let Some(Node::Leaf(head)) = children.first() {
+            if head == "?" {
+                let parts = &children[1..];
+                if parts.len() >= 3 {
+                    if let (Node::Leaf(w), Node::Leaf(p)) =
+                        (&parts[parts.len() - 2], &parts[parts.len() - 1])
+                    {
+                        return w == "with" && p == "proof";
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Build a derivation tree witnessing how `node` reduces under `env`.
+/// Returns a `Node::List` of the form `(by <rule> <subderivation>...)`.
+///
+/// The walker mirrors the structural cases of `eval_node`: definitions and
+/// configuration directives become leaf witnesses, infix and prefix
+/// operators become rule applications whose subderivations recurse through
+/// `build_proof`, and equality picks `assigned-equality` /
+/// `structural-equality` / `numeric-equality` (and the negated counterparts)
+/// based on the same lookups `eval_node` performs.
+pub fn build_proof(node: &Node, env: &Env) -> Node {
+    match node {
+        // Numeric and bare-symbol leaves are axiomatic at this level.
+        Node::Leaf(s) => {
+            if is_num(s) {
+                wrap_proof("literal", vec![leaf(s)])
+            } else {
+                wrap_proof("symbol", vec![leaf(s)])
+            }
+        }
+        Node::List(children) => {
+            // Definitions and operator redefs: (head: ...)
+            if let Some(Node::Leaf(s)) = children.first() {
+                if s.ends_with(':') {
+                    return wrap_proof("definition", vec![node.clone()]);
+                }
+            }
+
+            // Assignment: ((expr) has probability p)
+            if children.len() == 4 {
+                if let (Node::Leaf(w1), Node::Leaf(w2), Node::Leaf(w3)) =
+                    (&children[1], &children[2], &children[3])
+                {
+                    if w1 == "has" && w2 == "probability" && is_num(w3) {
+                        return wrap_proof(
+                            "assigned-probability",
+                            vec![children[0].clone(), leaf(w3)],
+                        );
+                    }
+                }
+            }
+
+            // Range / valence configuration directives.
+            if children.len() == 3 {
+                if let (Node::Leaf(h), Node::Leaf(lo_s), Node::Leaf(hi_s)) =
+                    (&children[0], &children[1], &children[2])
+                {
+                    if h == "range" && is_num(lo_s) && is_num(hi_s) {
+                        return wrap_proof(
+                            "configuration",
+                            vec![leaf("range"), leaf(lo_s), leaf(hi_s)],
+                        );
+                    }
+                }
+            }
+            if children.len() == 2 {
+                if let (Node::Leaf(h), Node::Leaf(v)) = (&children[0], &children[1]) {
+                    if h == "valence" && is_num(v) {
+                        return wrap_proof(
+                            "configuration",
+                            vec![leaf("valence"), leaf(v)],
+                        );
+                    }
+                }
+            }
+
+            // Query: (? expr) and the per-query proof form (? expr with proof)
+            if let Some(Node::Leaf(head)) = children.first() {
+                if head == "?" {
+                    let parts = &children[1..];
+                    let inner = strip_with_proof(parts);
+                    let target = if inner.len() == 1 {
+                        inner[0].clone()
+                    } else {
+                        Node::List(inner.to_vec())
+                    };
+                    return wrap_proof("query", vec![build_proof(&target, env)]);
+                }
+            }
+
+            // Infix arithmetic: (A + B), (A - B), (A * B), (A / B)
+            if children.len() == 3 {
+                if let Node::Leaf(op_name) = &children[1] {
+                    if matches!(op_name.as_str(), "+" | "-" | "*" | "/") {
+                        let rule = match op_name.as_str() {
+                            "+" => "sum",
+                            "-" => "difference",
+                            "*" => "product",
+                            "/" => "quotient",
+                            _ => unreachable!(),
+                        };
+                        return wrap_proof(
+                            rule,
+                            vec![build_proof(&children[0], env), build_proof(&children[2], env)],
+                        );
+                    }
+                }
+            }
+
+            // Infix AND/OR/BOTH/NEITHER
+            if children.len() == 3 {
+                if let Node::Leaf(op_name) = &children[1] {
+                    if matches!(op_name.as_str(), "and" | "or" | "both" | "neither") {
+                        return wrap_proof(
+                            op_name,
+                            vec![build_proof(&children[0], env), build_proof(&children[2], env)],
+                        );
+                    }
+                }
+            }
+
+            // Composite both/neither chains: (both A and B [and C ...]),
+            // (neither A nor B [nor C ...]).
+            if children.len() >= 4 && children.len() % 2 == 0 {
+                if let Node::Leaf(head) = &children[0] {
+                    if head == "both" || head == "neither" {
+                        let sep = if head == "both" { "and" } else { "nor" };
+                        let mut valid = true;
+                        for i in (2..children.len()).step_by(2) {
+                            if let Node::Leaf(s) = &children[i] {
+                                if s != sep {
+                                    valid = false;
+                                    break;
+                                }
+                            } else {
+                                valid = false;
+                                break;
+                            }
+                        }
+                        if valid {
+                            let subs: Vec<Node> = (1..children.len())
+                                .step_by(2)
+                                .map(|i| build_proof(&children[i], env))
+                                .collect();
+                            return wrap_proof(head, subs);
+                        }
+                    }
+                }
+            }
+
+            // Infix equality / inequality: (L = R), (L != R)
+            if children.len() == 3 {
+                if let Node::Leaf(op_name) = &children[1] {
+                    if op_name == "=" || op_name == "!=" {
+                        let l = &children[0];
+                        let r = &children[2];
+                        let k_prefix =
+                            key_of(&Node::List(vec![leaf("="), l.clone(), r.clone()]));
+                        let k_infix =
+                            key_of(&Node::List(vec![l.clone(), leaf("="), r.clone()]));
+                        let rule = if env.assign.contains_key(&k_prefix)
+                            || env.assign.contains_key(&k_infix)
+                        {
+                            if op_name == "!=" {
+                                "assigned-inequality"
+                            } else {
+                                "assigned-equality"
+                            }
+                        } else if is_structurally_same(l, r) {
+                            if op_name == "!=" {
+                                "structural-inequality"
+                            } else {
+                                "structural-equality"
+                            }
+                        } else if op_name == "!=" {
+                            "numeric-inequality"
+                        } else {
+                            "numeric-equality"
+                        };
+                        // Sub-derivation of equality preserves the original
+                        // operands as a link so the witness reads
+                        // `(by structural-equality (a a))` per the issue.
+                        let pair = Node::List(vec![l.clone(), r.clone()]);
+                        return wrap_proof(rule, vec![pair]);
+                    }
+                }
+            }
+
+            // ---------- Type system witnesses ----------
+            if children.len() == 2 {
+                if let (Node::Leaf(h), level) = (&children[0], &children[1]) {
+                    if h == "Type" {
+                        return wrap_proof("type-universe", vec![level.clone()]);
+                    }
+                }
+            }
+            if children.len() == 1 {
+                if let Node::Leaf(h) = &children[0] {
+                    if h == "Prop" {
+                        return wrap_proof("prop", vec![]);
+                    }
+                }
+            }
+            if children.len() == 3 {
+                if let Node::Leaf(h) = &children[0] {
+                    if h == "Pi" {
+                        return wrap_proof(
+                            "pi-formation",
+                            vec![children[1].clone(), children[2].clone()],
+                        );
+                    }
+                    if h == "lambda" {
+                        return wrap_proof(
+                            "lambda-formation",
+                            vec![children[1].clone(), children[2].clone()],
+                        );
+                    }
+                    if h == "apply" {
+                        return wrap_proof(
+                            "beta-reduction",
+                            vec![build_proof(&children[1], env), build_proof(&children[2], env)],
+                        );
+                    }
+                }
+            }
+            if children.len() == 3 {
+                if let (Node::Leaf(h), Node::Leaf(m)) = (&children[0], &children[1]) {
+                    if h == "type" && m == "of" {
+                        return wrap_proof(
+                            "type-query",
+                            vec![children[2].clone()],
+                        );
+                    }
+                }
+                if let Node::Leaf(m) = &children[1] {
+                    if m == "of" {
+                        return wrap_proof(
+                            "type-check",
+                            vec![children[0].clone(), children[2].clone()],
+                        );
+                    }
+                }
+            }
+
+            // Prefix operator: (op X Y ...)
+            if let Node::Leaf(head) = &children[0] {
+                if env.has_op(head) {
+                    let subs: Vec<Node> = children[1..]
+                        .iter()
+                        .map(|arg| build_proof(arg, env))
+                        .collect();
+                    return wrap_proof(head, subs);
+                }
+            }
+
+            // Fallback for unrecognised heads / named lambda applications.
+            wrap_proof("reduce", vec![node.clone()])
+        }
+    }
+}
+
 /// Evaluate an AST node in the given environment.
 pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
     match node {
@@ -1206,10 +1531,20 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                 }
             }
 
-            // Query: (? expr)
+            // Query: (? expr) or (? expr with proof)
+            // The trailing `with proof` keyword pair is consumed here so it
+            // does not interfere with evaluation; `evaluate_inner` looks at
+            // the original form to decide whether to populate a proof slot.
+            // The proof itself is built by `build_proof` after evaluation.
             if let Node::Leaf(ref first) = children[0] {
                 if first == "?" {
-                    let result = eval_node(&children[1], env);
+                    let parts = strip_with_proof(&children[1..]);
+                    let target: Node = if parts.len() == 1 {
+                        parts[0].clone()
+                    } else {
+                        Node::List(parts.to_vec())
+                    };
+                    let result = eval_node(&target, env);
                     // If inner result is already a type query, pass it through
                     if result.is_type_query() {
                         return result;
@@ -2171,7 +2506,7 @@ pub fn evaluate(text: &str, file: Option<&str>, options: Option<EnvOptions>) -> 
         file,
         EvaluateOptions {
             env: options,
-            trace: false,
+            ..EvaluateOptions::default()
         },
     )
 }
@@ -2222,6 +2557,7 @@ pub fn evaluate_file(file_path: &str, options: EvaluateOptions) -> EvaluateResul
                 results: Vec::new(),
                 diagnostics: vec![diag],
                 trace: Vec::new(),
+                proofs: Vec::new(),
             };
         }
     };
@@ -2490,6 +2826,19 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
 
     let mut results: Vec<RunResult> = Vec::new();
 
+    // Proof collection (issue #35). When `options.with_proofs` is true the
+    // global flag forces a derivation for every query; otherwise we lazily
+    // allocate `proofs` on the first per-query `(? expr with proof)` opt-in
+    // and backfill `None` for any prior bare queries so indices stay aligned
+    // with `results`. When neither code path fires `proofs` stays empty and
+    // is returned as `Vec::new()` — matching the plain `evaluate()` shape.
+    let proofs_enabled = options.with_proofs;
+    let mut proofs: Option<Vec<Option<Node>>> = if proofs_enabled {
+        Some(Vec::new())
+    } else {
+        None
+    };
+
     // Silence the default panic hook while we deliberately catch evaluator
     // panics — otherwise they'd leak to stderr alongside the diagnostics.
     let prev_hook = std::panic::take_hook();
@@ -2620,10 +2969,52 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
                             .push(TraceEvent::new("eval", summary, span.clone()));
                     }
                 }
+                let was_query = matches!(
+                    eval_res,
+                    EvalResult::Query(_) | EvalResult::TypeQuery(_)
+                );
                 match eval_res {
                     EvalResult::Query(v) => results.push(RunResult::Num(v)),
                     EvalResult::TypeQuery(s) => results.push(RunResult::Type(s)),
                     _ => {}
+                }
+                if was_query {
+                    let wants_proof = proofs_enabled || query_requests_proof(&form);
+                    if wants_proof {
+                        // Lazily allocate the proofs vec on first per-query
+                        // opt-in so callers that never ask for proofs get
+                        // an empty vec back. Backfill `None` for any prior
+                        // bare queries so indices stay aligned with results.
+                        if proofs.is_none() {
+                            let backfill = results.len().saturating_sub(1);
+                            proofs = Some(vec![None; backfill]);
+                        }
+                        // Strip the surrounding (? ...) so the proof attaches
+                        // to the queried expression directly; this matches
+                        // the issue example `(by structural-equality (a a))`
+                        // rather than nesting under `(by query ...)`.
+                        let proof_node = match &form {
+                            Node::List(form_children)
+                                if matches!(
+                                    form_children.first(),
+                                    Some(Node::Leaf(s)) if s == "?"
+                                ) =>
+                            {
+                                let parts = &form_children[1..];
+                                let inner = strip_with_proof(parts);
+                                let target: Node = if inner.len() == 1 {
+                                    inner[0].clone()
+                                } else {
+                                    Node::List(inner.to_vec())
+                                };
+                                build_proof(&target, env)
+                            }
+                            _ => build_proof(&form, env),
+                        };
+                        proofs.as_mut().unwrap().push(Some(proof_node));
+                    } else if let Some(p) = proofs.as_mut() {
+                        p.push(None);
+                    }
                 }
             }
             Err(payload) => {
@@ -2657,6 +3048,7 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
         results,
         diagnostics,
         trace,
+        proofs: proofs.unwrap_or_default(),
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> ExitCode {
         EvaluateOptions {
             env: None,
             trace,
+            ..EvaluateOptions::default()
         },
     );
     if trace {

--- a/rust/tests/proofs_tests.rs
+++ b/rust/tests/proofs_tests.rs
@@ -1,0 +1,311 @@
+// Tests for the proof-producing evaluator (issue #35).
+// Mirrors js/tests/proofs.test.mjs so any drift between the two
+// implementations fails both test suites. Covers the global
+// `with_proofs` option, the inline `(? expr with proof)` keyword
+// pair, derivation shape per built-in operator, the
+// `parse(print(proof)) == proof` round-trip, and that proofs do
+// not affect query results or diagnostics.
+
+use rml::{
+    build_proof, evaluate, evaluate_with_options, is_structurally_same, key_of, parse_one,
+    tokenize_one, Env, EvaluateOptions, Node, RunResult,
+};
+
+// Build an `EvaluateOptions` with proofs enabled.
+fn opts_with_proofs() -> EvaluateOptions {
+    EvaluateOptions {
+        with_proofs: true,
+        ..EvaluateOptions::default()
+    }
+}
+
+// Round-trip a derivation through print -> tokenize -> parse and assert
+// the resulting AST is structurally identical to the original. This is
+// the acceptance criterion from the issue: "round-trip parse(print(D)) == D".
+fn assert_round_trip(proof: &Node) {
+    let printed = key_of(proof);
+    let reparsed = parse_one(&tokenize_one(&printed)).expect("reparse failed");
+    assert!(
+        is_structurally_same(proof, &reparsed),
+        "proof did not round-trip: {}",
+        printed
+    );
+}
+
+fn rule_name(proof: &Node) -> &str {
+    match proof {
+        Node::List(children) => match &children[1] {
+            Node::Leaf(s) => s.as_str(),
+            _ => panic!("rule name slot was not a leaf"),
+        },
+        _ => panic!("proof was not a list"),
+    }
+}
+
+// ===== evaluate() returns proofs only when requested =====
+
+#[test]
+fn omits_proofs_when_neither_flag_nor_inline_keyword_used() {
+    let out = evaluate("(? 1)", None, None);
+    assert!(out.proofs.is_empty());
+}
+
+#[test]
+fn returns_proofs_array_when_with_proofs_is_true() {
+    let out = evaluate_with_options("(? 1)", None, opts_with_proofs());
+    assert_eq!(out.proofs.len(), 1);
+    assert!(out.proofs[0].is_some());
+}
+
+#[test]
+fn returns_proofs_array_when_inline_with_proof_is_present() {
+    let out = evaluate("(? 1)\n(? 2 with proof)", None, None);
+    assert_eq!(out.proofs.len(), 2);
+    // First query did not opt in -> None; second one did.
+    assert!(out.proofs[0].is_none());
+    assert!(out.proofs[1].is_some());
+}
+
+// ===== issue example reproduction =====
+
+#[test]
+fn produces_canonical_structural_equality_witness() {
+    let out = evaluate("(a: a is a)\n(? (a = a) with proof)", None, None);
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+    assert_eq!(out.proofs.len(), 1);
+    let proof = out.proofs[0].as_ref().expect("proof missing");
+    assert_eq!(key_of(proof), "(by structural-equality (a a))");
+    assert_round_trip(proof);
+}
+
+#[test]
+fn produces_same_witness_under_global_flag() {
+    let out =
+        evaluate_with_options("(a: a is a)\n(? (a = a))", None, opts_with_proofs());
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+    let proof = out.proofs[0].as_ref().expect("proof missing");
+    assert_eq!(key_of(proof), "(by structural-equality (a a))");
+}
+
+// ===== per-rule witness shapes =====
+
+#[test]
+fn records_assigned_equality_when_assignment_exists() {
+    let src = "((a = a) has probability 0.7)\n(? (a = a))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    assert_eq!(out.results, vec![RunResult::Num(0.7)]);
+    let proof = out.proofs[0].as_ref().expect("proof missing");
+    assert_eq!(key_of(proof), "(by assigned-equality (a a))");
+    assert_round_trip(proof);
+}
+
+#[test]
+fn records_assigned_inequality_for_inequality_query() {
+    let src = "((a = a) has probability 0.7)\n(? (a != a))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    let proof = out.proofs[0].as_ref().expect("proof missing");
+    assert_eq!(key_of(proof), "(by assigned-inequality (a a))");
+    assert_round_trip(proof);
+}
+
+#[test]
+fn records_numeric_equality_when_no_assignment_and_operands_differ() {
+    // 1 = 2 is false; rule fires regardless of clamped truth value.
+    let out = evaluate_with_options("(? (1 = 2))", None, opts_with_proofs());
+    let proof = out.proofs[0].as_ref().expect("proof missing");
+    assert_eq!(key_of(proof), "(by numeric-equality (1 2))");
+    assert_round_trip(proof);
+}
+
+#[test]
+fn records_arithmetic_rules() {
+    let src = "(? (1 + 2))\n(? (5 - 2))\n(? (3 * 4))\n(? (8 / 2))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    assert_eq!(out.results.len(), 4);
+    let rules: Vec<&str> = out
+        .proofs
+        .iter()
+        .map(|p| rule_name(p.as_ref().expect("proof missing")))
+        .collect();
+    assert_eq!(rules, vec!["sum", "difference", "product", "quotient"]);
+    for p in &out.proofs {
+        assert_round_trip(p.as_ref().unwrap());
+    }
+}
+
+#[test]
+fn records_and_or_for_binary_infix_logic() {
+    let src = "(? (1 and 0))\n(? (1 or 0))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    assert_eq!(rule_name(out.proofs[0].as_ref().unwrap()), "and");
+    assert_eq!(rule_name(out.proofs[1].as_ref().unwrap()), "or");
+    for p in &out.proofs {
+        assert_round_trip(p.as_ref().unwrap());
+    }
+}
+
+#[test]
+fn records_both_neither_for_composite_chains() {
+    let src = "(? (both 1 and 0 and 1))\n(? (neither 0 nor 0))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    let p0 = out.proofs[0].as_ref().unwrap();
+    assert_eq!(rule_name(p0), "both");
+    if let Node::List(children) = p0 {
+        // (by both s1 s2 s3) -> length 5
+        assert_eq!(children.len(), 5);
+    } else {
+        panic!("not a list");
+    }
+    assert_eq!(rule_name(out.proofs[1].as_ref().unwrap()), "neither");
+    for p in &out.proofs {
+        assert_round_trip(p.as_ref().unwrap());
+    }
+}
+
+#[test]
+fn records_prefix_operator_names() {
+    let src = "(? (not 1))\n(? (and 1 1))\n(? (or 0 1))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    let rules: Vec<&str> = out
+        .proofs
+        .iter()
+        .map(|p| rule_name(p.as_ref().unwrap()))
+        .collect();
+    assert_eq!(rules, vec!["not", "and", "or"]);
+    for p in &out.proofs {
+        assert_round_trip(p.as_ref().unwrap());
+    }
+}
+
+#[test]
+fn records_assigned_probability_for_top_level_form() {
+    let env = Env::new(None);
+    // ((a = a) has probability 0.5)
+    let node = Node::List(vec![
+        Node::List(vec![
+            Node::Leaf("a".to_string()),
+            Node::Leaf("=".to_string()),
+            Node::Leaf("a".to_string()),
+        ]),
+        Node::Leaf("has".to_string()),
+        Node::Leaf("probability".to_string()),
+        Node::Leaf("0.5".to_string()),
+    ]);
+    let proof = build_proof(&node, &env);
+    assert_eq!(key_of(&proof), "(by assigned-probability (a = a) 0.5)");
+    assert_round_trip(&proof);
+}
+
+#[test]
+fn records_type_universe_prop_pi_lambda() {
+    let env = Env::new(None);
+
+    // Type 0
+    let u = build_proof(
+        &Node::List(vec![Node::Leaf("Type".to_string()), Node::Leaf("0".to_string())]),
+        &env,
+    );
+    assert_eq!(key_of(&u), "(by type-universe 0)");
+    assert_round_trip(&u);
+
+    // Prop
+    let p = build_proof(&Node::List(vec![Node::Leaf("Prop".to_string())]), &env);
+    assert_eq!(key_of(&p), "(by prop)");
+    assert_round_trip(&p);
+
+    // Pi (x: A) B
+    let pi = build_proof(
+        &Node::List(vec![
+            Node::Leaf("Pi".to_string()),
+            Node::List(vec![Node::Leaf("x:".to_string()), Node::Leaf("A".to_string())]),
+            Node::Leaf("B".to_string()),
+        ]),
+        &env,
+    );
+    assert_eq!(key_of(&pi), "(by pi-formation (x: A) B)");
+    assert_round_trip(&pi);
+
+    // lambda (x: A) x
+    let lam = build_proof(
+        &Node::List(vec![
+            Node::Leaf("lambda".to_string()),
+            Node::List(vec![Node::Leaf("x:".to_string()), Node::Leaf("A".to_string())]),
+            Node::Leaf("x".to_string()),
+        ]),
+        &env,
+    );
+    assert_eq!(key_of(&lam), "(by lambda-formation (x: A) x)");
+    assert_round_trip(&lam);
+}
+
+// ===== proofs are index-aligned with results =====
+
+#[test]
+fn emits_none_for_bare_queries_in_inline_mode() {
+    let src = "(? 1)\n(? 0 with proof)\n(? 1)";
+    let out = evaluate(src, None, None);
+    assert_eq!(out.results.len(), 3);
+    assert_eq!(out.proofs.len(), 3);
+    assert!(out.proofs[0].is_none());
+    assert!(out.proofs[1].is_some());
+    assert!(out.proofs[2].is_none());
+}
+
+#[test]
+fn produces_proof_for_every_query_when_with_proofs_is_true() {
+    let src = "(a: a is a)\n(? 1)\n(? (1 + 0))\n(? (a = a))";
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    assert_eq!(out.results.len(), 3);
+    assert_eq!(out.proofs.len(), 3);
+    for p in &out.proofs {
+        let proof = p.as_ref().expect("proof missing");
+        assert_round_trip(proof);
+    }
+}
+
+// ===== proofs do not affect query results or diagnostics =====
+
+#[test]
+fn produces_identical_results_and_diagnostics_with_and_without_proofs() {
+    let src = [
+        "(a: a is a)",
+        "(b: b is b)",
+        "((a = a) has probability 1)",
+        "((b = b) has probability 0)",
+        "(? ((a = a) and (b = b)))",
+    ]
+    .join("\n");
+    let plain = evaluate(&src, None, None);
+    let proven = evaluate_with_options(&src, None, opts_with_proofs());
+    assert_eq!(plain.results, proven.results);
+    assert_eq!(plain.diagnostics, proven.diagnostics);
+}
+
+// ===== round-trip property holds for every produced proof =====
+
+#[test]
+fn round_trip_holds_for_representative_operator_bundle() {
+    let src = [
+        "(a: a is a)",
+        "((a = a) has probability 0.7)",
+        "(? (a = a))",
+        "(? (1 + 2))",
+        "(? (5 - 2))",
+        "(? (3 * 4))",
+        "(? (8 / 2))",
+        "(? (not 1))",
+        "(? (1 and 0))",
+        "(? (0 or 1))",
+        "(? (both 1 and 1 and 0))",
+        "(? (neither 0 nor 0))",
+        "(? (1 = 2))",
+        "(? (1 != 2))",
+    ]
+    .join("\n");
+    let out = evaluate_with_options(&src, None, opts_with_proofs());
+    assert_eq!(out.proofs.len(), out.results.len());
+    for p in &out.proofs {
+        let proof = p.as_ref().expect("proof missing");
+        assert_round_trip(proof);
+    }
+}

--- a/rust/tests/trace_tests.rs
+++ b/rust/tests/trace_tests.rs
@@ -20,6 +20,7 @@ fn trace_demo() -> Vec<TraceEvent> {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     out.trace
@@ -69,6 +70,7 @@ fn trace_does_not_affect_results_or_diagnostics() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     assert_eq!(plain.results, traced.results);
@@ -83,6 +85,7 @@ fn resolve_event_for_aggregator_redef() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     let resolves: Vec<_> = out
@@ -105,6 +108,7 @@ fn assign_event_for_probability_form() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     let assigns: Vec<_> = out
@@ -126,6 +130,7 @@ fn lookup_event_when_assigned_equality_fires() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     let lookups: Vec<_> = out
@@ -165,6 +170,7 @@ fn format_trace_event_renders_span_kind_detail() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     let line = format_trace_event(&out.trace[0]);
@@ -179,6 +185,7 @@ fn format_trace_event_falls_back_to_input_when_no_file() {
         EvaluateOptions {
             env: None,
             trace: true,
+            ..EvaluateOptions::default()
         },
     );
     let line = format_trace_event(&out.trace[0]);


### PR DESCRIPTION
## Summary

Implements [issue #35](https://github.com/link-foundation/relative-meta-logic/issues/35): every query can now optionally return a derivation tree of links witnessing how its result was reduced.

- **LiNo surface**: `(? (a = a) with proof) → 1 (by structural-equality (a a))` — the canonical example from the issue.
- **JS API**: `evaluate(src, { withProofs: true }) → { results, diagnostics, proofs }` with `proofs[i]` index-aligned with `results[i]`.
- **Rust API**: `EvaluateOptions { with_proofs: true, .. }` returns `EvaluateResult { results, diagnostics, trace, proofs: Vec<Option<Node>> }`.
- **Two activation modes** that work side-by-side:
  - Global: every query gets a proof.
  - Per-query: `(? expr with proof)` opts in for one query while leaving the rest at `None` / `null`.
- **Round-trip**: derivations reuse the existing `keyOf` / `parseOne` / `tokenizeOne` helpers, so `parse(print(D)) == D` (the issue's acceptance criterion) for every emitted witness.

## Per-rule witnesses

`build_proof` walks the same structural cases as `eval_node` and emits a `(by <rule> <subderivation>...)` link for every built-in operator:

| Operator family | Rule names |
|---|---|
| Leaves | `literal`, `symbol` |
| Top-level forms | `definition`, `assigned-probability`, `configuration`, `query` |
| Arithmetic | `sum`, `difference`, `product`, `quotient` |
| Logic (infix and prefix) | `and`, `or`, `both`, `neither`, `not` |
| Equality / inequality | `assigned-equality` / `-inequality`, `structural-equality` / `-inequality`, `numeric-equality` / `-inequality` |
| Type system | `type-universe`, `prop`, `pi-formation`, `lambda-formation`, `beta-reduction`, `type-query`, `type-check` |
| Fallback | `reduce` |

## Backwards compatibility

- The default `evaluate(src)` still returns `{ results, diagnostics }` (JS) and `EvaluateResult { results, diagnostics, trace, proofs: vec![] }` (Rust). All 494 existing JS tests and all existing Rust tests pass unchanged.
- All existing `EvaluateOptions { .. }` literals were updated to use `..EvaluateOptions::default()` so adding the `with_proofs` field is purely additive.
- Enabling proofs cannot change query results: `build_proof` is read-only and mirrors the lookups `eval_node` already performs.

## Tests

Mirrored test suites — `js/tests/proofs.test.mjs` (18 tests) and `rust/tests/proofs_tests.rs` (18 tests) — cover:

- The `withProofs` flag and `(? ... with proof)` keyword pair both produce proofs and the bare form does not.
- The issue's canonical example reproduces `(by structural-equality (a a))`.
- Per-rule witness shapes for every operator listed above.
- `proofs.length == results.length` with `None`/`null` for bare queries in inline mode.
- Enabling proofs produces identical `results` and `diagnostics`.
- `parse(print(proof)) == proof` for a representative bundle of operators.

## Test plan

- [x] `cd js && node --test tests/` — 494 / 494 pass
- [x] `cd rust && cargo test` — all suites pass (242 lib + 18 proofs + others)
- [x] `cd rust && cargo build` — clean
- [x] `experiments/test-proofs.mjs` smoke script exercises every rule manually

Fixes #35