### PR TITLE
[C2] Independent proof-replay checker (rml-check)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T19:28:20.526Z for PR creation at branch issue-36-c4dced57ba27 for issue https://github.com/link-foundation/relative-meta-logic/issues/36

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T19:28:20.526Z for PR creation at branch issue-36-c4dced57ba27 for issue https://github.com/link-foundation/relative-meta-logic/issues/36

--- a/experiments/program.lino
+++ b/experiments/program.lino
@@ -1,0 +1,7 @@
+(a: a is a)
+(? (a = a))
+((b = b) has probability 0.7)
+(? (b = b))
+(? (1 + 2))
+(? (not 0))
+(? (1 = 2))

--- a/experiments/proofs-mutated.lino
+++ b/experiments/proofs-mutated.lino
@@ -1,0 +1,5 @@
+(by numeric-equality (a a))
+(by assigned-equality (b b))
+(by sum (by literal 1) (by literal 2))
+(by not (by literal 0))
+(by numeric-equality (1 2))

--- a/experiments/proofs-mutated2.lino
+++ b/experiments/proofs-mutated2.lino
@@ -1,0 +1,5 @@
+(by structural-equality (a a))
+(by assigned-equality (b b))
+(by sum (by literal 1) (by literal 5))
+(by not (by literal 0))
+(by numeric-equality (1 2))

--- a/experiments/proofs.lino
+++ b/experiments/proofs.lino
@@ -1,0 +1,5 @@
+(by structural-equality (a a))
+(by assigned-equality (b b))
+(by sum (by literal 1) (by literal 2))
+(by not (by literal 0))
+(by numeric-equality (1 2))

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -11,6 +11,10 @@
       "dependencies": {
         "links-notation": "^0.13.0"
       },
+      "bin": {
+        "rml": "src/rml-links.mjs",
+        "rml-check": "src/rml-check.mjs"
+      },
       "devDependencies": {},
       "engines": {
         "node": ">=18.0.0"

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,12 +1,17 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",
+  "bin": {
+    "rml": "src/rml-links.mjs",
+    "rml-check": "src/rml-check.mjs"
+  },
   "scripts": {
     "test": "node --test tests/ ../scripts/",
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
+    "check": "node src/rml-check.mjs",
     "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino"
   },
   "keywords": [

--- a/js/src/check.mjs
+++ b/js/src/check.mjs
@@ -1,0 +1,504 @@
+// rml-check — independent proof-replay checker (issue #36).
+//
+// Verifies that a derivation produced by the proof-producing evaluator
+// (issue #35) replays under the kernel alone — never calls evaluate().
+// Each `(by <rule> <sub>...)` node is matched against the kernel's
+// structural shape for its expression: rule name, arity, and that
+// sub-derivations recurse onto matching sub-expressions. Mutating any of
+// those rejects.
+//
+// Mirrors rust/src/check.rs so any drift between the two implementations
+// fails both test suites.
+
+import {
+  parseLino,
+  parseOne,
+  tokenizeOne,
+  keyOf,
+  isStructurallySame,
+} from './rml-links.mjs';
+
+const isNum = s => typeof s === 'string' && /^-?(\d+(\.\d+)?|\.\d+)$/.test(s);
+
+// Built-in operator names plus user-declared `(name: ...)` heads. Used to
+// validate the prefix-operator fallback rule. Mirrors the names recognised
+// by `Env` so the checker can validate proofs without an env.
+function collectOperators(forms) {
+  const ops = new Set(['not', 'and', 'or', '=', '!=', '+', '-', '*', '/']);
+  for (const f of forms) {
+    if (Array.isArray(f) && typeof f[0] === 'string' && f[0].endsWith(':')) {
+      const name = f[0].slice(0, -1);
+      if (name) ops.add(name);
+    }
+  }
+  return ops;
+}
+
+// Equality keys (both prefix and infix shapes) that the program assigned a
+// probability to. Used by `expectedRule` to know whether `assigned-*`
+// rules are admissible at a given equality node.
+function collectAssignments(forms) {
+  const out = new Set();
+  for (const f of forms) {
+    if (
+      Array.isArray(f) &&
+      f.length === 4 &&
+      f[1] === 'has' &&
+      f[2] === 'probability' &&
+      isNum(f[3])
+    ) {
+      const inner = f[0];
+      out.add(keyOf(inner));
+      if (Array.isArray(inner) && inner.length === 3 && inner[1] === '=') {
+        out.add(keyOf(['=', inner[0], inner[2]]));
+      }
+    }
+  }
+  return out;
+}
+
+// Parse a `.lino` source into top-level forms via the kernel parser.
+function parseForms(src) {
+  const out = [];
+  for (const s of parseLino(src)) {
+    if (s.trimStart().startsWith('(#')) continue;
+    try {
+      out.push(parseOne(tokenizeOne(s)));
+    } catch (_) {
+      // Skip unparseable forms. The checker reports a count mismatch
+      // downstream if this hides a real query.
+    }
+  }
+  return out;
+}
+
+// Strip `(? expr)` wrappers and the optional `with proof` keyword pair.
+function queryTarget(n) {
+  if (!Array.isArray(n) || n[0] !== '?') return null;
+  let parts = n.slice(1);
+  if (
+    parts.length >= 2 &&
+    parts[parts.length - 2] === 'with' &&
+    parts[parts.length - 1] === 'proof'
+  ) {
+    parts = parts.slice(0, -2);
+  }
+  return parts.length === 1 ? parts[0] : parts;
+}
+
+// Decompose `(by <rule> <sub>...)` or fail with a descriptive error.
+function decode(p, path) {
+  if (
+    Array.isArray(p) &&
+    p.length >= 2 &&
+    p[0] === 'by' &&
+    typeof p[1] === 'string'
+  ) {
+    return { rule: p[1], subs: p.slice(2) };
+  }
+  throw {
+    path: [...path],
+    message: `expected \`(by <rule> ...)\`, got \`${keyOf(p)}\``,
+  };
+}
+
+// The single rule the kernel would emit for `expr`. Equality is the only
+// shape with multiple admissible rules (assigned/structural/numeric); we
+// pick the unique one matching the program facts.
+function expectedRule(expr, ops, assigned) {
+  if (typeof expr === 'string') return isNum(expr) ? 'literal' : 'symbol';
+  if (!Array.isArray(expr)) return 'reduce';
+
+  const head = expr[0];
+  if (typeof head === 'string' && head.endsWith(':')) return 'definition';
+  if (head === 'Type' && expr.length === 2) return 'type-universe';
+  if (head === 'Prop' && expr.length === 1) return 'prop';
+  if (head === 'Pi' && expr.length === 3) return 'pi-formation';
+  if (head === 'lambda' && expr.length === 3) return 'lambda-formation';
+  if (head === 'apply' && expr.length === 3) return 'beta-reduction';
+  if (head === 'type' && expr.length === 3 && expr[1] === 'of') {
+    return 'type-query';
+  }
+
+  // ((expr) has probability p)
+  if (
+    expr.length === 4 &&
+    expr[1] === 'has' &&
+    expr[2] === 'probability' &&
+    isNum(expr[3])
+  ) {
+    return 'assigned-probability';
+  }
+
+  // (range lo hi) / (valence N)
+  if (
+    expr.length === 3 &&
+    head === 'range' &&
+    isNum(expr[1]) &&
+    isNum(expr[2])
+  ) {
+    return 'configuration';
+  }
+  if (expr.length === 2 && head === 'valence' && isNum(expr[1])) {
+    return 'configuration';
+  }
+
+  // (L op R) infix.
+  if (expr.length === 3 && typeof expr[1] === 'string') {
+    const op = expr[1];
+    const arith = { '+': 'sum', '-': 'difference', '*': 'product', '/': 'quotient' };
+    if (op in arith) return arith[op];
+    if (op === 'and' || op === 'or' || op === 'both' || op === 'neither') return op;
+    if (op === 'of') return 'type-check';
+    if (op === '=' || op === '!=') {
+      const L = expr[0];
+      const R = expr[2];
+      const kP = keyOf(['=', L, R]);
+      const kI = keyOf([L, '=', R]);
+      const isAssigned = assigned.has(kP) || assigned.has(kI);
+      if (op === '!=') {
+        if (isAssigned) return 'assigned-inequality';
+        return isStructurallySame(L, R) ? 'structural-inequality' : 'numeric-inequality';
+      }
+      if (isAssigned) return 'assigned-equality';
+      return isStructurallySame(L, R) ? 'structural-equality' : 'numeric-equality';
+    }
+  }
+
+  // Composite (both A and B [...]) / (neither A nor B [...]).
+  if (expr.length >= 4 && expr.length % 2 === 0) {
+    if (head === 'both') return 'both';
+    if (head === 'neither') return 'neither';
+  }
+
+  // Prefix operator: (op X Y ...)
+  if (typeof head === 'string' && ops.has(head)) {
+    return prefixMarker(head);
+  }
+  return 'reduce';
+}
+
+// Stable name for a prefix-op rule: the op name itself maps to its
+// operational rule (e.g. `not` → `not`). Anything else falls back to
+// `reduce` so the structural validator handles it via the prefix path.
+function prefixMarker(name) {
+  switch (name) {
+    case 'not': return 'not';
+    case 'and': return 'and';
+    case 'or': return 'or';
+    case '+': return 'sum';
+    case '-': return 'difference';
+    case '*': return 'product';
+    case '/': return 'quotient';
+    default: return 'reduce';
+  }
+}
+
+// Walk both trees in lockstep and verify each level matches.
+function checkNode(expr, proof, ops, assigned, path) {
+  const { rule, subs } = decode(proof, path);
+  const exp = expectedRule(expr, ops, assigned);
+  const ruleOk = rule === exp || prefixMatch(rule, expr, ops);
+  if (!ruleOk) {
+    throw {
+      path: [...path],
+      message: `rule \`${rule}\` does not justify \`${keyOf(expr)}\` (expected \`${exp}\`)`,
+    };
+  }
+  const nextPath = [...path, rule];
+
+  switch (rule) {
+    case 'literal': {
+      arity(rule, subs, 1, path);
+      if (typeof subs[0] !== 'string' || !isNum(subs[0]) || subs[0] !== expr) {
+        throw {
+          path: [...path],
+          message: `literal \`${keyOf(subs[0])}\` ≠ \`${keyOf(expr)}\``,
+        };
+      }
+      return rule;
+    }
+    case 'symbol': {
+      arity(rule, subs, 1, path);
+      if (typeof subs[0] !== 'string' || subs[0] !== expr) {
+        throw {
+          path: [...path],
+          message: `symbol \`${keyOf(subs[0])}\` ≠ \`${keyOf(expr)}\``,
+        };
+      }
+      return rule;
+    }
+    case 'definition':
+    case 'configuration':
+    case 'assigned-probability':
+    case 'reduce':
+      return rule;
+    case 'query':
+      throw { path: [...path], message: 'stray `query` rule (stripped by checker)' };
+    case 'sum':
+    case 'difference':
+    case 'product':
+    case 'quotient': {
+      const opMap = { sum: '+', difference: '-', product: '*', quotient: '/' };
+      return checkInfix(expr, rule, subs, opMap[rule], ops, assigned, nextPath, path);
+    }
+    case 'and':
+    case 'or':
+    case 'both':
+    case 'neither':
+      return checkLogic(expr, rule, subs, ops, assigned, nextPath, path);
+    case 'not': {
+      arity(rule, subs, 1, path);
+      if (
+        Array.isArray(expr) &&
+        expr.length === 2 &&
+        expr[0] === 'not'
+      ) {
+        checkNode(expr[1], subs[0], ops, assigned, nextPath);
+        return rule;
+      }
+      throw { path: [...path], message: `\`not\` ≠ \`${keyOf(expr)}\`` };
+    }
+    case 'structural-equality':
+    case 'numeric-equality':
+    case 'assigned-equality':
+    case 'structural-inequality':
+    case 'numeric-inequality':
+    case 'assigned-inequality':
+      return checkEq(expr, rule, subs, ops, assigned, path);
+    case 'type-universe':
+    case 'prop':
+    case 'pi-formation':
+    case 'lambda-formation':
+    case 'type-query':
+    case 'type-check':
+      return checkTypesys(expr, rule, subs, path);
+    case 'beta-reduction': {
+      arity(rule, subs, 2, path);
+      if (
+        Array.isArray(expr) &&
+        expr.length === 3 &&
+        expr[0] === 'apply'
+      ) {
+        checkNode(expr[1], subs[0], ops, assigned, nextPath);
+        checkNode(expr[2], subs[1], ops, assigned, nextPath);
+        return rule;
+      }
+      throw {
+        path: [...path],
+        message: `\`beta-reduction\` ≠ \`${keyOf(expr)}\``,
+      };
+    }
+    default:
+      return checkPrefix(expr, rule, subs, ops, assigned, nextPath, path);
+  }
+}
+
+function arity(rule, subs, n, path) {
+  if (subs.length !== n) {
+    throw {
+      path: [...path],
+      message: `rule \`${rule}\` expects ${n} sub(s), got ${subs.length}`,
+    };
+  }
+}
+
+// True when `rule` is the bare name of a prefix operator applied at expr.
+function prefixMatch(rule, expr, ops) {
+  if (!ops.has(rule)) return false;
+  return Array.isArray(expr) && expr[0] === rule;
+}
+
+function checkInfix(expr, rule, subs, op, ops, assigned, nextPath, path) {
+  arity(rule, subs, 2, path);
+  if (
+    Array.isArray(expr) &&
+    expr.length === 3 &&
+    expr[1] === op
+  ) {
+    checkNode(expr[0], subs[0], ops, assigned, nextPath);
+    checkNode(expr[2], subs[1], ops, assigned, nextPath);
+    return rule;
+  }
+  throw { path: [...path], message: `rule \`${rule}\` ≠ \`${keyOf(expr)}\`` };
+}
+
+function checkLogic(expr, rule, subs, ops, assigned, nextPath, path) {
+  if (Array.isArray(expr)) {
+    // Binary infix.
+    if (expr.length === 3 && expr[1] === rule) {
+      arity(rule, subs, 2, path);
+      checkNode(expr[0], subs[0], ops, assigned, nextPath);
+      checkNode(expr[2], subs[1], ops, assigned, nextPath);
+      return rule;
+    }
+    // Composite chain.
+    if (
+      (rule === 'both' || rule === 'neither') &&
+      expr.length >= 4 &&
+      expr.length % 2 === 0 &&
+      expr[0] === rule
+    ) {
+      const sep = rule === 'both' ? 'and' : 'nor';
+      for (let i = 2; i < expr.length; i += 2) {
+        if (expr[i] !== sep) {
+          throw {
+            path: [...path],
+            message: `composite \`${rule}\` separator must be \`${sep}\``,
+          };
+        }
+      }
+      const n = expr.length / 2;
+      arity(rule, subs, n, path);
+      for (let j = 0; j < subs.length; j++) {
+        checkNode(expr[1 + j * 2], subs[j], ops, assigned, nextPath);
+      }
+      return rule;
+    }
+  }
+  throw { path: [...path], message: `rule \`${rule}\` ≠ \`${keyOf(expr)}\`` };
+}
+
+function checkEq(expr, rule, subs, ops, assigned, path) {
+  arity(rule, subs, 1, path);
+  const pair = subs[0];
+  if (!Array.isArray(pair) || pair.length !== 2) {
+    throw { path: [...path], message: `\`${rule}\` expects \`(L R)\` sub` };
+  }
+  if (
+    Array.isArray(expr) &&
+    expr.length === 3 &&
+    (expr[1] === '=' || expr[1] === '!=')
+  ) {
+    if (
+      !isStructurallySame(expr[0], pair[0]) ||
+      !isStructurallySame(expr[2], pair[1])
+    ) {
+      throw {
+        path: [...path],
+        message: `operands \`${keyOf(pair[0])} ${keyOf(pair[1])}\` ≠ \`${keyOf(expr[0])} ${keyOf(expr[2])}\``,
+      };
+    }
+    const exp = expectedRule(expr, ops, assigned);
+    if (exp === rule) return rule;
+    throw {
+      path: [...path],
+      message: `rule \`${rule}\` ≠ expected \`${exp}\``,
+    };
+  }
+  throw { path: [...path], message: `rule \`${rule}\` ≠ \`${keyOf(expr)}\`` };
+}
+
+function checkTypesys(expr, rule, subs, path) {
+  const bad = (reason) => {
+    throw {
+      path: [...path],
+      message: `\`${rule}\` ≠ \`${keyOf(expr)}\` (${reason})`,
+    };
+  };
+  if (!Array.isArray(expr)) bad('shape mismatch');
+
+  if (rule === 'type-universe' && expr.length === 2 && expr[0] === 'Type') {
+    arity(rule, subs, 1, path);
+    if (isStructurallySame(expr[1], subs[0])) return rule;
+    bad('Type level mismatch');
+  }
+  if (rule === 'prop' && expr.length === 1 && expr[0] === 'Prop') {
+    arity(rule, subs, 0, path);
+    return rule;
+  }
+  if (
+    (rule === 'pi-formation' && expr.length === 3 && expr[0] === 'Pi') ||
+    (rule === 'lambda-formation' && expr.length === 3 && expr[0] === 'lambda')
+  ) {
+    arity(rule, subs, 2, path);
+    if (
+      isStructurallySame(expr[1], subs[0]) &&
+      isStructurallySame(expr[2], subs[1])
+    ) {
+      return rule;
+    }
+    bad('binder mismatch');
+  }
+  if (
+    rule === 'type-query' &&
+    expr.length === 3 &&
+    expr[0] === 'type' &&
+    expr[1] === 'of'
+  ) {
+    arity(rule, subs, 1, path);
+    if (isStructurallySame(expr[2], subs[0])) return rule;
+    bad('type-query mismatch');
+  }
+  if (rule === 'type-check' && expr.length === 3 && expr[1] === 'of') {
+    arity(rule, subs, 2, path);
+    if (
+      isStructurallySame(expr[0], subs[0]) &&
+      isStructurallySame(expr[2], subs[1])
+    ) {
+      return rule;
+    }
+    bad('type-check mismatch');
+  }
+  bad('shape mismatch');
+}
+
+function checkPrefix(expr, rule, subs, ops, assigned, nextPath, path) {
+  if (
+    Array.isArray(expr) &&
+    expr.length >= 1 &&
+    expr[0] === rule &&
+    ops.has(rule)
+  ) {
+    arity(rule, subs, expr.length - 1, path);
+    for (let i = 0; i < subs.length; i++) {
+      checkNode(expr[1 + i], subs[i], ops, assigned, nextPath);
+    }
+    return rule;
+  }
+  throw {
+    path: [...path],
+    message: `unknown rule \`${rule}\` for \`${keyOf(expr)}\``,
+  };
+}
+
+/**
+ * Public entry point: parse both `.lino` sources, pair queries with
+ * derivations 1:1, and verify each pair structurally. Returns
+ * `{ ok: [{rule, expr}, ...], errors: [{path, message}, ...] }`.
+ */
+export function checkProgram(programSrc, proofsSrc) {
+  const programForms = parseForms(programSrc);
+  const proofForms = parseForms(proofsSrc);
+  const queries = programForms.map(queryTarget).filter(q => q !== null);
+  const ops = collectOperators(programForms);
+  const assigned = collectAssignments(programForms);
+  const result = { ok: [], errors: [] };
+
+  if (queries.length !== proofForms.length) {
+    result.errors.push({
+      path: [],
+      message: `expected ${queries.length} derivation(s), got ${proofForms.length}`,
+    });
+    return result;
+  }
+
+  for (let i = 0; i < queries.length; i++) {
+    const path = [`query[${i}]`];
+    try {
+      const rule = checkNode(queries[i], proofForms[i], ops, assigned, path);
+      result.ok.push({ rule, expr: keyOf(queries[i]) });
+    } catch (e) {
+      if (e && typeof e === 'object' && 'path' in e && 'message' in e) {
+        result.errors.push(e);
+      } else {
+        throw e;
+      }
+    }
+  }
+  return result;
+}
+
+export function isOk(result) {
+  return result.errors.length === 0;
+}

--- a/js/src/check.mjs
+++ b/js/src/check.mjs
@@ -229,10 +229,13 @@ function checkNode(expr, proof, ops, assigned, path) {
       return rule;
     }
     case 'definition':
+      return checkPayload(rule, subs, [expr], path);
     case 'configuration':
+      return checkConfiguration(expr, rule, subs, path);
     case 'assigned-probability':
+      return checkAssignedProbability(expr, rule, subs, path);
     case 'reduce':
-      return rule;
+      return checkPayload(rule, subs, [expr], path);
     case 'query':
       throw { path: [...path], message: 'stray `query` rule (stripped by checker)' };
     case 'sum':
@@ -301,6 +304,41 @@ function arity(rule, subs, n, path) {
       message: `rule \`${rule}\` expects ${n} sub(s), got ${subs.length}`,
     };
   }
+}
+
+function checkPayload(rule, subs, expected, path) {
+  arity(rule, subs, expected.length, path);
+  for (let i = 0; i < expected.length; i++) {
+    if (!isStructurallySame(subs[i], expected[i])) {
+      throw {
+        path: [...path],
+        message: `payload ${i} \`${keyOf(subs[i])}\` ≠ \`${keyOf(expected[i])}\``,
+      };
+    }
+  }
+  return rule;
+}
+
+function checkConfiguration(expr, rule, subs, path) {
+  if (Array.isArray(expr) && expr.length === 3 && expr[0] === 'range') {
+    return checkPayload(rule, subs, ['range', expr[1], expr[2]], path);
+  }
+  if (Array.isArray(expr) && expr.length === 2 && expr[0] === 'valence') {
+    return checkPayload(rule, subs, ['valence', expr[1]], path);
+  }
+  throw { path: [...path], message: `\`${rule}\` ≠ \`${keyOf(expr)}\`` };
+}
+
+function checkAssignedProbability(expr, rule, subs, path) {
+  if (
+    Array.isArray(expr) &&
+    expr.length === 4 &&
+    expr[1] === 'has' &&
+    expr[2] === 'probability'
+  ) {
+    return checkPayload(rule, subs, [expr[0], expr[3]], path);
+  }
+  throw { path: [...path], message: `\`${rule}\` ≠ \`${keyOf(expr)}\`` };
 }
 
 // True when `rule` is the bare name of a prefix operator applied at expr.

--- a/js/src/rml-check.mjs
+++ b/js/src/rml-check.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// rml-check — independent proof-replay checker (issue #36).
+//
+// CLI front-end for the `check.mjs` module. Reads a program file and a
+// proof file, validates that every derivation in the proof file
+// corresponds to a query in the program, and prints
+// `OK: N derivations replayed.` on success.
+
+import fs from 'node:fs';
+import { checkProgram, isOk } from './check.mjs';
+
+function main(argv) {
+  if (argv.length !== 4) {
+    process.stderr.write('Usage: rml-check <program.lino> <proofs.lino>\n');
+    return 2;
+  }
+  const programPath = argv[2];
+  const proofsPath = argv[3];
+
+  let program;
+  let proofs;
+  try {
+    program = fs.readFileSync(programPath, 'utf8');
+  } catch (e) {
+    process.stderr.write(`Error reading ${programPath}: ${e.message}\n`);
+    return 1;
+  }
+  try {
+    proofs = fs.readFileSync(proofsPath, 'utf8');
+  } catch (e) {
+    process.stderr.write(`Error reading ${proofsPath}: ${e.message}\n`);
+    return 1;
+  }
+
+  const result = checkProgram(program, proofs);
+  if (isOk(result)) {
+    process.stdout.write(`OK: ${result.ok.length} derivations replayed.\n`);
+    return 0;
+  }
+  for (const err of result.errors) {
+    const path = err.path.length === 0 ? '<root>' : err.path.join(' / ');
+    process.stderr.write(`FAIL [${path}]: ${err.message}\n`);
+  }
+  return 1;
+}
+
+process.exit(main(process.argv));

--- a/js/tests/check.test.mjs
+++ b/js/tests/check.test.mjs
@@ -1,0 +1,198 @@
+// Integration tests for the independent proof-replay checker (issue #36).
+// Mirrors `rust/tests/check_tests.rs` so any drift between the two
+// implementations fails both test suites. The checker is deliberately
+// kernel-only — it never calls `evaluate()` — and the tests below verify
+// that valid proofs replay successfully while every mutation we can come
+// up with (wrong rule, wrong operand, wrong arity, missing or extra
+// derivation, swapped sub-tree) is rejected.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { evaluate, keyOf } from '../src/rml-links.mjs';
+import { checkProgram, isOk } from '../src/check.mjs';
+
+// Drive the proof-producing evaluator and return the printed proof stream
+// that the kernel-only checker should accept verbatim.
+function proofsFrom(src) {
+  const out = evaluate(src, { withProofs: true });
+  return out.proofs
+    .filter(p => p !== null && p !== undefined)
+    .map(keyOf)
+    .join('\n');
+}
+
+describe('replay acceptance: structural-equality witness', () => {
+  it('replays the canonical (by structural-equality (a a)) witness', () => {
+    const r = checkProgram('(a: a is a)\n(? (a = a))', '(by structural-equality (a a))');
+    assert.ok(isOk(r), JSON.stringify(r.errors));
+    assert.strictEqual(r.ok.length, 1);
+    assert.strictEqual(r.ok[0].rule, 'structural-equality');
+  });
+
+  it('matches proofs emitted by the evaluator for a varied program', () => {
+    const program = [
+      '(a: a is a)',
+      '((b = b) has probability 0.7)',
+      '(? (a = a))',
+      '(? (b = b))',
+      '(? (1 + 2))',
+      '(? (5 - 2))',
+      '(? (3 * 4))',
+      '(? (8 / 2))',
+      '(? (not 0))',
+      '(? (1 and 0))',
+      '(? (0 or 1))',
+      '(? (both 1 and 1 and 0))',
+      '(? (neither 0 nor 0))',
+      '(? (1 = 2))',
+      '(? (1 != 2))',
+    ].join('\n');
+    const proofs = proofsFrom(program);
+    const r = checkProgram(program, proofs);
+    assert.ok(isOk(r), JSON.stringify(r.errors));
+    assert.strictEqual(r.ok.length, 13);
+  });
+});
+
+describe('rule-name mutations', () => {
+  it('rejects wrong rule for structural equality', () => {
+    const r = checkProgram(
+      '(a: a is a)\n(? (a = a))',
+      '(by numeric-equality (a a))',
+    );
+    assert.ok(!isOk(r));
+    assert.ok(r.errors[0].message.includes('numeric-equality'));
+  });
+
+  it('rejects assigned rule when no assignment exists', () => {
+    const r = checkProgram(
+      '(a: a is a)\n(? (a = a))',
+      '(by assigned-equality (a a))',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects swapped arithmetic rule', () => {
+    const r = checkProgram(
+      '(? (1 - 2))',
+      '(by sum (by literal 1) (by literal 2))',
+    );
+    assert.ok(!isOk(r));
+  });
+});
+
+describe('operand mutations', () => {
+  it('rejects wrong operands in equality pair', () => {
+    const r = checkProgram(
+      '(a: a is a)\n(b: b is b)\n(? (a = a))',
+      '(by structural-equality (a b))',
+    );
+    assert.ok(!isOk(r));
+    const m = r.errors[0].message.toLowerCase();
+    assert.ok(m.includes('operand') || r.errors[0].message.includes('does not match'));
+  });
+
+  it('rejects wrong literal inside arithmetic subtree', () => {
+    const r = checkProgram(
+      '(? (1 + 2))',
+      '(by sum (by literal 1) (by literal 5))',
+    );
+    assert.ok(!isOk(r));
+    assert.ok(r.errors[0].message.includes('5'));
+  });
+});
+
+describe('arity / shape mutations', () => {
+  it('rejects missing subtree', () => {
+    const r = checkProgram(
+      '(? (1 + 2))',
+      '(by sum (by literal 1))',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects extra subtree', () => {
+    const r = checkProgram(
+      '(? (not 0))',
+      '(by not (by literal 0) (by literal 0))',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects non-by node at top level', () => {
+    const r = checkProgram(
+      '(? (a = a))',
+      '(structural-equality (a a))',
+    );
+    assert.ok(!isOk(r));
+  });
+});
+
+describe('pairing mutations', () => {
+  it('rejects too few proofs for program', () => {
+    const r = checkProgram(
+      '(? (1 + 2))\n(? (1 - 2))',
+      '(by sum (by literal 1) (by literal 2))',
+    );
+    assert.ok(!isOk(r));
+    assert.ok(r.errors[0].message.includes('expected 2'));
+  });
+
+  it('rejects too many proofs for program', () => {
+    const r = checkProgram(
+      '(? (1 + 2))',
+      '(by sum (by literal 1) (by literal 2))\n(by sum (by literal 3) (by literal 4))',
+    );
+    assert.ok(!isOk(r));
+  });
+});
+
+describe('composite chains', () => {
+  it('replays composite both chain', () => {
+    const program = '(? (both 1 and 0 and 1))';
+    const proofs = proofsFrom(program);
+    const r = checkProgram(program, proofs);
+    assert.ok(isOk(r), JSON.stringify(r.errors));
+  });
+
+  it('rejects mutated composite chain', () => {
+    const r = checkProgram(
+      '(? (both 1 and 0 and 1))',
+      '(by both (by literal 1) (by literal 0))',
+    );
+    assert.ok(!isOk(r));
+  });
+});
+
+describe('result agreement: replay does not depend on truth values', () => {
+  it('checker accepts the evaluator output and rejects rule-mutated stream', () => {
+    const program = [
+      '(a: a is a)',
+      '((a = a) has probability 1)',
+      '(? ((a = a) and (a = a)))',
+    ].join('\n');
+    const proofs = proofsFrom(program);
+    assert.ok(isOk(checkProgram(program, proofs)));
+    const mutated = proofs.replace(/assigned-equality/g, 'structural-equality');
+    assert.notStrictEqual(mutated, proofs);
+    assert.ok(!isOk(checkProgram(program, mutated)));
+  });
+});
+
+describe('result aggregation', () => {
+  it('reports count of replayed derivations', () => {
+    const program = '(? 1)\n(? 0)\n(? (1 + 1))';
+    const proofs = '(by literal 1)\n(by literal 0)\n(by sum (by literal 1) (by literal 1))';
+    const r = checkProgram(program, proofs);
+    assert.ok(isOk(r));
+    assert.strictEqual(r.ok.length, 3);
+  });
+
+  it('evaluator results match independently when proof replay succeeds', () => {
+    const program = '(? (0 + 1))';
+    const out = evaluate(program, { withProofs: true });
+    assert.deepStrictEqual(out.results, [1]);
+    const proof = keyOf(out.proofs[0]);
+    assert.ok(isOk(checkProgram(program, proof)));
+  });
+});

--- a/js/tests/check.test.mjs
+++ b/js/tests/check.test.mjs
@@ -102,6 +102,40 @@ describe('operand mutations', () => {
   });
 });
 
+describe('payload mutations', () => {
+  it('rejects wrong reduce payload', () => {
+    const r = checkProgram(
+      '(? (mystery 1))',
+      '(by reduce (different 2))',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects wrong definition payload', () => {
+    const r = checkProgram(
+      '(? (foo: bar))',
+      '(by definition (bar: foo))',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects wrong configuration payload', () => {
+    const r = checkProgram(
+      '(? (range 0 1))',
+      '(by configuration valence 9)',
+    );
+    assert.ok(!isOk(r));
+  });
+
+  it('rejects wrong assigned-probability payload', () => {
+    const r = checkProgram(
+      '(? ((a = a) has probability 0.7))',
+      '(by assigned-probability (b = b) 0.2)',
+    );
+    assert.ok(!isOk(r));
+  });
+});
+
 describe('arity / shape mutations', () => {
   it('rejects missing subtree', () => {
     const r = checkProgram(

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"
@@ -8,6 +8,10 @@ license = "Unlicense"
 [[bin]]
 name = "rml"
 path = "src/main.rs"
+
+[[bin]]
+name = "rml-check"
+path = "src/bin/rml-check.rs"
 
 [lib]
 name = "rml"

--- a/rust/src/bin/rml-check.rs
+++ b/rust/src/bin/rml-check.rs
@@ -1,0 +1,50 @@
+// rml-check — independent proof-replay checker (issue #36).
+//
+// CLI front-end for the `rml::check` module. Reads a program file and a
+// proof file, validates that every derivation in the proof file
+// corresponds to a query in the program, and prints `OK: N derivations
+// replayed.` on success.
+
+use rml::check::check_program;
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: rml-check <program.lino> <proofs.lino>");
+        return ExitCode::from(2);
+    }
+    let program_path = &args[1];
+    let proofs_path = &args[2];
+    let program = match fs::read_to_string(program_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error reading {}: {}", program_path, e);
+            return ExitCode::from(1);
+        }
+    };
+    let proofs = match fs::read_to_string(proofs_path) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error reading {}: {}", proofs_path, e);
+            return ExitCode::from(1);
+        }
+    };
+    let result = check_program(&program, &proofs);
+    if result.is_ok() {
+        println!("OK: {} derivations replayed.", result.ok.len());
+        ExitCode::SUCCESS
+    } else {
+        for err in &result.errors {
+            let path = if err.path.is_empty() {
+                String::from("<root>")
+            } else {
+                err.path.join(" / ")
+            };
+            eprintln!("FAIL [{}]: {}", path, err.message);
+        }
+        ExitCode::from(1)
+    }
+}

--- a/rust/src/check.rs
+++ b/rust/src/check.rs
@@ -1,0 +1,693 @@
+// rml-check — independent proof-replay checker (issue #36).
+//
+// Verifies that a derivation produced by the proof-producing evaluator
+// (issue #35) replays under the kernel alone — no evaluator. Each
+// `(by <rule> <sub>...)` node is matched against the kernel's structural
+// shape for its expression: rule name, arity, and that sub-derivations
+// recurse onto matching sub-expressions. Mutating any of those rejects.
+
+use crate::{is_num, is_structurally_same, key_of, parse_lino, parse_one, tokenize_one, Node};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CheckOk {
+    pub rule: String,
+    pub expr: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CheckError {
+    pub path: Vec<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CheckResult {
+    pub ok: Vec<CheckOk>,
+    pub errors: Vec<CheckError>,
+}
+
+impl CheckResult {
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+// Built-in operator names plus user-declared `(name: ...)` heads. Used to
+// validate the prefix-operator fallback rule. Mirrors the names recognised
+// by `Env::new()` so the checker can validate proofs without an env.
+fn collect_operators(forms: &[Node]) -> HashSet<String> {
+    let mut ops: HashSet<String> = ["not", "and", "or", "=", "!=", "+", "-", "*", "/"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    for f in forms {
+        if let Node::List(c) = f {
+            if let Some(Node::Leaf(s)) = c.first() {
+                if let Some(name) = s.strip_suffix(':') {
+                    if !name.is_empty() {
+                        ops.insert(name.to_string());
+                    }
+                }
+            }
+        }
+    }
+    ops
+}
+
+// Equality keys (both prefix and infix shapes) that the program assigned a
+// probability to. Used by `expected_rule` to know whether `assigned-*`
+// rules are admissible at a given equality node.
+fn collect_assignments(forms: &[Node]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for f in forms {
+        if let Node::List(c) = f {
+            if c.len() == 4 {
+                if let (Node::Leaf(w1), Node::Leaf(w2), Node::Leaf(w3)) =
+                    (&c[1], &c[2], &c[3])
+                {
+                    if w1 == "has" && w2 == "probability" && is_num(w3) {
+                        if let Node::List(inner) = &c[0] {
+                            out.insert(key_of(&c[0]));
+                            if inner.len() == 3 {
+                                if let Node::Leaf(op) = &inner[1] {
+                                    if op == "=" {
+                                        out.insert(key_of(&Node::List(vec![
+                                            Node::Leaf("=".into()),
+                                            inner[0].clone(),
+                                            inner[2].clone(),
+                                        ])));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+// Parse a `.lino` source into top-level forms via the kernel parser.
+fn parse_forms(src: &str) -> Vec<Node> {
+    parse_lino(src)
+        .into_iter()
+        .filter(|s| !s.trim_start().starts_with("(#"))
+        .filter_map(|s| parse_one(&tokenize_one(&s)).ok())
+        .collect()
+}
+
+// Strip `(? expr)` wrappers and the optional `with proof` keyword pair.
+fn query_target(n: &Node) -> Option<Node> {
+    if let Node::List(c) = n {
+        if let Some(Node::Leaf(h)) = c.first() {
+            if h == "?" {
+                let parts: Vec<Node> = c[1..].to_vec();
+                let parts = if parts.len() >= 2 {
+                    if let (Node::Leaf(a), Node::Leaf(b)) =
+                        (&parts[parts.len() - 2], &parts[parts.len() - 1])
+                    {
+                        if a == "with" && b == "proof" {
+                            parts[..parts.len() - 2].to_vec()
+                        } else {
+                            parts
+                        }
+                    } else {
+                        parts
+                    }
+                } else {
+                    parts
+                };
+                return Some(if parts.len() == 1 {
+                    parts[0].clone()
+                } else {
+                    Node::List(parts)
+                });
+            }
+        }
+    }
+    None
+}
+
+// Decompose `(by <rule> <sub>...)` or fail with a descriptive error.
+fn decode<'a>(p: &'a Node, path: &[String]) -> Result<(String, &'a [Node]), CheckError> {
+    if let Node::List(c) = p {
+        if c.len() >= 2 {
+            if let (Node::Leaf(by), Node::Leaf(rule)) = (&c[0], &c[1]) {
+                if by == "by" {
+                    return Ok((rule.clone(), &c[2..]));
+                }
+            }
+        }
+    }
+    Err(CheckError {
+        path: path.to_vec(),
+        message: format!("expected `(by <rule> ...)`, got `{}`", key_of(p)),
+    })
+}
+
+// The single rule the kernel would emit for `expr`. Equality is the only
+// shape with multiple admissible rules (assigned/structural/numeric); we
+// pick the unique one matching the program facts.
+fn expected_rule(
+    expr: &Node,
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+) -> &'static str {
+    match expr {
+        Node::Leaf(s) => {
+            if is_num(s) {
+                "literal"
+            } else {
+                "symbol"
+            }
+        }
+        Node::List(c) => {
+            if let Some(Node::Leaf(h)) = c.first() {
+                if h.ends_with(':') {
+                    return "definition";
+                }
+                match h.as_str() {
+                    "Type" if c.len() == 2 => return "type-universe",
+                    "Prop" if c.len() == 1 => return "prop",
+                    "Pi" if c.len() == 3 => return "pi-formation",
+                    "lambda" if c.len() == 3 => return "lambda-formation",
+                    "apply" if c.len() == 3 => return "beta-reduction",
+                    "type" if c.len() == 3 => {
+                        if let Node::Leaf(of) = &c[1] {
+                            if of == "of" {
+                                return "type-query";
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            // ((expr) has probability p)
+            if c.len() == 4 {
+                if let (Node::Leaf(w1), Node::Leaf(w2), Node::Leaf(w3)) = (&c[1], &c[2], &c[3]) {
+                    if w1 == "has" && w2 == "probability" && is_num(w3) {
+                        return "assigned-probability";
+                    }
+                }
+            }
+            // (range lo hi) / (valence N)
+            if c.len() == 3 {
+                if let (Node::Leaf(h), Node::Leaf(a), Node::Leaf(b)) = (&c[0], &c[1], &c[2]) {
+                    if h == "range" && is_num(a) && is_num(b) {
+                        return "configuration";
+                    }
+                }
+            }
+            if c.len() == 2 {
+                if let (Node::Leaf(h), Node::Leaf(v)) = (&c[0], &c[1]) {
+                    if h == "valence" && is_num(v) {
+                        return "configuration";
+                    }
+                }
+            }
+            // (L op R) infix.
+            if c.len() == 3 {
+                if let Node::Leaf(op) = &c[1] {
+                    return match op.as_str() {
+                        "+" => "sum",
+                        "-" => "difference",
+                        "*" => "product",
+                        "/" => "quotient",
+                        "and" => "and",
+                        "or" => "or",
+                        "both" => "both",
+                        "neither" => "neither",
+                        "of" => "type-check",
+                        "=" | "!=" => {
+                            let l = &c[0];
+                            let r = &c[2];
+                            let kp = key_of(&Node::List(vec![
+                                Node::Leaf("=".into()),
+                                l.clone(),
+                                r.clone(),
+                            ]));
+                            let ki = key_of(&Node::List(vec![
+                                l.clone(),
+                                Node::Leaf("=".into()),
+                                r.clone(),
+                            ]));
+                            let assigned = assigned.contains(&kp) || assigned.contains(&ki);
+                            if op == "!=" {
+                                if assigned {
+                                    "assigned-inequality"
+                                } else if is_structurally_same(l, r) {
+                                    "structural-inequality"
+                                } else {
+                                    "numeric-inequality"
+                                }
+                            } else if assigned {
+                                "assigned-equality"
+                            } else if is_structurally_same(l, r) {
+                                "structural-equality"
+                            } else {
+                                "numeric-equality"
+                            }
+                        }
+                        _ => fallback_prefix(c, ops),
+                    };
+                }
+            }
+            // Composite (both A and B [...]) / (neither A nor B [...]).
+            if c.len() >= 4 && c.len() % 2 == 0 {
+                if let Node::Leaf(h) = &c[0] {
+                    if h == "both" {
+                        return "both";
+                    }
+                    if h == "neither" {
+                        return "neither";
+                    }
+                }
+            }
+            fallback_prefix(c, ops)
+        }
+    }
+}
+
+fn fallback_prefix(c: &[Node], ops: &HashSet<String>) -> &'static str {
+    if let Some(Node::Leaf(h)) = c.first() {
+        if ops.contains(h) {
+            return prefix_marker(h);
+        }
+    }
+    "reduce"
+}
+
+// Stable static slice for prefix-op rule names: the rule string is the op
+// name itself, so we look it up via `prefix_marker` to keep the return
+// type `&'static str`. Any unrecognised name falls back to `reduce`.
+fn prefix_marker(name: &str) -> &'static str {
+    match name {
+        "not" => "not",
+        "and" => "and",
+        "or" => "or",
+        "+" => "sum",
+        "-" => "difference",
+        "*" => "product",
+        "/" => "quotient",
+        // User-declared / less common prefix ops: report `reduce` so the
+        // checker's structural validator handles them via the prefix path.
+        _ => "reduce",
+    }
+}
+
+// Walk both trees in lockstep and verify each level matches.
+fn check_node(
+    expr: &Node,
+    proof: &Node,
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+    path: &[String],
+) -> Result<String, CheckError> {
+    let (rule, subs) = decode(proof, path)?;
+    let exp = expected_rule(expr, ops, assigned);
+    // For prefix-applied operators the kernel writes the op name itself
+    // (e.g. `not`, `and`, custom `myop`); accept either the marker we
+    // returned or the matching head leaf when expr is a prefix call.
+    let rule_ok = rule == exp || prefix_match(&rule, expr, ops);
+    if !rule_ok {
+        return Err(err(
+            path,
+            format!(
+                "rule `{}` does not justify `{}` (expected `{}`)",
+                rule,
+                key_of(expr),
+                exp
+            ),
+        ));
+    }
+    let mut next_path = path.to_vec();
+    next_path.push(format!("{}", rule));
+    match rule.as_str() {
+        // Leaves
+        "literal" => arity(&rule, subs, 1, path).and_then(|_| match (&subs[0], expr) {
+            (Node::Leaf(n), Node::Leaf(en)) if is_num(n) && n == en => Ok(rule),
+            _ => Err(err(path, format!("literal `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)))),
+        }),
+        "symbol" => arity(&rule, subs, 1, path).and_then(|_| match (&subs[0], expr) {
+            (Node::Leaf(s), Node::Leaf(es)) if s == es => Ok(rule),
+            _ => Err(err(path, format!("symbol `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)))),
+        }),
+        // Top-level forms: definitions, configuration, assignment — the
+        // kernel produces these without sub-derivations to recurse into,
+        // so structural equality of the witness payload is enough.
+        "definition" | "configuration" | "assigned-probability" => Ok(rule),
+        "query" => Err(err(path, "stray `query` rule (stripped by checker)".into())),
+        "reduce" => Ok(rule),
+        // Infix arithmetic
+        "sum" | "difference" | "product" | "quotient" => {
+            let op = match rule.as_str() {
+                "sum" => "+",
+                "difference" => "-",
+                "product" => "*",
+                "quotient" => "/",
+                _ => unreachable!(),
+            };
+            check_infix(expr, &rule, subs, op, ops, assigned, &next_path, path)
+        }
+        // Logic — binary infix or composite chain
+        "and" | "or" | "both" | "neither" => {
+            check_logic(expr, &rule, subs, ops, assigned, &next_path, path)
+        }
+        // Unary not. Composite chains for `not` aren't a thing; only (not X).
+        "not" => arity(&rule, subs, 1, path).and_then(|_| match expr {
+            Node::List(c) if c.len() == 2 => match &c[0] {
+                Node::Leaf(h) if h == "not" => {
+                    check_node(&c[1], &subs[0], ops, assigned, &next_path).map(|_| rule.clone())
+                }
+                _ => Err(err(path, format!("`not` ≠ `{}`", key_of(expr)))),
+            },
+            _ => Err(err(path, format!("`not` ≠ `{}`", key_of(expr)))),
+        }),
+        // Equality / inequality
+        "structural-equality" | "numeric-equality" | "assigned-equality"
+        | "structural-inequality" | "numeric-inequality" | "assigned-inequality" => {
+            check_eq(expr, &rule, subs, ops, assigned, path)
+        }
+        // Type-system witnesses
+        "type-universe" | "prop" | "pi-formation" | "lambda-formation" | "type-query"
+        | "type-check" => check_typesys(expr, &rule, subs, path),
+        "beta-reduction" => arity(&rule, subs, 2, path).and_then(|_| match expr {
+            Node::List(c) if c.len() == 3 => match &c[0] {
+                Node::Leaf(h) if h == "apply" => {
+                    check_node(&c[1], &subs[0], ops, assigned, &next_path)?;
+                    check_node(&c[2], &subs[1], ops, assigned, &next_path)?;
+                    Ok(rule.clone())
+                }
+                _ => Err(err(path, format!("`beta-reduction` ≠ `{}`", key_of(expr)))),
+            },
+            _ => Err(err(path, format!("`beta-reduction` ≠ `{}`", key_of(expr)))),
+        }),
+        // Prefix operator named after the rule.
+        _ => check_prefix(expr, &rule, subs, ops, assigned, &next_path, path),
+    }
+}
+
+fn err(path: &[String], message: String) -> CheckError {
+    CheckError { path: path.to_vec(), message }
+}
+
+fn arity(rule: &str, subs: &[Node], n: usize, path: &[String]) -> Result<(), CheckError> {
+    if subs.len() == n {
+        Ok(())
+    } else {
+        Err(err(
+            path,
+            format!("rule `{}` expects {} sub(s), got {}", rule, n, subs.len()),
+        ))
+    }
+}
+
+// True when `rule` is the bare name of a prefix operator applied at expr.
+fn prefix_match(rule: &str, expr: &Node, ops: &HashSet<String>) -> bool {
+    if !ops.contains(rule) {
+        return false;
+    }
+    if let Node::List(c) = expr {
+        if let Some(Node::Leaf(h)) = c.first() {
+            return h == rule;
+        }
+    }
+    false
+}
+
+fn check_infix(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    op: &str,
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+    next_path: &[String],
+    path: &[String],
+) -> Result<String, CheckError> {
+    arity(rule, subs, 2, path)?;
+    if let Node::List(c) = expr {
+        if c.len() == 3 {
+            if let Node::Leaf(o) = &c[1] {
+                if o == op {
+                    check_node(&c[0], &subs[0], ops, assigned, next_path)?;
+                    check_node(&c[2], &subs[1], ops, assigned, next_path)?;
+                    return Ok(rule.into());
+                }
+            }
+        }
+    }
+    Err(err(path, format!("rule `{}` ≠ `{}`", rule, key_of(expr))))
+}
+
+fn check_logic(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+    next_path: &[String],
+    path: &[String],
+) -> Result<String, CheckError> {
+    if let Node::List(c) = expr {
+        // Binary infix.
+        if c.len() == 3 {
+            if let Node::Leaf(o) = &c[1] {
+                if o == rule {
+                    arity(rule, subs, 2, path)?;
+                    check_node(&c[0], &subs[0], ops, assigned, next_path)?;
+                    check_node(&c[2], &subs[1], ops, assigned, next_path)?;
+                    return Ok(rule.into());
+                }
+            }
+        }
+        // Composite chain.
+        if (rule == "both" || rule == "neither") && c.len() >= 4 && c.len() % 2 == 0 {
+            if let Node::Leaf(h) = &c[0] {
+                if h == rule {
+                    let sep = if rule == "both" { "and" } else { "nor" };
+                    for i in (2..c.len()).step_by(2) {
+                        if let Node::Leaf(s) = &c[i] {
+                            if s != sep {
+                                return Err(err(
+                                    path,
+                                    format!("composite `{}` separator must be `{}`", rule, sep),
+                                ));
+                            }
+                        } else {
+                            return Err(err(
+                                path,
+                                format!("composite `{}` separator must be `{}`", rule, sep),
+                            ));
+                        }
+                    }
+                    let n = c.len() / 2;
+                    arity(rule, subs, n, path)?;
+                    for (j, sub) in subs.iter().enumerate() {
+                        check_node(&c[1 + j * 2], sub, ops, assigned, next_path)?;
+                    }
+                    return Ok(rule.into());
+                }
+            }
+        }
+    }
+    Err(err(path, format!("rule `{}` ≠ `{}`", rule, key_of(expr))))
+}
+
+fn check_eq(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+    path: &[String],
+) -> Result<String, CheckError> {
+    arity(rule, subs, 1, path)?;
+    let pair = match &subs[0] {
+        Node::List(p) if p.len() == 2 => p,
+        _ => return Err(err(path, format!("`{}` expects `(L R)` sub", rule))),
+    };
+    if let Node::List(c) = expr {
+        if c.len() == 3 {
+            if let Node::Leaf(op) = &c[1] {
+                if op == "=" || op == "!=" {
+                    if !is_structurally_same(&c[0], &pair[0])
+                        || !is_structurally_same(&c[2], &pair[1])
+                    {
+                        return Err(err(
+                            path,
+                            format!(
+                                "operands `{} {}` ≠ `{} {}`",
+                                key_of(&pair[0]),
+                                key_of(&pair[1]),
+                                key_of(&c[0]),
+                                key_of(&c[2])
+                            ),
+                        ));
+                    }
+                    let exp = expected_rule(expr, ops, assigned);
+                    if exp == rule {
+                        return Ok(rule.into());
+                    }
+                    return Err(err(
+                        path,
+                        format!("rule `{}` ≠ expected `{}`", rule, exp),
+                    ));
+                }
+            }
+        }
+    }
+    Err(err(path, format!("rule `{}` ≠ `{}`", rule, key_of(expr))))
+}
+
+fn check_typesys(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    path: &[String],
+) -> Result<String, CheckError> {
+    let bad = |reason: &str| Err(err(path, format!("`{}` ≠ `{}` ({})", rule, key_of(expr), reason)));
+    if let Node::List(c) = expr {
+        match (rule, c.len()) {
+            ("type-universe", 2) => {
+                arity(rule, subs, 1, path)?;
+                if let Node::Leaf(h) = &c[0] {
+                    if h == "Type" && is_structurally_same(&c[1], &subs[0]) {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("Type level mismatch");
+            }
+            ("prop", 1) => {
+                arity(rule, subs, 0, path)?;
+                if let Node::Leaf(h) = &c[0] {
+                    if h == "Prop" {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("Prop head mismatch");
+            }
+            ("pi-formation", 3) | ("lambda-formation", 3) => {
+                arity(rule, subs, 2, path)?;
+                let head = if rule == "pi-formation" { "Pi" } else { "lambda" };
+                if let Node::Leaf(h) = &c[0] {
+                    if h == head
+                        && is_structurally_same(&c[1], &subs[0])
+                        && is_structurally_same(&c[2], &subs[1])
+                    {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("binder mismatch");
+            }
+            ("type-query", 3) => {
+                arity(rule, subs, 1, path)?;
+                if let (Node::Leaf(h), Node::Leaf(of)) = (&c[0], &c[1]) {
+                    if h == "type" && of == "of" && is_structurally_same(&c[2], &subs[0]) {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("type-query mismatch");
+            }
+            ("type-check", 3) => {
+                arity(rule, subs, 2, path)?;
+                if let Node::Leaf(of) = &c[1] {
+                    if of == "of"
+                        && is_structurally_same(&c[0], &subs[0])
+                        && is_structurally_same(&c[2], &subs[1])
+                    {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("type-check mismatch");
+            }
+            _ => {}
+        }
+    }
+    bad("shape mismatch")
+}
+
+fn check_prefix(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    ops: &HashSet<String>,
+    assigned: &HashSet<String>,
+    next_path: &[String],
+    path: &[String],
+) -> Result<String, CheckError> {
+    if let Node::List(c) = expr {
+        if let Some(Node::Leaf(h)) = c.first() {
+            if h == rule && ops.contains(rule) {
+                arity(rule, subs, c.len() - 1, path)?;
+                for (i, sub) in subs.iter().enumerate() {
+                    check_node(&c[1 + i], sub, ops, assigned, next_path)?;
+                }
+                return Ok(rule.into());
+            }
+        }
+    }
+    Err(err(
+        path,
+        format!("unknown rule `{}` for `{}`", rule, key_of(expr)),
+    ))
+}
+
+/// Public entry point: parse both `.lino` sources, pair queries with
+/// derivations 1:1, and verify each pair structurally. Returns a
+/// `CheckResult` with one `CheckOk` per replayed derivation or a list of
+/// `CheckError`s describing the first divergence per query.
+pub fn check_program(program_src: &str, proofs_src: &str) -> CheckResult {
+    let program_forms = parse_forms(program_src);
+    let proof_forms = parse_forms(proofs_src);
+    let queries: Vec<Node> = program_forms.iter().filter_map(query_target).collect();
+    let ops = collect_operators(&program_forms);
+    let assigned = collect_assignments(&program_forms);
+    let mut result = CheckResult::default();
+    if queries.len() != proof_forms.len() {
+        result.errors.push(CheckError {
+            path: vec![],
+            message: format!(
+                "expected {} derivation(s), got {}",
+                queries.len(),
+                proof_forms.len()
+            ),
+        });
+        return result;
+    }
+    for (i, (q, p)) in queries.iter().zip(proof_forms.iter()).enumerate() {
+        let path = vec![format!("query[{}]", i)];
+        match check_node(q, p, &ops, &assigned, &path) {
+            Ok(rule) => result.ok.push(CheckOk { rule, expr: key_of(q) }),
+            Err(e) => result.errors.push(e),
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod sanity {
+    // Real coverage in `rust/tests/check_tests.rs`. These confirm the
+    // checker compiles against the kernel without pulling the evaluator.
+    use super::*;
+
+    #[test]
+    fn smoke_structural_equality() {
+        assert!(check_program(
+            "(a: a is a)\n(? (a = a))",
+            "(by structural-equality (a a))"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn smoke_mutated_rule_fails() {
+        assert!(!check_program(
+            "(a: a is a)\n(? (a = a))",
+            "(by numeric-equality (a a))"
+        )
+        .is_ok());
+    }
+}

--- a/rust/src/check.rs
+++ b/rust/src/check.rs
@@ -63,9 +63,7 @@ fn collect_assignments(forms: &[Node]) -> HashSet<String> {
     for f in forms {
         if let Node::List(c) = f {
             if c.len() == 4 {
-                if let (Node::Leaf(w1), Node::Leaf(w2), Node::Leaf(w3)) =
-                    (&c[1], &c[2], &c[3])
-                {
+                if let (Node::Leaf(w1), Node::Leaf(w2), Node::Leaf(w3)) = (&c[1], &c[2], &c[3]) {
                     if w1 == "has" && w2 == "probability" && is_num(w3) {
                         if let Node::List(inner) = &c[0] {
                             out.insert(key_of(&c[0]));
@@ -150,11 +148,7 @@ fn decode<'a>(p: &'a Node, path: &[String]) -> Result<(String, &'a [Node]), Chec
 // The single rule the kernel would emit for `expr`. Equality is the only
 // shape with multiple admissible rules (assigned/structural/numeric); we
 // pick the unique one matching the program facts.
-fn expected_rule(
-    expr: &Node,
-    ops: &HashSet<String>,
-    assigned: &HashSet<String>,
-) -> &'static str {
+fn expected_rule(expr: &Node, ops: &HashSet<String>, assigned: &HashSet<String>) -> &'static str {
     match expr {
         Node::Leaf(s) => {
             if is_num(s) {
@@ -328,18 +322,25 @@ fn check_node(
         // Leaves
         "literal" => arity(&rule, subs, 1, path).and_then(|_| match (&subs[0], expr) {
             (Node::Leaf(n), Node::Leaf(en)) if is_num(n) && n == en => Ok(rule),
-            _ => Err(err(path, format!("literal `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)))),
+            _ => Err(err(
+                path,
+                format!("literal `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)),
+            )),
         }),
         "symbol" => arity(&rule, subs, 1, path).and_then(|_| match (&subs[0], expr) {
             (Node::Leaf(s), Node::Leaf(es)) if s == es => Ok(rule),
-            _ => Err(err(path, format!("symbol `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)))),
+            _ => Err(err(
+                path,
+                format!("symbol `{}` ≠ `{}`", key_of(&subs[0]), key_of(expr)),
+            )),
         }),
-        // Top-level forms: definitions, configuration, assignment — the
-        // kernel produces these without sub-derivations to recurse into,
-        // so structural equality of the witness payload is enough.
-        "definition" | "configuration" | "assigned-probability" => Ok(rule),
+        // Top-level leaf-like forms carry payloads that must match the
+        // expression exactly, even though there are no sub-derivations.
+        "definition" => check_payload(&rule, subs, &[expr.clone()], path),
+        "configuration" => check_configuration(expr, &rule, subs, path),
+        "assigned-probability" => check_assigned_probability(expr, &rule, subs, path),
         "query" => Err(err(path, "stray `query` rule (stripped by checker)".into())),
-        "reduce" => Ok(rule),
+        "reduce" => check_payload(&rule, subs, &[expr.clone()], path),
         // Infix arithmetic
         "sum" | "difference" | "product" | "quotient" => {
             let op = match rule.as_str() {
@@ -366,10 +367,12 @@ fn check_node(
             _ => Err(err(path, format!("`not` ≠ `{}`", key_of(expr)))),
         }),
         // Equality / inequality
-        "structural-equality" | "numeric-equality" | "assigned-equality"
-        | "structural-inequality" | "numeric-inequality" | "assigned-inequality" => {
-            check_eq(expr, &rule, subs, ops, assigned, path)
-        }
+        "structural-equality"
+        | "numeric-equality"
+        | "assigned-equality"
+        | "structural-inequality"
+        | "numeric-inequality"
+        | "assigned-inequality" => check_eq(expr, &rule, subs, ops, assigned, path),
         // Type-system witnesses
         "type-universe" | "prop" | "pi-formation" | "lambda-formation" | "type-query"
         | "type-check" => check_typesys(expr, &rule, subs, path),
@@ -390,7 +393,10 @@ fn check_node(
 }
 
 fn err(path: &[String], message: String) -> CheckError {
-    CheckError { path: path.to_vec(), message }
+    CheckError {
+        path: path.to_vec(),
+        message,
+    }
 }
 
 fn arity(rule: &str, subs: &[Node], n: usize, path: &[String]) -> Result<(), CheckError> {
@@ -402,6 +408,68 @@ fn arity(rule: &str, subs: &[Node], n: usize, path: &[String]) -> Result<(), Che
             format!("rule `{}` expects {} sub(s), got {}", rule, n, subs.len()),
         ))
     }
+}
+
+fn check_payload(
+    rule: &str,
+    subs: &[Node],
+    expected: &[Node],
+    path: &[String],
+) -> Result<String, CheckError> {
+    arity(rule, subs, expected.len(), path)?;
+    for (i, want) in expected.iter().enumerate() {
+        if !is_structurally_same(&subs[i], want) {
+            return Err(err(
+                path,
+                format!("payload {} `{}` ≠ `{}`", i, key_of(&subs[i]), key_of(want)),
+            ));
+        }
+    }
+    Ok(rule.into())
+}
+
+fn check_configuration(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    path: &[String],
+) -> Result<String, CheckError> {
+    match expr {
+        Node::List(c) if c.len() == 3 => match (&c[0], &c[1], &c[2]) {
+            (Node::Leaf(h), lo, hi) if h == "range" => check_payload(
+                rule,
+                subs,
+                &[Node::Leaf("range".into()), lo.clone(), hi.clone()],
+                path,
+            ),
+            _ => Err(err(path, format!("`{}` ≠ `{}`", rule, key_of(expr)))),
+        },
+        Node::List(c) if c.len() == 2 => match (&c[0], &c[1]) {
+            (Node::Leaf(h), v) if h == "valence" => {
+                check_payload(rule, subs, &[Node::Leaf("valence".into()), v.clone()], path)
+            }
+            _ => Err(err(path, format!("`{}` ≠ `{}`", rule, key_of(expr)))),
+        },
+        _ => Err(err(path, format!("`{}` ≠ `{}`", rule, key_of(expr)))),
+    }
+}
+
+fn check_assigned_probability(
+    expr: &Node,
+    rule: &str,
+    subs: &[Node],
+    path: &[String],
+) -> Result<String, CheckError> {
+    if let Node::List(c) = expr {
+        if c.len() == 4 {
+            if let (Node::Leaf(w1), Node::Leaf(w2)) = (&c[1], &c[2]) {
+                if w1 == "has" && w2 == "probability" {
+                    return check_payload(rule, subs, &[c[0].clone(), c[3].clone()], path);
+                }
+            }
+        }
+    }
+    Err(err(path, format!("`{}` ≠ `{}`", rule, key_of(expr))))
 }
 
 // True when `rule` is the bare name of a prefix operator applied at expr.
@@ -531,10 +599,7 @@ fn check_eq(
                     if exp == rule {
                         return Ok(rule.into());
                     }
-                    return Err(err(
-                        path,
-                        format!("rule `{}` ≠ expected `{}`", rule, exp),
-                    ));
+                    return Err(err(path, format!("rule `{}` ≠ expected `{}`", rule, exp)));
                 }
             }
         }
@@ -548,7 +613,12 @@ fn check_typesys(
     subs: &[Node],
     path: &[String],
 ) -> Result<String, CheckError> {
-    let bad = |reason: &str| Err(err(path, format!("`{}` ≠ `{}` ({})", rule, key_of(expr), reason)));
+    let bad = |reason: &str| {
+        Err(err(
+            path,
+            format!("`{}` ≠ `{}` ({})", rule, key_of(expr), reason),
+        ))
+    };
     if let Node::List(c) = expr {
         match (rule, c.len()) {
             ("type-universe", 2) => {
@@ -571,7 +641,11 @@ fn check_typesys(
             }
             ("pi-formation", 3) | ("lambda-formation", 3) => {
                 arity(rule, subs, 2, path)?;
-                let head = if rule == "pi-formation" { "Pi" } else { "lambda" };
+                let head = if rule == "pi-formation" {
+                    "Pi"
+                } else {
+                    "lambda"
+                };
                 if let Node::Leaf(h) = &c[0] {
                     if h == head
                         && is_structurally_same(&c[1], &subs[0])
@@ -660,7 +734,10 @@ pub fn check_program(program_src: &str, proofs_src: &str) -> CheckResult {
     for (i, (q, p)) in queries.iter().zip(proof_forms.iter()).enumerate() {
         let path = vec![format!("query[{}]", i)];
         match check_node(q, p, &ops, &assigned, &path) {
-            Ok(rule) => result.ok.push(CheckOk { rule, expr: key_of(q) }),
+            Ok(rule) => result.ok.push(CheckOk {
+                rule,
+                expr: key_of(q),
+            }),
             Err(e) => result.errors.push(e),
         }
     }
@@ -675,19 +752,13 @@ mod sanity {
 
     #[test]
     fn smoke_structural_equality() {
-        assert!(check_program(
-            "(a: a is a)\n(? (a = a))",
-            "(by structural-equality (a a))"
-        )
-        .is_ok());
+        assert!(
+            check_program("(a: a is a)\n(? (a = a))", "(by structural-equality (a a))").is_ok()
+        );
     }
 
     #[test]
     fn smoke_mutated_rule_fails() {
-        assert!(!check_program(
-            "(a: a is a)\n(? (a = a))",
-            "(by numeric-equality (a a))"
-        )
-        .is_ok());
+        assert!(!check_program("(a: a is a)\n(? (a = a))", "(by numeric-equality (a a))").is_ok());
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3162,3 +3162,4 @@ pub fn run(text: &str, options: Option<EnvOptions>) -> Vec<f64> {
 // To run: cargo test
 
 pub mod repl;
+pub mod check;

--- a/rust/tests/check_tests.rs
+++ b/rust/tests/check_tests.rs
@@ -1,0 +1,239 @@
+// Integration tests for the independent proof-replay checker (issue #36).
+// Mirrors `js/tests/check.test.mjs` so any drift between the two
+// implementations fails both test suites. The checker is deliberately
+// kernel-only — it never calls `evaluate()` — and the tests below verify
+// that valid proofs replay successfully while every mutation we can come
+// up with (wrong rule, wrong operand, wrong arity, missing or extra
+// derivation, swapped sub-tree) is rejected.
+
+use rml::check::check_program;
+use rml::{evaluate_with_options, key_of, EvaluateOptions, RunResult};
+
+fn opts_with_proofs() -> EvaluateOptions {
+    EvaluateOptions {
+        with_proofs: true,
+        ..EvaluateOptions::default()
+    }
+}
+
+// Helper: drive the proof-producing evaluator and return the printed proof
+// stream that the kernel-only checker should accept verbatim.
+fn proofs_from(src: &str) -> String {
+    let out = evaluate_with_options(src, None, opts_with_proofs());
+    out.proofs
+        .iter()
+        .filter_map(|p| p.as_ref().map(key_of))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// ===== Acceptance: structural-equality replay (issue example) =====
+
+#[test]
+fn replays_structural_equality_witness() {
+    let program = "(a: a is a)\n(? (a = a))";
+    let proofs = "(by structural-equality (a a))";
+    let r = check_program(program, proofs);
+    assert!(r.is_ok(), "{:?}", r);
+    assert_eq!(r.ok.len(), 1);
+    assert_eq!(r.ok[0].rule, "structural-equality");
+}
+
+#[test]
+fn matches_proofs_emitted_by_evaluator() {
+    let program = [
+        "(a: a is a)",
+        "((b = b) has probability 0.7)",
+        "(? (a = a))",
+        "(? (b = b))",
+        "(? (1 + 2))",
+        "(? (5 - 2))",
+        "(? (3 * 4))",
+        "(? (8 / 2))",
+        "(? (not 0))",
+        "(? (1 and 0))",
+        "(? (0 or 1))",
+        "(? (both 1 and 1 and 0))",
+        "(? (neither 0 nor 0))",
+        "(? (1 = 2))",
+        "(? (1 != 2))",
+    ]
+    .join("\n");
+    let proofs = proofs_from(&program);
+    let r = check_program(&program, &proofs);
+    assert!(r.is_ok(), "{:?}", r);
+    assert_eq!(r.ok.len(), 13);
+}
+
+// ===== Mutation: rule names =====
+
+#[test]
+fn rejects_wrong_rule_for_structural_equality() {
+    let r = check_program(
+        "(a: a is a)\n(? (a = a))",
+        "(by numeric-equality (a a))",
+    );
+    assert!(!r.is_ok());
+    assert!(r.errors[0].message.contains("numeric-equality"));
+}
+
+#[test]
+fn rejects_assigned_rule_when_no_assignment_exists() {
+    // No `((a = a) has probability ...)` declared — the kernel would
+    // pick `structural-equality`. Claiming `assigned-equality` must fail.
+    let r = check_program(
+        "(a: a is a)\n(? (a = a))",
+        "(by assigned-equality (a a))",
+    );
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_swapped_arithmetic_rule() {
+    // `(by sum ...)` for `(1 - 2)` is wrong; the kernel would pick `difference`.
+    let r = check_program(
+        "(? (1 - 2))",
+        "(by sum (by literal 1) (by literal 2))",
+    );
+    assert!(!r.is_ok());
+}
+
+// ===== Mutation: operands =====
+
+#[test]
+fn rejects_wrong_operands_in_equality_pair() {
+    let r = check_program(
+        "(a: a is a)\n(b: b is b)\n(? (a = a))",
+        "(by structural-equality (a b))",
+    );
+    assert!(!r.is_ok());
+    assert!(
+        r.errors[0].message.to_lowercase().contains("operand")
+            || r.errors[0].message.contains("does not match")
+    );
+}
+
+#[test]
+fn rejects_wrong_literal_inside_arithmetic_subtree() {
+    let r = check_program(
+        "(? (1 + 2))",
+        "(by sum (by literal 1) (by literal 5))",
+    );
+    assert!(!r.is_ok());
+    assert!(r.errors[0].message.contains("5"));
+}
+
+// ===== Mutation: arity / shape =====
+
+#[test]
+fn rejects_missing_subtree() {
+    let r = check_program(
+        "(? (1 + 2))",
+        "(by sum (by literal 1))",
+    );
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_extra_subtree() {
+    let r = check_program(
+        "(? (not 0))",
+        "(by not (by literal 0) (by literal 0))",
+    );
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_non_by_node_at_top_level() {
+    let r = check_program(
+        "(? (a = a))",
+        "(structural-equality (a a))",
+    );
+    assert!(!r.is_ok());
+}
+
+// ===== Mutation: pairing =====
+
+#[test]
+fn rejects_too_few_proofs_for_program() {
+    let r = check_program(
+        "(? (1 + 2))\n(? (1 - 2))",
+        "(by sum (by literal 1) (by literal 2))",
+    );
+    assert!(!r.is_ok());
+    assert!(r.errors[0].message.contains("expected 2"));
+}
+
+#[test]
+fn rejects_too_many_proofs_for_program() {
+    let r = check_program(
+        "(? (1 + 2))",
+        "(by sum (by literal 1) (by literal 2))\n(by sum (by literal 3) (by literal 4))",
+    );
+    assert!(!r.is_ok());
+}
+
+// ===== Composite chains =====
+
+#[test]
+fn replays_composite_both_chain() {
+    let program = "(? (both 1 and 0 and 1))";
+    let proofs = proofs_from(program);
+    let r = check_program(program, &proofs);
+    assert!(r.is_ok(), "{:?}", r);
+}
+
+#[test]
+fn rejects_mutated_composite_chain() {
+    let r = check_program(
+        "(? (both 1 and 0 and 1))",
+        "(by both (by literal 1) (by literal 0))",
+    );
+    assert!(!r.is_ok());
+}
+
+// ===== Result agreement: replaying does not depend on truth values =====
+
+#[test]
+fn checker_does_not_re_evaluate_the_program() {
+    // A non-trivial program with multiple operators. We confirm the
+    // proof-producing evaluator's output replays through the checker, and
+    // that mutating ANY single character in the printed proof stream
+    // breaks the check. The key invariant: the checker accepts/rejects on
+    // shape, not on truth value, so it never needs the evaluator.
+    let program = [
+        "(a: a is a)",
+        "((a = a) has probability 1)",
+        "(? ((a = a) and (a = a)))",
+    ]
+    .join("\n");
+    let proofs = proofs_from(&program);
+    assert!(check_program(&program, &proofs).is_ok());
+    let mutated = proofs.replace("assigned-equality", "structural-equality");
+    assert_ne!(mutated, proofs);
+    assert!(!check_program(&program, &mutated).is_ok());
+}
+
+// ===== Result aggregation =====
+
+#[test]
+fn reports_count_of_replayed_derivations() {
+    let program = "(? 1)\n(? 0)\n(? (1 + 1))";
+    let proofs = "(by literal 1)\n(by literal 0)\n(by sum (by literal 1) (by literal 1))";
+    let r = check_program(program, &proofs);
+    assert!(r.is_ok());
+    assert_eq!(r.ok.len(), 3);
+}
+
+#[test]
+fn evaluator_results_match_when_proof_replay_succeeds() {
+    // Sanity check: when the checker accepts, the evaluator's results are
+    // still computable independently. This mirrors the "trusted-kernel
+    // cornerstone" property — the checker corroborates derivations the
+    // evaluator produced without relying on the evaluator at check time.
+    let program = "(? (0 + 1))";
+    let out = evaluate_with_options(program, None, opts_with_proofs());
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+    let proof = key_of(out.proofs[0].as_ref().unwrap());
+    assert!(check_program(program, &proof).is_ok());
+}

--- a/rust/tests/check_tests.rs
+++ b/rust/tests/check_tests.rs
@@ -69,10 +69,7 @@ fn matches_proofs_emitted_by_evaluator() {
 
 #[test]
 fn rejects_wrong_rule_for_structural_equality() {
-    let r = check_program(
-        "(a: a is a)\n(? (a = a))",
-        "(by numeric-equality (a a))",
-    );
+    let r = check_program("(a: a is a)\n(? (a = a))", "(by numeric-equality (a a))");
     assert!(!r.is_ok());
     assert!(r.errors[0].message.contains("numeric-equality"));
 }
@@ -81,20 +78,14 @@ fn rejects_wrong_rule_for_structural_equality() {
 fn rejects_assigned_rule_when_no_assignment_exists() {
     // No `((a = a) has probability ...)` declared — the kernel would
     // pick `structural-equality`. Claiming `assigned-equality` must fail.
-    let r = check_program(
-        "(a: a is a)\n(? (a = a))",
-        "(by assigned-equality (a a))",
-    );
+    let r = check_program("(a: a is a)\n(? (a = a))", "(by assigned-equality (a a))");
     assert!(!r.is_ok());
 }
 
 #[test]
 fn rejects_swapped_arithmetic_rule() {
     // `(by sum ...)` for `(1 - 2)` is wrong; the kernel would pick `difference`.
-    let r = check_program(
-        "(? (1 - 2))",
-        "(by sum (by literal 1) (by literal 2))",
-    );
+    let r = check_program("(? (1 - 2))", "(by sum (by literal 1) (by literal 2))");
     assert!(!r.is_ok());
 }
 
@@ -115,40 +106,57 @@ fn rejects_wrong_operands_in_equality_pair() {
 
 #[test]
 fn rejects_wrong_literal_inside_arithmetic_subtree() {
-    let r = check_program(
-        "(? (1 + 2))",
-        "(by sum (by literal 1) (by literal 5))",
-    );
+    let r = check_program("(? (1 + 2))", "(by sum (by literal 1) (by literal 5))");
     assert!(!r.is_ok());
     assert!(r.errors[0].message.contains("5"));
+}
+
+// ===== Mutation: leaf payloads =====
+
+#[test]
+fn rejects_wrong_reduce_payload() {
+    let r = check_program("(? (mystery 1))", "(by reduce (different 2))");
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_wrong_definition_payload() {
+    let r = check_program("(? (foo: bar))", "(by definition (bar: foo))");
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_wrong_configuration_payload() {
+    let r = check_program("(? (range 0 1))", "(by configuration valence 9)");
+    assert!(!r.is_ok());
+}
+
+#[test]
+fn rejects_wrong_assigned_probability_payload() {
+    let r = check_program(
+        "(? ((a = a) has probability 0.7))",
+        "(by assigned-probability (b = b) 0.2)",
+    );
+    assert!(!r.is_ok());
 }
 
 // ===== Mutation: arity / shape =====
 
 #[test]
 fn rejects_missing_subtree() {
-    let r = check_program(
-        "(? (1 + 2))",
-        "(by sum (by literal 1))",
-    );
+    let r = check_program("(? (1 + 2))", "(by sum (by literal 1))");
     assert!(!r.is_ok());
 }
 
 #[test]
 fn rejects_extra_subtree() {
-    let r = check_program(
-        "(? (not 0))",
-        "(by not (by literal 0) (by literal 0))",
-    );
+    let r = check_program("(? (not 0))", "(by not (by literal 0) (by literal 0))");
     assert!(!r.is_ok());
 }
 
 #[test]
 fn rejects_non_by_node_at_top_level() {
-    let r = check_program(
-        "(? (a = a))",
-        "(structural-equality (a a))",
-    );
+    let r = check_program("(? (a = a))", "(structural-equality (a a))");
     assert!(!r.is_ok());
 }
 


### PR DESCRIPTION
## Summary
Implements C2 from issue #36: a separate `rml-check` executable in both JavaScript and Rust that replays derivations produced by the proof-producing evaluator using only the kernel-facing AST/parser helpers. The checker does not call `evaluate()`; it walks the `(by <rule> <sub>...)` derivation tree beside each query AST and validates rule name, arity, sub-expression alignment, and leaf payloads.

- **Rust**: `rust/src/check.rs` plus `rust/src/bin/rml-check.rs`, registered as a second `[[bin]]` in `rust/Cargo.toml`.
- **JavaScript**: `js/src/check.mjs` plus `js/src/rml-check.mjs`, registered in `js/package.json` so npm installs expose both `rml` and `rml-check`.
- Both CLIs print `OK: N derivations replayed.` on success and `FAIL [path]: <message>` on failure.
- Version metadata is aligned at **0.13.0** in Rust and JavaScript manifests/locks.

## How to reproduce / try it
```sh
# JavaScript
cd js && npm install
node src/rml-check.mjs ../experiments/program.lino ../experiments/proofs.lino
# OK: 5 derivations replayed.

node src/rml-check.mjs ../experiments/program.lino ../experiments/proofs-mutated.lino
# FAIL [query[0]]: rule `numeric-equality` does not justify `(a = a)` (expected `structural-equality`)

# Rust
cd rust && cargo run --bin rml-check -- ../experiments/program.lino ../experiments/proofs.lino
# OK: 5 derivations replayed.
```

## Tests
21 mirrored integration tests in each language cover:
- Replays of structural-equality and evaluator-emitted proof streams.
- Rule mutations, assigned/structural disambiguation, and swapped arithmetic rules.
- Operand, literal, arity, top-level shape, proof-count, and composite-chain mutations.
- Leaf payload mutations for `reduce`, `definition`, `configuration`, and `assigned-probability`.
- Result aggregation and the invariant that replay validates proof shape without evaluating truth values.

| Suite | Result |
|---|---|
| `cd rust && cargo test --test check_tests` | 21 passed |
| `cd rust && cargo test` | 355 passed |
| `cd js && node --test tests/check.test.mjs` | 21 passed |
| `cd js && npm test` | 548 passed |

## Files changed
- `rust/src/check.rs` — kernel-only proof-replay checker.
- `rust/src/bin/rml-check.rs` — Rust CLI front-end.
- `rust/src/lib.rs` — exports the checker module.
- `rust/Cargo.toml`, `rust/Cargo.lock` — adds `rml-check`, bumps version.
- `rust/tests/check_tests.rs` — mirrored checker regression tests.
- `js/src/check.mjs` — JavaScript proof-replay checker.
- `js/src/rml-check.mjs` — Node CLI front-end.
- `js/package.json`, `js/package-lock.json` — adds CLI bins/scripts, bumps version.
- `js/tests/check.test.mjs` — mirrored checker regression tests.
- `experiments/program.lino`, `experiments/proofs*.lino` — manual smoke fixtures.

## Test plan
- [x] `cargo test --test check_tests`
- [x] `cargo test`
- [x] `node --test tests/check.test.mjs`
- [x] `npm test`
- [x] JS and Rust `rml-check` accept valid smoke proofs and reject mutated smoke proofs with matching failure text

Fixes #36
