### PR TITLE
[D1] Document typed kernel rules

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-02T07:34:17.491Z for PR creation at branch issue-37-892be8398f3d for issue https://github.com/link-foundation/relative-meta-logic/issues/37

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-02T07:34:17.491Z for PR creation at branch issue-37-892be8398f3d for issue https://github.com/link-foundation/relative-meta-logic/issues/37

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,10 +96,19 @@ Each AST node is evaluated recursively by `eval_node` / `evalNode`. The evaluati
 | `(A = B)`, `(A != B)` | Equality/inequality | `(a = b)` |
 | `(not X)` | Prefix negation | `(not 0.5)` |
 | `(op X Y ...)` | Prefix operator application | `(and X Y Z)` |
+| `(Pi (A x) B)` | Dependent product formation | `(Pi (Natural n) Natural)` |
+| `(lambda (A x) body)` | Lambda formation | `(lambda (Natural x) x)` |
+| `(apply f x)` | Lambda application by beta-reduction | `(apply identity zero)` |
+| `(expr of Type)` | Type membership check | `(zero of Natural)` |
+| `(type of expr)` | Type query | `(type of zero)` |
+
+The typed-kernel rules are specified in [docs/KERNEL.md](./docs/KERNEL.md).
 
 ### Stage 4: Output
 
-Only query expressions `(? ...)` produce output. Their evaluated truth values are collected and returned as an array of numbers.
+Only query expressions `(? ...)` produce output. Their evaluated truth
+values are collected and returned as an array of numbers; `(type of ...)`
+queries return type strings in the typed runner APIs.
 
 ## Public Library API
 
@@ -150,6 +159,8 @@ The environment holds all mutable state during evaluation:
 - **`lo`, `hi`**: Truth value range bounds. Default: `[0, 1]`.
 - **`valence`**: Number of discrete truth levels. Default: `0` (continuous).
 - **`ops`**: Map from operator names to operator implementations.
+- **`types`**: Map from expression keys to type-expression keys.
+- **`lambdas`**: Map from lambda names to their parameter, parameter type, and body.
 
 ### Truth Constants
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 - [Core concept comparison](./docs/CONCEPTS-COMPARISION.md) - RML vs Twelf, LF, HELF, Isabelle, Coq/Rocq, Lean, Foundation, AFP, Abella, lambda Prolog, and Pecan by logical/metatheoretic concepts.
 - [Product feature comparison](./docs/FEATURE-COMPARISION.md) - RML vs the same systems by authoring workflow, automation, libraries, tooling, and distribution.
 - [Configurability and operator redefinition](./docs/CONFIGURABILITY.md) - Why every operator, truth constant, range, and valence is redefinable at runtime, with the precedence rules and a comparison to Lean/Rocq fixed semantics.
+- [Typed kernel rules](./docs/KERNEL.md) - The implemented D1 rules for `Pi`, `lambda`, `apply`, `(expr of Type)`, and `(type of expr)`.
 
 ## Overview
 

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,0 +1,223 @@
+# Typed Kernel
+
+This document specifies the typed-kernel surface implemented by the
+JavaScript and Rust evaluators. It is the D1 contract from issue #37:
+the rules for `Pi`, `lambda`, `apply`, type membership with `of`, and
+type queries with `(type of ...)`.
+
+RML remains a dynamic axiomatic system. These rules install and query type
+facts in the evaluator environment; they are not yet a full bidirectional
+checker with rejection diagnostics. That stricter layer is planned in the
+later typed-kernel issues.
+
+## Judgements
+
+The rules below use standard notation, mapped to LiNo:
+
+| Judgement | Meaning in RML |
+|-----------|----------------|
+| `Gamma |- e : A` | Environment `Gamma` records expression `e` as having type `A`. |
+| `Gamma, x : A` | The environment extended with variable `x` of type `A`. |
+| `Gamma |- e => v` | Evaluating `e` produces value `v`. |
+| `hi` / `lo` | The current truth range maximum/minimum. Defaults are `1` and `0`. |
+
+In the implementation, type facts are stored by canonical LiNo keys. For
+example, `(Pi (Natural n) Natural)` is stored under that exact printed link.
+
+## Type Declarations
+
+Types and typed terms use the same prefix declaration pattern:
+
+```lino
+(Type: Type Type)
+(Natural: Type Natural)
+(zero: Natural zero)
+```
+
+Rule:
+
+```text
+Gamma |- A is a type-like link
+------------------------------
+Gamma |- (x: A x) installs x : A
+```
+
+The declaration is intentionally syntactic. `(Type: Type Type)` is allowed
+because RML tolerates circular axioms and resolves paradoxical truth values
+through the configured many-valued logic.
+
+The stratified universe form is also supported:
+
+```lino
+(Type 0)
+(Type 1)
+(? ((Type 0) of (Type 1)))  # -> hi
+```
+
+Universe rule:
+
+```text
+-------------------------------
+Gamma |- (Type N) : (Type N+1)
+```
+
+## Pi Formation
+
+`Pi` forms a dependent product. The binder is written in prefix type notation:
+
+```lino
+(Pi (Natural n) Natural)
+```
+
+Rule:
+
+```text
+Gamma, n : Natural |- B is a type-like link
+-------------------------------------------
+Gamma |- (Pi (Natural n) B) : (Type 0)
+```
+
+The current implementation records the bound parameter in the type
+environment and records the `Pi` expression as a member of `(Type 0)`.
+Full validation of the codomain is deferred to the bidirectional checker.
+
+Non-dependent function types use `_` when the result does not mention the
+argument:
+
+```lino
+(Pi (Natural _) Boolean)
+```
+
+## Lambda Formation
+
+`lambda` forms an abstraction over one typed parameter:
+
+```lino
+(lambda (Natural x) x)
+(identity: lambda (Natural x) x)
+```
+
+Rule:
+
+```text
+Gamma, x : A |- body : B
+------------------------
+Gamma |- (lambda (A x) body) : (Pi (A x) B)
+```
+
+For named lambdas, the evaluator stores both:
+
+- the lambda body for later application;
+- the inferred `Pi` type of the name.
+
+Example:
+
+```lino
+(Natural: (Type 0) Natural)
+(identity: lambda (Natural x) x)
+(? (identity of (Pi (Natural x) Natural)))  # -> 1
+(? (type of identity))                      # -> (Pi (Natural x) Natural)
+```
+
+## Application
+
+`apply` explicitly applies a lambda to an argument:
+
+```lino
+(apply identity zero)
+(apply (lambda (Natural x) (x + 1)) 0)
+```
+
+Evaluation rule:
+
+```text
+Gamma |- f => (lambda (A x) body)
+Gamma |- a : A
+---------------------------------
+Gamma |- (apply f a) => body[x := a]
+```
+
+The implemented reduction substitutes the argument into the lambda body and
+evaluates the result. Named lambdas and inline lambdas both use the same
+substitution helper. The helper does not substitute under a nested `lambda`
+or `Pi` binder that shadows the same variable.
+
+The intended typing rule is the standard dependent application rule:
+
+```text
+Gamma |- f : (Pi (A x) B)
+Gamma |- a : A
+-------------------------
+Gamma |- (apply f a) : B[x := a]
+```
+
+The evaluator realizes the reduction path today. Full type checking of the
+argument against the domain belongs to the later bidirectional checker.
+
+## Type Membership And Query Links
+
+Membership checks use `(expr of Type)`:
+
+```lino
+(? (zero of Natural))
+(? ((Type 0) of (Type 1)))
+```
+
+Rule:
+
+```text
+Gamma records expr : A
+----------------------  if A equals Expected
+Gamma |- (expr of Expected) => hi
+
+Gamma does not record expr : Expected
+-------------------------------------
+Gamma |- (expr of Expected) => lo
+```
+
+Type queries use `(type of expr)`:
+
+```lino
+(? (type of zero))  # -> Natural
+```
+
+Rule:
+
+```text
+Gamma records expr : A
+----------------------
+Gamma |- (type of expr) => A
+
+Gamma has no type fact for expr
+-------------------------------
+Gamma |- (type of expr) => unknown
+```
+
+## Proof Witness Names
+
+When proof production is enabled, typed-kernel forms produce derivation
+links with these rule names:
+
+| Form | Witness rule |
+|------|--------------|
+| `(Type N)` | `type-universe` |
+| `(Prop)` | `prop` |
+| `(Pi (A x) B)` | `pi-formation` |
+| `(lambda (A x) body)` | `lambda-formation` |
+| `(apply f a)` | `beta-reduction` |
+| `(type of expr)` | `type-query` |
+| `(expr of Type)` | `type-check` |
+
+## Example Contract
+
+The shared example
+[`examples/dependent-types.lino`](../examples/dependent-types.lino) is the
+public executable sample for this surface. Both implementations run every
+file in `examples/` and compare the results with
+[`examples/expected.lino`](../examples/expected.lino), so changes to these
+rules must update the shared fixtures intentionally.
+
+The dedicated kernel tests are:
+
+- JavaScript: `js/tests/kernel.test.mjs`
+- Rust: `rust/tests/kernel_tests.rs`

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -1031,8 +1031,15 @@ function defineForm(head, rhs, env){
         const body = rhs[2];
         env.terms.add(storeName);
         env.setLambda(storeName, paramName, paramType, body);
+        const hadParamTerm = env.terms.has(paramName);
+        const previousParamType = env.getType(paramName);
+        env.terms.add(paramName);
+        env.setType(paramName, paramType);
         const paramTypeKey = typeof paramType === 'string' ? paramType : keyOf(paramType);
         const bodyTypeKey = env.getType(body) || (typeof body === 'string' ? body : keyOf(body));
+        if (!hadParamTerm) env.terms.delete(paramName);
+        if (previousParamType === null) env.types.delete(paramName);
+        else env.setType(paramName, previousParamType);
         env.setType(storeName, '(Pi (' + paramTypeKey + ' ' + paramName + ') ' + bodyTypeKey + ')');
         return 1;
       }

--- a/js/tests/kernel.test.mjs
+++ b/js/tests/kernel.test.mjs
@@ -1,0 +1,73 @@
+// Typed kernel rules for issue #37.
+//
+// These tests keep the documented D1 surface honest: Pi formation, lambda
+// formation, application by beta-reduction, and type membership/query links.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { evaluate } from '../src/rml-links.mjs';
+
+function evaluateClean(src) {
+  const out = evaluate(src);
+  assert.deepStrictEqual(out.diagnostics, []);
+  return out.results;
+}
+
+describe('kernel typing rules', () => {
+  it('forms a Pi type and records it as a Type 0 member', () => {
+    const results = evaluateClean(`
+(Natural: (Type 0) Natural)
+(succ: (Pi (Natural n) Natural))
+(? (Pi (Natural n) Natural))
+(? ((Pi (Natural n) Natural) of (Type 0)))
+(? (succ of (Pi (Natural n) Natural)))
+(? (type of succ))
+`);
+    assert.deepStrictEqual(results, [1, 1, 1, '(Pi (Natural n) Natural)']);
+  });
+
+  it('types a named lambda under its bound parameter context', () => {
+    const results = evaluateClean(`
+(Natural: (Type 0) Natural)
+(identity: lambda (Natural x) x)
+(? (identity of (Pi (Natural x) Natural)))
+(? (type of identity))
+`);
+    assert.deepStrictEqual(results, [1, '(Pi (Natural x) Natural)']);
+  });
+
+  it('keeps a named lambda parameter scoped to the lambda body', () => {
+    const results = evaluateClean(`
+(Natural: (Type 0) Natural)
+(identity: lambda (Natural x) x)
+(? (x of Natural))
+`);
+    assert.deepStrictEqual(results, [0]);
+  });
+
+  it('applies lambdas by beta-reducing the argument into the body', () => {
+    const results = evaluateClean(`
+(Natural: (Type 0) Natural)
+(zero: Natural zero)
+(identity: lambda (Natural x) x)
+(? ((apply identity zero) = zero))
+(? (apply (lambda (Natural x) (x + 0.1)) 0.2))
+`);
+    assert.deepStrictEqual(results, [1, 0.3]);
+  });
+
+  it('checks type membership and returns stored types through of links', () => {
+    const results = evaluateClean(`
+(Type: Type Type)
+(Natural: Type Natural)
+(zero: Natural zero)
+(Type 0)
+(Type 1)
+(? (zero of Natural))
+(? (Natural of Type))
+(? (type of zero))
+(? ((Type 0) of (Type 1)))
+`);
+    assert.deepStrictEqual(results, [1, 1, 'Natural', 1]);
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2042,6 +2042,10 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
                 if let Some((param_name, param_type)) = parse_binding(&rhs[1]) {
                     let body = rhs[2].clone();
                     env.terms.insert(store_name.clone());
+                    let had_param_term = env.terms.contains(&param_name);
+                    let previous_param_type = env.get_type(&param_name).cloned();
+                    env.terms.insert(param_name.clone());
+                    env.set_type(&param_name, &param_type);
                     let body_key = key_of(&body);
                     let body_type =
                         env.get_type(&body_key)
@@ -2050,6 +2054,14 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
                                 Node::Leaf(s) => s.clone(),
                                 other => key_of(other),
                             });
+                    if !had_param_term {
+                        env.terms.remove(&param_name);
+                    }
+                    if let Some(previous) = previous_param_type {
+                        env.set_type(&param_name, &previous);
+                    } else {
+                        env.types.remove(&param_name);
+                    }
                     env.set_type(
                         &store_name,
                         &format!("(Pi ({} {}) {})", param_type, param_name, body_type),

--- a/rust/tests/kernel_tests.rs
+++ b/rust/tests/kernel_tests.rs
@@ -1,0 +1,110 @@
+// Typed kernel rules for issue #37.
+//
+// These tests keep the documented D1 surface honest: Pi formation, lambda
+// formation, application by beta-reduction, and type membership/query links.
+
+use rml::{evaluate, RunResult};
+
+fn evaluate_clean(src: &str) -> Vec<RunResult> {
+    let out = evaluate(src, None, None);
+    assert!(
+        out.diagnostics.is_empty(),
+        "unexpected diagnostics: {:?}",
+        out.diagnostics
+    );
+    out.results
+}
+
+#[test]
+fn forms_pi_type_and_records_type_zero_membership() {
+    let results = evaluate_clean(
+        r#"
+(Natural: (Type 0) Natural)
+(succ: (Pi (Natural n) Natural))
+(? (Pi (Natural n) Natural))
+(? ((Pi (Natural n) Natural) of (Type 0)))
+(? (succ of (Pi (Natural n) Natural)))
+(? (type of succ))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Type("(Pi (Natural n) Natural)".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn types_named_lambda_under_bound_parameter_context() {
+    let results = evaluate_clean(
+        r#"
+(Natural: (Type 0) Natural)
+(identity: lambda (Natural x) x)
+(? (identity of (Pi (Natural x) Natural)))
+(? (type of identity))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Type("(Pi (Natural x) Natural)".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn keeps_named_lambda_parameter_scoped_to_lambda_body() {
+    let results = evaluate_clean(
+        r#"
+(Natural: (Type 0) Natural)
+(identity: lambda (Natural x) x)
+(? (x of Natural))
+"#,
+    );
+    assert_eq!(results, vec![RunResult::Num(0.0)]);
+}
+
+#[test]
+fn applies_lambdas_by_beta_reducing_argument_into_body() {
+    let results = evaluate_clean(
+        r#"
+(Natural: (Type 0) Natural)
+(zero: Natural zero)
+(identity: lambda (Natural x) x)
+(? ((apply identity zero) = zero))
+(? (apply (lambda (Natural x) (x + 0.1)) 0.2))
+"#,
+    );
+    assert_eq!(results, vec![RunResult::Num(1.0), RunResult::Num(0.3)]);
+}
+
+#[test]
+fn checks_type_membership_and_returns_stored_types_through_of_links() {
+    let results = evaluate_clean(
+        r#"
+(Type: Type Type)
+(Natural: Type Natural)
+(zero: Natural zero)
+(Type 0)
+(Type 1)
+(? (zero of Natural))
+(? (Natural of Type))
+(? (type of zero))
+(? ((Type 0) of (Type 1)))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Type("Natural".to_string()),
+            RunResult::Num(1.0),
+        ]
+    );
+}


### PR DESCRIPTION
Fixes #37

## Summary
- Adds `docs/KERNEL.md` with the D1 rules for `Pi`, `lambda`, `apply`, `(expr of Type)`, `(type of expr)`, type declarations, universes, and proof witness names.
- Adds mirrored JavaScript and Rust kernel tests covering the documented rules, including the issue surface forms `(succ: (Pi (Natural n) Natural))`, `(identity: lambda (Natural x) x)`, and `(apply identity zero)`.
- Fixes named lambda type inference so the body is typed under the temporary bound-parameter context without leaking the parameter afterward.
- Links the kernel spec from README/architecture docs and documents that existing examples are checked through the shared example fixtures.

## Tests
- `node --test tests/kernel.test.mjs`
- `cargo test --test kernel_tests`
- `npm test`
- `cargo test`
