### PR TITLE
[D8] Capture-avoiding substitution and freshness

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-02T20:37:48.863Z for PR creation at branch issue-38-6e163b3ed3dd for issue https://github.com/link-foundation/relative-meta-logic/issues/38

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-02T20:37:48.863Z for PR creation at branch issue-38-6e163b3ed3dd for issue https://github.com/link-foundation/relative-meta-logic/issues/38

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -99,6 +99,8 @@ Each AST node is evaluated recursively by `eval_node` / `evalNode`. The evaluati
 | `(Pi (A x) B)` | Dependent product formation | `(Pi (Natural n) Natural)` |
 | `(lambda (A x) body)` | Lambda formation | `(lambda (Natural x) x)` |
 | `(apply f x)` | Lambda application by beta-reduction | `(apply identity zero)` |
+| `(subst term x replacement)` | Capture-avoiding substitution | `(subst (x + 0.1) x 0.2)` |
+| `(fresh x in body)` | Temporarily introduce a fresh scoped variable | `(fresh x in (x of Natural))` |
 | `(expr of Type)` | Type membership check | `(zero of Natural)` |
 | `(type of expr)` | Type query | `(type of zero)` |
 
@@ -108,7 +110,8 @@ The typed-kernel rules are specified in [docs/KERNEL.md](./docs/KERNEL.md).
 
 Only query expressions `(? ...)` produce output. Their evaluated truth
 values are collected and returned as an array of numbers; `(type of ...)`
-queries return type strings in the typed runner APIs.
+queries return type strings in the typed runner APIs, and direct `(subst ...)`
+queries return the substituted link string.
 
 ## Public Library API
 

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -83,6 +83,7 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E007` | Import error: cycle in the file dependency graph, missing import target, or non-string import target. Triggered by `(import "<path>")` directives. |
 | `E008` | Shadowing warning: a top-level definition rebinds a name introduced by an earlier `(import …)`. Triggered, for example, by `(import "lib.lino") (myop: max)` when `lib.lino` already defines `myop`. The redefinition still takes effect — `E008` is informational, not fatal. |
 | `E009` | Namespace or alias error: invalid namespace name (empty or dotted, e.g. `(namespace foo.bar)`), or an alias collision between two `(import "..." as <alias>)` directives in the same file. |
+| `E010` | Freshness error: `(fresh x in body)` tried to introduce a name that already appears in the current evaluator context. |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying
@@ -186,4 +187,3 @@ through the same `formatTraceValue` helper in both runtimes. Two consecutive
 runs on the same input produce identical traces, and the JavaScript and
 Rust implementations produce the same trace lines for the same input — both
 properties are exercised by the trace test suites.
-

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -2,8 +2,8 @@
 
 This document specifies the typed-kernel surface implemented by the
 JavaScript and Rust evaluators. It is the D1 contract from issue #37:
-the rules for `Pi`, `lambda`, `apply`, type membership with `of`, and
-type queries with `(type of ...)`.
+the rules for `Pi`, `lambda`, `apply`, capture-avoiding substitution,
+freshness, type membership with `of`, and type queries with `(type of ...)`.
 
 RML remains a dynamic axiomatic system. These rules install and query type
 facts in the evaluator environment; they are not yet a full bidirectional
@@ -139,8 +139,7 @@ Gamma |- (apply f a) => body[x := a]
 
 The implemented reduction substitutes the argument into the lambda body and
 evaluates the result. Named lambdas and inline lambdas both use the same
-substitution helper. The helper does not substitute under a nested `lambda`
-or `Pi` binder that shadows the same variable.
+capture-avoiding substitution helper.
 
 The intended typing rule is the standard dependent application rule:
 
@@ -153,6 +152,59 @@ Gamma |- (apply f a) : B[x := a]
 
 The evaluator realizes the reduction path today. Full type checking of the
 argument against the domain belongs to the later bidirectional checker.
+
+## Substitution
+
+`subst` is the kernel primitive for capture-avoiding substitution:
+
+```lino
+(subst (lambda (Natural y) (x + y)) x y)
+```
+
+Rule:
+
+```text
+Gamma |- term[x := replacement] = term'
+----------------------------------------
+Gamma |- (subst term x replacement) => term'
+```
+
+The helper substitutes only free occurrences of the target variable. It stops
+at `lambda`, `Pi`, and `fresh` binders that shadow the target variable. When
+the replacement contains a free variable that would be captured by a binder in
+the term, the binder is alpha-renamed deterministically:
+
+```lino
+(? (subst (lambda (Natural y) (x + y)) x y))
+# -> (lambda (Natural y_1) (y + y_1))
+```
+
+## Freshness
+
+`fresh` introduces a scoped name that must not already appear in the current
+environment:
+
+```lino
+(fresh y in ((lambda (Natural x) (x + y)) y))
+```
+
+Rule:
+
+```text
+x notin Gamma
+Gamma, x fresh |- body => v
+---------------------------
+Gamma |- (fresh x in body) => v
+```
+
+If the name is already present in the context, evaluation rejects the form with
+diagnostic `E010`:
+
+```lino
+(Natural: (Type 0) Natural)
+(y: Natural y)
+(? (fresh y in y))  # E010
+```
 
 ## Type Membership And Query Links
 
@@ -205,6 +257,8 @@ links with these rule names:
 | `(Pi (A x) B)` | `pi-formation` |
 | `(lambda (A x) body)` | `lambda-formation` |
 | `(apply f a)` | `beta-reduction` |
+| `(subst term x replacement)` | `substitution` |
+| `(fresh x in body)` | `fresh` |
 | `(type of expr)` | `type-query` |
 | `(expr of Type)` | `type-check` |
 

--- a/js/README.md
+++ b/js/README.md
@@ -70,6 +70,7 @@ import {
   isNum,
   parseBinding,
   parseBindings,
+  subst,
   substitute,
   formalizeSelectedInterpretation,
   evaluateFormalization,
@@ -117,14 +118,14 @@ The meta-expression adapter deliberately keeps unsupported real-world claims par
 npm test
 ```
 
-The test suite includes 199 tests covering:
+The test suite covers:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
-- Dependent type system: universes, Pi-types, lambdas, application, type queries
+- Dependent type system: universes, Pi-types, lambdas, application, capture-avoiding substitution, freshness, type queries
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Dependencies

--- a/js/src/check.mjs
+++ b/js/src/check.mjs
@@ -116,6 +116,8 @@ function expectedRule(expr, ops, assigned) {
   if (head === 'Pi' && expr.length === 3) return 'pi-formation';
   if (head === 'lambda' && expr.length === 3) return 'lambda-formation';
   if (head === 'apply' && expr.length === 3) return 'beta-reduction';
+  if (head === 'subst' && expr.length === 4) return 'substitution';
+  if (head === 'fresh' && expr.length === 4 && expr[2] === 'in') return 'fresh';
   if (head === 'type' && expr.length === 3 && expr[1] === 'of') {
     return 'type-query';
   }
@@ -275,6 +277,8 @@ function checkNode(expr, proof, ops, assigned, path) {
     case 'lambda-formation':
     case 'type-query':
     case 'type-check':
+    case 'substitution':
+    case 'fresh':
       return checkTypesys(expr, rule, subs, path);
     case 'beta-reduction': {
       arity(rule, subs, 2, path);
@@ -477,6 +481,27 @@ function checkTypesys(expr, rule, subs, path) {
       return rule;
     }
     bad('type-check mismatch');
+  }
+  if (rule === 'substitution' && expr.length === 4 && expr[0] === 'subst') {
+    arity(rule, subs, 3, path);
+    if (
+      isStructurallySame(expr[1], subs[0]) &&
+      isStructurallySame(expr[2], subs[1]) &&
+      isStructurallySame(expr[3], subs[2])
+    ) {
+      return rule;
+    }
+    bad('substitution mismatch');
+  }
+  if (rule === 'fresh' && expr.length === 4 && expr[0] === 'fresh' && expr[2] === 'in') {
+    arity(rule, subs, 2, path);
+    if (
+      isStructurallySame(expr[1], subs[0]) &&
+      isStructurallySame(expr[3], subs[1])
+    ) {
+      return rule;
+    }
+    bad('fresh mismatch');
   }
   bad('shape mismatch');
 }

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -433,23 +433,171 @@ function parseBindings(binding) {
 }
 
 // ---------- Substitution (for beta-reduction) ----------
-// Substitute all occurrences of variable `name` with `replacement` in `expr`.
-// Both expr and replacement can be strings or arrays (AST nodes).
-function substitute(expr, name, replacement) {
+// Capture-avoiding substitution for kernel terms. Both expr and replacement
+// can be strings or arrays (AST nodes). The public primitive is `subst`;
+// `substitute` remains as the backwards-compatible helper name.
+const NON_VARIABLE_TOKENS = new Set([
+  'lambda', 'Pi', 'fresh', 'in', 'subst', 'apply', 'type', 'of',
+  'has', 'probability', 'with', 'proof', 'range', 'valence',
+  'namespace', 'import', 'as', 'is', '?',
+  '+', '-', '*', '/', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
+]);
+
+function cloneTerm(node) {
+  return Array.isArray(node) ? node.map(cloneTerm) : node;
+}
+
+function tokenBaseName(token) {
+  if (typeof token !== 'string') return null;
+  return token.replace(/[:,]+$/g, '');
+}
+
+function isVariableToken(token) {
+  if (typeof token !== 'string') return false;
+  const base = tokenBaseName(token);
+  return !!base && base === token && !isNum(base) && !NON_VARIABLE_TOKENS.has(base);
+}
+
+function bindingParamNames(binding) {
+  const parsed = parseBindings(binding);
+  return parsed ? parsed.map(b => b.paramName) : [];
+}
+
+function binderInfo(expr) {
+  if (!Array.isArray(expr)) return null;
+  if (expr.length === 3 && (expr[0] === 'lambda' || expr[0] === 'Pi')) {
+    const params = bindingParamNames(expr[1]);
+    if (params.length > 0) {
+      return { kind: expr[0], params, bodyIndex: 2, bindingIndex: 1 };
+    }
+  }
+  if (expr.length === 4 && expr[0] === 'fresh' && expr[2] === 'in' && typeof expr[1] === 'string') {
+    return { kind: 'fresh', params: [expr[1]], bodyIndex: 3, bindingIndex: 1 };
+  }
+  return null;
+}
+
+function freeVariables(expr, bound = new Set()) {
+  const out = new Set();
+  function addAll(set) {
+    for (const v of set) out.add(v);
+  }
+  if (typeof expr === 'string') {
+    if (isVariableToken(expr) && !bound.has(expr)) out.add(expr);
+    return out;
+  }
+  if (!Array.isArray(expr)) return out;
+
+  const binder = binderInfo(expr);
+  if (binder) {
+    const nested = new Set(bound);
+    for (const param of binder.params) nested.add(param);
+    if (binder.kind !== 'fresh') {
+      const paramSet = new Set(binder.params);
+      for (const child of expr[binder.bindingIndex]) {
+        if (typeof child === 'string' && paramSet.has(tokenBaseName(child))) continue;
+        addAll(freeVariables(child, bound));
+      }
+    }
+    addAll(freeVariables(expr[binder.bodyIndex], nested));
+    return out;
+  }
+
+  for (const child of expr) addAll(freeVariables(child, bound));
+  return out;
+}
+
+function containsFree(expr, name) {
+  return freeVariables(expr).has(name);
+}
+
+function collectNames(expr, out = new Set()) {
+  if (typeof expr === 'string') {
+    const base = tokenBaseName(expr);
+    if (base && !isNum(base) && !NON_VARIABLE_TOKENS.has(base)) out.add(base);
+    return out;
+  }
+  if (Array.isArray(expr)) {
+    for (const child of expr) collectNames(child, out);
+  }
+  return out;
+}
+
+function freshName(base, avoid) {
+  let i = 1;
+  let candidate = `${base}_${i}`;
+  while (avoid.has(candidate)) {
+    i++;
+    candidate = `${base}_${i}`;
+  }
+  return candidate;
+}
+
+function renameBindingParam(binding, oldName, newName) {
+  if (!Array.isArray(binding)) return binding;
+  return binding.map(child => {
+    if (typeof child !== 'string') return cloneTerm(child);
+    if (child === oldName) return newName;
+    if (child === `${oldName},`) return `${newName},`;
+    if (child === `${oldName}:`) return `${newName}:`;
+    return child;
+  });
+}
+
+function renameBoundOccurrences(expr, oldName, newName) {
+  if (typeof expr === 'string') return expr === oldName ? newName : expr;
+  if (!Array.isArray(expr)) return expr;
+
+  const binder = binderInfo(expr);
+  if (binder && binder.params.includes(oldName)) {
+    return cloneTerm(expr);
+  }
+
+  return expr.map(child => renameBoundOccurrences(child, oldName, newName));
+}
+
+function renameBinder(expr, binder, oldName, newName) {
+  const out = expr.map(cloneTerm);
+  if (binder.kind === 'fresh') {
+    out[binder.bindingIndex] = newName;
+  } else {
+    out[binder.bindingIndex] = renameBindingParam(out[binder.bindingIndex], oldName, newName);
+  }
+  out[binder.bodyIndex] = renameBoundOccurrences(out[binder.bodyIndex], oldName, newName);
+  return out;
+}
+
+function subst(expr, name, replacement) {
   if (typeof expr === 'string') {
     return expr === name ? replacement : expr;
   }
   if (Array.isArray(expr)) {
-    // Don't substitute inside a binding that shadows the variable
-    if (expr.length === 3 && (expr[0] === 'lambda' || expr[0] === 'Pi') && Array.isArray(expr[1])) {
-      const parsed = parseBinding(expr[1]);
-      if (parsed && parsed.paramName === name) {
-        return expr; // shadowed
+    const binder = binderInfo(expr);
+    if (binder) {
+      if (binder.params.includes(name)) return expr; // shadowed
+      let current = expr.map(cloneTerm);
+      const replacementFree = freeVariables(replacement);
+      if (containsFree(expr[binder.bodyIndex], name)) {
+        const avoid = collectNames(current);
+        collectNames(replacement, avoid);
+        avoid.add(name);
+        for (const param of binder.params) {
+          if (replacementFree.has(param)) {
+            const next = freshName(param, avoid);
+            avoid.add(next);
+            current = renameBinder(current, binderInfo(current), param, next);
+          }
+        }
       }
+      return current.map(child => subst(child, name, replacement));
     }
-    return expr.map(child => substitute(child, name, replacement));
+    return expr.map(child => subst(child, name, replacement));
   }
   return expr;
+}
+
+function substitute(expr, name, replacement) {
+  return subst(expr, name, replacement);
 }
 
 // ---------- Eval ----------
@@ -592,6 +740,12 @@ function buildProof(node, env) {
   if (node.length === 3 && node[0] === 'apply') {
     return _wrap('beta-reduction', buildProof(node[1], env), buildProof(node[2], env));
   }
+  if (node.length === 4 && node[0] === 'subst') {
+    return _wrap('substitution', node[1], node[2], node[3]);
+  }
+  if (node.length === 4 && node[0] === 'fresh' && node[2] === 'in') {
+    return _wrap('fresh', node[1], node[3]);
+  }
   if (node.length === 3 && node[0] === 'type' && node[1] === 'of') {
     return _wrap('type-query', node[2]);
   }
@@ -630,7 +784,83 @@ function _queryRequestsProof(node) {
 // Evaluate a node in arithmetic context — numeric literals are NOT clamped to the logic range.
 function evalArith(node, env){
   if (typeof node === 'string' && isNum(node)) return parseFloat(node);
-  return evalNode(node, env);
+  const evaluated = evalNode(node, env);
+  if (isTermResult(evaluated)) return evalArith(evaluated.term, env);
+  return evaluated;
+}
+
+function isTermResult(value) {
+  return value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'term');
+}
+
+function evalTermNode(node, env) {
+  if (!Array.isArray(node)) return node;
+
+  if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+    return evalTermNode(subst(evalTermNode(node[1], env), node[2], evalTermNode(node[3], env)), env);
+  }
+
+  if (node.length === 3 && node[0] === 'apply') {
+    const fn = node[1];
+    const arg = evalTermNode(node[2], env);
+    if (Array.isArray(fn) && fn.length === 3 && fn[0] === 'lambda') {
+      const parsed = parseBinding(fn[1]);
+      if (parsed) return evalTermNode(subst(fn[2], parsed.paramName, arg), env);
+    }
+    if (typeof fn === 'string') {
+      const lambda = env.getLambda(fn);
+      if (lambda) return evalTermNode(subst(lambda.body, lambda.param, arg), env);
+    }
+  }
+
+  if (Array.isArray(node[0]) && node[0].length === 3 && node[0][0] === 'lambda' && node.length >= 2) {
+    const parsed = parseBinding(node[0][1]);
+    if (parsed) {
+      const reduced = subst(node[0][2], parsed.paramName, evalTermNode(node[1], env));
+      return node.length === 2 ? evalTermNode(reduced, env) : evalTermNode([reduced, ...node.slice(2)], env);
+    }
+  }
+
+  return node;
+}
+
+function contextHasName(env, name) {
+  if (env.terms.has(name) || env.types.has(name) || env.lambdas.has(name) || env.symbolProb.has(name) || env.ops.has(name)) {
+    return true;
+  }
+  const resolved = env._resolveQualified(name);
+  return resolved !== name && (
+    env.terms.has(resolved) ||
+    env.types.has(resolved) ||
+    env.lambdas.has(resolved) ||
+    env.symbolProb.has(resolved) ||
+    env.ops.has(resolved)
+  );
+}
+
+function evalFresh(varName, body, env) {
+  if (contextHasName(env, varName)) {
+    throw new RmlError('E010', `fresh variable "${varName}" already appears in context`);
+  }
+  const hadTerm = env.terms.has(varName);
+  const hadType = env.types.has(varName);
+  const previousType = env.types.get(varName);
+  const hadLambda = env.lambdas.has(varName);
+  const previousLambda = env.lambdas.get(varName);
+  const hadSymbol = env.symbolProb.has(varName);
+  const previousSymbol = env.symbolProb.get(varName);
+  env.terms.add(varName);
+  try {
+    return evalNode(body, env);
+  } finally {
+    if (!hadTerm) env.terms.delete(varName);
+    if (hadType) env.types.set(varName, previousType);
+    else env.types.delete(varName);
+    if (hadLambda) env.lambdas.set(varName, previousLambda);
+    else env.lambdas.delete(varName);
+    if (hadSymbol) env.symbolProb.set(varName, previousSymbol);
+    else env.symbolProb.delete(varName);
+  }
 }
 
 function evalNode(node, env){
@@ -685,7 +915,18 @@ function evalNode(node, env){
     const v = evalNode(target, env);
     // If inner result is already a query (e.g. from (type of x)), pass it through
     if (v && typeof v === 'object' && v.query) return v;
+    if (isTermResult(v)) return { query:true, value: keyOf(v.term), typeQuery: true };
     return { query:true, value: env.clamp(v) };
+  }
+
+  // Kernel substitution primitive: (subst term x replacement)
+  if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+    return { term: evalTermNode(node, env) };
+  }
+
+  // Freshness binder: (fresh x in body)
+  if (node.length === 4 && node[0] === 'fresh' && node[2] === 'in' && typeof node[1] === 'string') {
+    return evalFresh(node[1], node[3], env);
   }
 
   // Infix arithmetic: (A + B), (A - B), (A * B), (A / B)
@@ -728,20 +969,22 @@ function evalNode(node, env){
   // Infix equality/inequality: (L = R), (L != R)
   if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='=' || node[1]==='!=')) {
     const op = env.getOp(node[1]);
+    const leftTerm = evalTermNode(node[0], env);
+    const rightTerm = evalTermNode(node[2], env);
     // Equality checks assigned probability first, then structural equality,
     // then falls back to numeric comparison of evaluated values (decimal-precision)
-    const raw = op(node[0], node[2], keyOf);
+    const raw = op(leftTerm, rightTerm, keyOf);
     // If structural/assigned equality already gave a definitive answer, use it
     if (raw === env.hi || raw === env.lo) {
       // Check if there's an explicit assignment — if so, trust it
-      const kPrefix = keyOf(['=',node[0],node[2]]);
-      const kInfix = keyOf([node[0],'=',node[2]]);
-      if (env.assign.has(kPrefix) || env.assign.has(kInfix) || isStructurallySame(node[0], node[2])) {
+      const kPrefix = keyOf(['=',leftTerm,rightTerm]);
+      const kInfix = keyOf([leftTerm,'=',rightTerm]);
+      if (env.assign.has(kPrefix) || env.assign.has(kInfix) || isStructurallySame(leftTerm, rightTerm)) {
         return env.clamp(raw);
       }
       // No explicit assignment and not structurally same — try numeric comparison
-      const L = evalNode(node[0], env);
-      const R = evalNode(node[2], env);
+      const L = evalArith(leftTerm, env);
+      const R = evalArith(rightTerm, env);
       const numEq = decRound(L) === decRound(R) ? env.hi : env.lo;
       if (node[1] === '!=') return env.clamp(env.getOp('not')(numEq));
       return env.clamp(numEq);
@@ -812,7 +1055,7 @@ function evalNode(node, env){
       const parsed = parseBinding(fn[1]);
       if (parsed) {
         const body = fn[2];
-        const result = substitute(body, parsed.paramName, arg);
+        const result = subst(body, parsed.paramName, arg);
         return evalNode(result, env);
       }
     }
@@ -821,7 +1064,7 @@ function evalNode(node, env){
     if (typeof fn === 'string') {
       const lambda = env.getLambda(fn);
       if (lambda) {
-        const result = substitute(lambda.body, lambda.param, arg);
+        const result = subst(lambda.body, lambda.param, arg);
         return evalNode(result, env);
       }
     }
@@ -869,7 +1112,7 @@ function evalNode(node, env){
     const lambda = env.getLambda(head) || env.getLambda(env._resolveQualified(head));
     if (lambda) {
       // Apply first argument, then recursively apply rest
-      let result = substitute(lambda.body, lambda.param, args[0]);
+      let result = subst(lambda.body, lambda.param, args[0]);
       if (args.length === 1) {
         return evalNode(result, env);
       }
@@ -880,6 +1123,16 @@ function evalNode(node, env){
         current = evalNode(args[i], env);
       }
       return current;
+    }
+  }
+
+  // Prefix application with an inline lambda head: ((lambda (A x) body) arg)
+  if (Array.isArray(head) && head.length === 3 && head[0] === 'lambda' && args.length >= 1) {
+    const parsed = parseBinding(head[1]);
+    if (parsed) {
+      const result = subst(head[2], parsed.paramName, args[0]);
+      if (args.length === 1) return evalNode(result, env);
+      return evalNode([result, ...args.slice(1)], env);
     }
   }
 
@@ -1301,6 +1554,8 @@ function evaluate(code, options) {
         if (res && res.query) {
           const tag = res.typeQuery ? 'type' : 'query';
           summary = `${formKey} → ${tag} ${formatTraceValue(res.value)}`;
+        } else if (isTermResult(res)) {
+          summary = `${formKey} → term ${keyOf(res.term)}`;
         } else {
           summary = `${formKey} → ${formatTraceValue(res)}`;
         }
@@ -1797,6 +2052,7 @@ export {
   isStructurallySame,
   parseBinding,
   parseBindings,
+  subst,
   substitute,
   formalizeSelectedInterpretation,
   evaluateFormalization,

--- a/js/src/rml-repl.mjs
+++ b/js/src/rml-repl.mjs
@@ -24,7 +24,7 @@ const META_COMMANDS = [
 const BUILTIN_KEYWORDS = [
   'and', 'or', 'not', 'both', 'neither', 'is', 'has', 'probability',
   'range', 'valence', 'true', 'false', 'unknown', 'undefined',
-  'lambda', 'apply', 'Pi', 'Type', 'Prop', 'of', 'type',
+  'lambda', 'apply', 'subst', 'fresh', 'in', 'Pi', 'Type', 'Prop', 'of', 'type',
 ];
 
 function formatNumber(v) {

--- a/js/tests/check.test.mjs
+++ b/js/tests/check.test.mjs
@@ -46,11 +46,13 @@ describe('replay acceptance: structural-equality witness', () => {
       '(? (neither 0 nor 0))',
       '(? (1 = 2))',
       '(? (1 != 2))',
+      '(? (subst (x + 0.1) x 0.2))',
+      '(? (fresh z in z))',
     ].join('\n');
     const proofs = proofsFrom(program);
     const r = checkProgram(program, proofs);
     assert.ok(isOk(r), JSON.stringify(r.errors));
-    assert.strictEqual(r.ok.length, 13);
+    assert.strictEqual(r.ok.length, 15);
   });
 });
 

--- a/js/tests/diagnostics.test.mjs
+++ b/js/tests/diagnostics.test.mjs
@@ -67,6 +67,30 @@ describe('Diagnostic shape and error codes', () => {
     assert.strictEqual(d.span.line, 1);
   });
 
+  it('E010 — fresh variables must not already appear in context', () => {
+    const out = evaluate(
+      '(Natural: (Type 0) Natural)\n(x: Natural x)\n(? (fresh x in x))',
+      { file: 'fresh.lino' },
+    );
+    assert.strictEqual(out.diagnostics.length, 1);
+    const d = out.diagnostics[0];
+    assert.strictEqual(d.code, 'E010');
+    assert.match(d.message, /fresh variable "x" already appears in context/);
+    assert.strictEqual(d.span.file, 'fresh.lino');
+    assert.strictEqual(d.span.line, 3);
+  });
+
+  it('restores fresh variables when the scoped body reports a diagnostic', () => {
+    const out = evaluate(
+      '(? (fresh z in (=: missing identity)))\n(? (fresh z in z))',
+      { file: 'fresh-error.lino' },
+    );
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E001');
+    assert.strictEqual(out.diagnostics[0].span.line, 1);
+    assert.strictEqual(out.results.length, 1);
+  });
+
   it('E001 — span tracks line for forms that follow blank lines', () => {
     const src = '(valence: 2)\n\n(=: missing identity)';
     const out = evaluate(src, { file: 'multi.lino' });

--- a/js/tests/kernel.test.mjs
+++ b/js/tests/kernel.test.mjs
@@ -1,7 +1,8 @@
-// Typed kernel rules for issue #37.
+// Typed kernel rules for issues #37 and #38.
 //
 // These tests keep the documented D1 surface honest: Pi formation, lambda
-// formation, application by beta-reduction, and type membership/query links.
+// formation, application by beta-reduction, capture-avoiding substitution,
+// freshness, and type membership/query links.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
@@ -54,6 +55,38 @@ describe('kernel typing rules', () => {
 (? (apply (lambda (Natural x) (x + 0.1)) 0.2))
 `);
     assert.deepStrictEqual(results, [1, 0.3]);
+  });
+
+  it('exposes substitution as a capture-avoiding kernel primitive', () => {
+    const results = evaluateClean(`
+(? (subst (lambda (Natural y) (x + y)) x y))
+(? ((subst (lambda (Natural y) (x + y)) x y) = (lambda (Natural y_1) (y + y_1))))
+(? ((subst (x + 0.1) x 0.2) = 0.3))
+`);
+    assert.deepStrictEqual(results, [
+      '(lambda (Natural y_1) (y + y_1))',
+      1,
+      1,
+    ]);
+  });
+
+  it('scopes fresh variables and rejects names already in context', () => {
+    const ok = evaluate(`
+(? (fresh y in ((lambda (Natural x) (x + y)) y)))
+(? (y of Natural))
+`);
+    assert.deepStrictEqual(ok.diagnostics, []);
+    assert.deepStrictEqual(ok.results, [1, 0]);
+
+    const bad = evaluate(`
+(Natural: (Type 0) Natural)
+(y: Natural y)
+(? (fresh y in y))
+`);
+    assert.deepStrictEqual(bad.results, []);
+    assert.strictEqual(bad.diagnostics.length, 1);
+    assert.strictEqual(bad.diagnostics[0].code, 'E010');
+    assert.match(bad.diagnostics[0].message, /fresh variable "y"/);
   });
 
   it('checks type membership and returns stored types through of links', () => {

--- a/js/tests/rml-links.test.mjs
+++ b/js/tests/rml-links.test.mjs
@@ -9,6 +9,7 @@ import {
   quantize,
   decRound,
   substitute,
+  subst,
   formalizeSelectedInterpretation,
   evaluateFormalization,
 } from '../src/rml-links.mjs';
@@ -1608,6 +1609,10 @@ describe('Truth constants: liar paradox using truth constants', () => {
 // =============================================================================
 
 describe('Type System: substitute (beta-reduction helper)', () => {
+  it('should expose subst as the kernel substitution primitive', () => {
+    assert.strictEqual(subst('x', 'x', 'y'), 'y');
+  });
+
   it('should substitute a variable in a string', () => {
     assert.strictEqual(substitute('x', 'x', 'y'), 'y');
   });
@@ -1650,6 +1655,30 @@ describe('Type System: substitute (beta-reduction helper)', () => {
     assert.deepStrictEqual(
       substitute(expr, 'x', '5'),
       ['lambda', ['Natural', 'y'], '5']
+    );
+  });
+
+  it('should alpha-rename lambda binders that would capture the replacement', () => {
+    const expr = ['lambda', ['Natural', 'y'], ['x', '+', 'y']];
+    assert.deepStrictEqual(
+      subst(expr, 'x', 'y'),
+      ['lambda', ['Natural', 'y_1'], ['y', '+', 'y_1']]
+    );
+  });
+
+  it('should alpha-rename Pi binders that would capture the replacement', () => {
+    const expr = ['Pi', ['Natural', 'y'], ['Vec', 'x', 'y']];
+    assert.deepStrictEqual(
+      subst(expr, 'x', 'y'),
+      ['Pi', ['Natural', 'y_1'], ['Vec', 'y', 'y_1']]
+    );
+  });
+
+  it('should alpha-rename fresh binders that would capture the replacement', () => {
+    const expr = ['fresh', 'y', 'in', ['x', '+', 'y']];
+    assert.deepStrictEqual(
+      subst(expr, 'x', 'y'),
+      ['fresh', 'y_1', 'in', ['y', '+', 'y_1']]
     );
   });
 });

--- a/rust/README.md
+++ b/rust/README.md
@@ -55,7 +55,7 @@ Or after building:
 ```rust
 use rml::{
     run, evaluate, format_diagnostic, Diagnostic, EvaluateResult, RunResult, Span,
-    tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round,
+    tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round, subst,
     formalize_selected_interpretation, evaluate_formalization,
     FormalizationRequest, Interpretation,
 };
@@ -101,14 +101,14 @@ The meta-expression adapter deliberately keeps unsupported real-world claims par
 cargo test
 ```
 
-The test suite includes 199 tests covering:
+The test suite covers:
 - Tokenization, parsing, and quantization
 - Evaluation logic and operator aggregators
 - Many-valued logics: unary, binary (Boolean), ternary (Kleene), quaternary, quinary, higher N-valued, and continuous (fuzzy)
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
-- Dependent type system: universes, Pi-types, lambdas, application, type queries
+- Dependent type system: universes, Pi-types, lambdas, application, capture-avoiding substitution, freshness, type queries
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Implementation Notes

--- a/rust/src/check.rs
+++ b/rust/src/check.rs
@@ -168,6 +168,14 @@ fn expected_rule(expr: &Node, ops: &HashSet<String>, assigned: &HashSet<String>)
                     "Pi" if c.len() == 3 => return "pi-formation",
                     "lambda" if c.len() == 3 => return "lambda-formation",
                     "apply" if c.len() == 3 => return "beta-reduction",
+                    "subst" if c.len() == 4 => return "substitution",
+                    "fresh" if c.len() == 4 => {
+                        if let Node::Leaf(in_kw) = &c[2] {
+                            if in_kw == "in" {
+                                return "fresh";
+                            }
+                        }
+                    }
                     "type" if c.len() == 3 => {
                         if let Node::Leaf(of) = &c[1] {
                             if of == "of" {
@@ -375,7 +383,7 @@ fn check_node(
         | "assigned-inequality" => check_eq(expr, &rule, subs, ops, assigned, path),
         // Type-system witnesses
         "type-universe" | "prop" | "pi-formation" | "lambda-formation" | "type-query"
-        | "type-check" => check_typesys(expr, &rule, subs, path),
+        | "type-check" | "substitution" | "fresh" => check_typesys(expr, &rule, subs, path),
         "beta-reduction" => arity(&rule, subs, 2, path).and_then(|_| match expr {
             Node::List(c) if c.len() == 3 => match &c[0] {
                 Node::Leaf(h) if h == "apply" => {
@@ -676,6 +684,32 @@ fn check_typesys(
                     }
                 }
                 return bad("type-check mismatch");
+            }
+            ("substitution", 4) => {
+                arity(rule, subs, 3, path)?;
+                if let Node::Leaf(h) = &c[0] {
+                    if h == "subst"
+                        && is_structurally_same(&c[1], &subs[0])
+                        && is_structurally_same(&c[2], &subs[1])
+                        && is_structurally_same(&c[3], &subs[2])
+                    {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("substitution mismatch");
+            }
+            ("fresh", 4) => {
+                arity(rule, subs, 2, path)?;
+                if let (Node::Leaf(h), Node::Leaf(in_kw)) = (&c[0], &c[2]) {
+                    if h == "fresh"
+                        && in_kw == "in"
+                        && is_structurally_same(&c[1], &subs[0])
+                        && is_structurally_same(&c[3], &subs[1])
+                    {
+                        return Ok(rule.into());
+                    }
+                }
+                return bad("fresh mismatch");
             }
             _ => {}
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -987,13 +987,14 @@ pub enum EvalResult {
     Value(f64),
     Query(f64),
     TypeQuery(String),
+    Term(Node),
 }
 
 impl EvalResult {
     pub fn as_f64(&self) -> f64 {
         match self {
             EvalResult::Value(v) | EvalResult::Query(v) => *v,
-            EvalResult::TypeQuery(_) => 0.0,
+            EvalResult::TypeQuery(_) | EvalResult::Term(_) => 0.0,
         }
     }
 
@@ -1096,8 +1097,252 @@ pub fn parse_bindings(binding: &Node) -> Option<Vec<(String, String)>> {
 
 // ========== Substitution ==========
 
-/// Substitute all occurrences of variable `name` with `replacement` in `expr`.
-pub fn substitute(expr: &Node, name: &str, replacement: &Node) -> Node {
+/// Capture-avoiding substitution for kernel terms. `subst` is the public
+/// primitive name; `substitute` remains as the backwards-compatible helper.
+#[derive(Debug, Clone, PartialEq)]
+enum BinderKind {
+    Lambda,
+    Pi,
+    Fresh,
+}
+
+#[derive(Debug, Clone)]
+struct BinderInfo {
+    kind: BinderKind,
+    params: Vec<String>,
+    body_index: usize,
+    binding_index: usize,
+}
+
+fn non_variable_token(s: &str) -> bool {
+    matches!(
+        s,
+        "lambda"
+            | "Pi"
+            | "fresh"
+            | "in"
+            | "subst"
+            | "apply"
+            | "type"
+            | "of"
+            | "has"
+            | "probability"
+            | "with"
+            | "proof"
+            | "range"
+            | "valence"
+            | "namespace"
+            | "import"
+            | "as"
+            | "is"
+            | "?"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "="
+            | "!="
+            | "and"
+            | "or"
+            | "not"
+            | "both"
+            | "neither"
+            | "nor"
+    )
+}
+
+fn token_base_name(token: &str) -> String {
+    token.trim_end_matches(|c| c == ':' || c == ',').to_string()
+}
+
+fn is_variable_token(token: &str) -> bool {
+    let base = token_base_name(token);
+    !base.is_empty() && base == token && !is_num(&base) && !non_variable_token(&base)
+}
+
+fn binding_param_names(binding: &Node) -> Vec<String> {
+    parse_bindings(binding)
+        .map(|bindings| bindings.into_iter().map(|(name, _)| name).collect())
+        .unwrap_or_default()
+}
+
+fn binder_info(expr: &Node) -> Option<BinderInfo> {
+    if let Node::List(children) = expr {
+        if children.len() == 3 {
+            if let Node::Leaf(head) = &children[0] {
+                if head == "lambda" || head == "Pi" {
+                    let params = binding_param_names(&children[1]);
+                    if !params.is_empty() {
+                        return Some(BinderInfo {
+                            kind: if head == "lambda" {
+                                BinderKind::Lambda
+                            } else {
+                                BinderKind::Pi
+                            },
+                            params,
+                            body_index: 2,
+                            binding_index: 1,
+                        });
+                    }
+                }
+            }
+        }
+        if children.len() == 4 {
+            if let (Node::Leaf(head), Node::Leaf(var_name), Node::Leaf(in_kw)) =
+                (&children[0], &children[1], &children[2])
+            {
+                if head == "fresh" && in_kw == "in" {
+                    return Some(BinderInfo {
+                        kind: BinderKind::Fresh,
+                        params: vec![var_name.clone()],
+                        body_index: 3,
+                        binding_index: 1,
+                    });
+                }
+            }
+        }
+    }
+    None
+}
+
+fn free_variables(expr: &Node) -> HashSet<String> {
+    fn walk(expr: &Node, bound: &HashSet<String>, out: &mut HashSet<String>) {
+        match expr {
+            Node::Leaf(s) => {
+                if is_variable_token(s) && !bound.contains(s) {
+                    out.insert(s.clone());
+                }
+            }
+            Node::List(children) => {
+                if let Some(binder) = binder_info(expr) {
+                    if binder.kind != BinderKind::Fresh {
+                        let params: HashSet<String> = binder.params.iter().cloned().collect();
+                        if let Node::List(binding_children) = &children[binder.binding_index] {
+                            for child in binding_children {
+                                if let Node::Leaf(s) = child {
+                                    if params.contains(&token_base_name(s)) {
+                                        continue;
+                                    }
+                                }
+                                walk(child, bound, out);
+                            }
+                        }
+                    }
+                    let mut nested = bound.clone();
+                    for param in binder.params {
+                        nested.insert(param);
+                    }
+                    walk(&children[binder.body_index], &nested, out);
+                    return;
+                }
+                for child in children {
+                    walk(child, bound, out);
+                }
+            }
+        }
+    }
+
+    let mut out = HashSet::new();
+    walk(expr, &HashSet::new(), &mut out);
+    out
+}
+
+fn contains_free(expr: &Node, name: &str) -> bool {
+    free_variables(expr).contains(name)
+}
+
+fn collect_names(expr: &Node, out: &mut HashSet<String>) {
+    match expr {
+        Node::Leaf(s) => {
+            let base = token_base_name(s);
+            if !base.is_empty() && !is_num(&base) && !non_variable_token(&base) {
+                out.insert(base);
+            }
+        }
+        Node::List(children) => {
+            for child in children {
+                collect_names(child, out);
+            }
+        }
+    }
+}
+
+fn fresh_name(base: &str, avoid: &HashSet<String>) -> String {
+    let mut i = 1;
+    loop {
+        let candidate = format!("{}_{}", base, i);
+        if !avoid.contains(&candidate) {
+            return candidate;
+        }
+        i += 1;
+    }
+}
+
+fn rename_binding_param(binding: &Node, old_name: &str, new_name: &str) -> Node {
+    if let Node::List(children) = binding {
+        return Node::List(
+            children
+                .iter()
+                .map(|child| match child {
+                    Node::Leaf(s) if s == old_name => Node::Leaf(new_name.to_string()),
+                    Node::Leaf(s) if s == &format!("{},", old_name) => {
+                        Node::Leaf(format!("{},", new_name))
+                    }
+                    Node::Leaf(s) if s == &format!("{}:", old_name) => {
+                        Node::Leaf(format!("{}:", new_name))
+                    }
+                    _ => child.clone(),
+                })
+                .collect(),
+        );
+    }
+    binding.clone()
+}
+
+fn rename_bound_occurrences(expr: &Node, old_name: &str, new_name: &str) -> Node {
+    match expr {
+        Node::Leaf(s) => {
+            if s == old_name {
+                Node::Leaf(new_name.to_string())
+            } else {
+                expr.clone()
+            }
+        }
+        Node::List(children) => {
+            if let Some(binder) = binder_info(expr) {
+                if binder.params.iter().any(|param| param == old_name) {
+                    return expr.clone();
+                }
+            }
+            Node::List(
+                children
+                    .iter()
+                    .map(|child| rename_bound_occurrences(child, old_name, new_name))
+                    .collect(),
+            )
+        }
+    }
+}
+
+fn rename_binder(expr: &Node, binder: &BinderInfo, old_name: &str, new_name: &str) -> Node {
+    if let Node::List(children) = expr {
+        let mut out = children.clone();
+        if binder.kind == BinderKind::Fresh {
+            out[binder.binding_index] = Node::Leaf(new_name.to_string());
+        } else {
+            out[binder.binding_index] =
+                rename_binding_param(&out[binder.binding_index], old_name, new_name);
+        }
+        out[binder.body_index] =
+            rename_bound_occurrences(&out[binder.body_index], old_name, new_name);
+        Node::List(out)
+    } else {
+        expr.clone()
+    }
+}
+
+/// Substitute all free occurrences of variable `name` with `replacement` in `expr`.
+pub fn subst(expr: &Node, name: &str, replacement: &Node) -> Node {
     match expr {
         Node::Leaf(s) => {
             if s == name {
@@ -1107,26 +1352,48 @@ pub fn substitute(expr: &Node, name: &str, replacement: &Node) -> Node {
             }
         }
         Node::List(children) => {
-            // Don't substitute inside a binding that shadows the variable
-            if children.len() == 3 {
-                if let Node::Leaf(ref head) = children[0] {
-                    if head == "lambda" || head == "Pi" {
-                        if let Some((param, _)) = parse_binding(&children[1]) {
-                            if param == name {
-                                return expr.clone(); // shadowed
-                            }
+            if let Some(binder) = binder_info(expr) {
+                if binder.params.iter().any(|param| param == name) {
+                    return expr.clone(); // shadowed
+                }
+                let mut current = expr.clone();
+                let replacement_free = free_variables(replacement);
+                if contains_free(&children[binder.body_index], name) {
+                    let mut avoid = HashSet::new();
+                    collect_names(&current, &mut avoid);
+                    collect_names(replacement, &mut avoid);
+                    avoid.insert(name.to_string());
+                    for param in &binder.params {
+                        if replacement_free.contains(param) {
+                            let next = fresh_name(param, &avoid);
+                            avoid.insert(next.clone());
+                            let current_binder = binder_info(&current).expect("renamed binder");
+                            current = rename_binder(&current, &current_binder, param, &next);
                         }
                     }
+                }
+                if let Node::List(current_children) = current {
+                    return Node::List(
+                        current_children
+                            .iter()
+                            .map(|child| subst(child, name, replacement))
+                            .collect(),
+                    );
                 }
             }
             Node::List(
                 children
                     .iter()
-                    .map(|child| substitute(child, name, replacement))
+                    .map(|child| subst(child, name, replacement))
                     .collect(),
             )
         }
     }
+}
+
+/// Backwards-compatible alias for [`subst`].
+pub fn substitute(expr: &Node, name: &str, replacement: &Node) -> Node {
+    subst(expr, name, replacement)
 }
 
 // ========== Evaluator ==========
@@ -1138,7 +1405,129 @@ fn eval_arith(node: &Node, env: &mut Env) -> f64 {
             return s.parse::<f64>().unwrap_or(0.0);
         }
     }
-    eval_node(node, env).as_f64()
+    match eval_node(node, env) {
+        EvalResult::Term(term) => eval_arith(&term, env),
+        other => other.as_f64(),
+    }
+}
+
+fn eval_term_node(node: &Node, env: &mut Env) -> Node {
+    if let Node::List(children) = node {
+        if children.len() == 4 {
+            if let (Node::Leaf(head), Node::Leaf(var_name)) = (&children[0], &children[2]) {
+                if head == "subst" {
+                    let term = eval_term_node(&children[1], env);
+                    let replacement = eval_term_node(&children[3], env);
+                    let reduced = subst(&term, var_name, &replacement);
+                    return eval_term_node(&reduced, env);
+                }
+            }
+        }
+
+        if children.len() == 3 {
+            if let Node::Leaf(head) = &children[0] {
+                if head == "apply" {
+                    let fn_node = &children[1];
+                    let arg = eval_term_node(&children[2], env);
+                    if let Node::List(fn_children) = fn_node {
+                        if fn_children.len() == 3 {
+                            if let Node::Leaf(fn_head) = &fn_children[0] {
+                                if fn_head == "lambda" {
+                                    if let Some((param_name, _)) = parse_binding(&fn_children[1]) {
+                                        let reduced = subst(&fn_children[2], &param_name, &arg);
+                                        return eval_term_node(&reduced, env);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Node::Leaf(fn_name) = fn_node {
+                        if let Some(lambda) = env.get_lambda(fn_name).cloned() {
+                            let reduced = subst(&lambda.body, &lambda.param, &arg);
+                            return eval_term_node(&reduced, env);
+                        }
+                    }
+                }
+            }
+        }
+
+        if children.len() >= 2 {
+            if let Node::List(head_children) = &children[0] {
+                if head_children.len() == 3 {
+                    if let Node::Leaf(fn_head) = &head_children[0] {
+                        if fn_head == "lambda" {
+                            if let Some((param_name, _)) = parse_binding(&head_children[1]) {
+                                let arg = eval_term_node(&children[1], env);
+                                let reduced = subst(&head_children[2], &param_name, &arg);
+                                if children.len() == 2 {
+                                    return eval_term_node(&reduced, env);
+                                }
+                                let mut next = vec![reduced];
+                                next.extend_from_slice(&children[2..]);
+                                return eval_term_node(&Node::List(next), env);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    node.clone()
+}
+
+fn context_has_name(env: &Env, name: &str) -> bool {
+    if env.terms.contains(name)
+        || env.types.contains_key(name)
+        || env.lambdas.contains_key(name)
+        || env.symbol_prob.contains_key(name)
+        || env.ops.contains_key(name)
+    {
+        return true;
+    }
+    let resolved = env.resolve_qualified(name);
+    resolved != name
+        && (env.terms.contains(&resolved)
+            || env.types.contains_key(&resolved)
+            || env.lambdas.contains_key(&resolved)
+            || env.symbol_prob.contains_key(&resolved)
+            || env.ops.contains_key(&resolved))
+}
+
+fn eval_fresh(var_name: &str, body: &Node, env: &mut Env) -> EvalResult {
+    if context_has_name(env, var_name) {
+        panic!(
+            "Freshness error: fresh variable \"{}\" already appears in context",
+            var_name
+        );
+    }
+    let had_term = env.terms.contains(var_name);
+    let previous_type = env.types.get(var_name).cloned();
+    let previous_lambda = env.lambdas.get(var_name).cloned();
+    let previous_symbol = env.symbol_prob.get(var_name).copied();
+    env.terms.insert(var_name.to_string());
+    let result = catch_unwind(AssertUnwindSafe(|| eval_node(body, env)));
+    if !had_term {
+        env.terms.remove(var_name);
+    }
+    if let Some(value) = previous_type {
+        env.types.insert(var_name.to_string(), value);
+    } else {
+        env.types.remove(var_name);
+    }
+    if let Some(value) = previous_lambda {
+        env.lambdas.insert(var_name.to_string(), value);
+    } else {
+        env.lambdas.remove(var_name);
+    }
+    if let Some(value) = previous_symbol {
+        env.symbol_prob.insert(var_name.to_string(), value);
+    } else {
+        env.symbol_prob.remove(var_name);
+    }
+    match result {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
 }
 
 // ========== Proof derivations (issue #35) ==========
@@ -1418,6 +1807,30 @@ pub fn build_proof(node: &Node, env: &Env) -> Node {
                     }
                 }
             }
+            if children.len() == 4 {
+                if let Node::Leaf(h) = &children[0] {
+                    if h == "subst" {
+                        return wrap_proof(
+                            "substitution",
+                            vec![
+                                children[1].clone(),
+                                children[2].clone(),
+                                children[3].clone(),
+                            ],
+                        );
+                    }
+                    if h == "fresh" {
+                        if let Node::Leaf(in_kw) = &children[2] {
+                            if in_kw == "in" {
+                                return wrap_proof(
+                                    "fresh",
+                                    vec![children[1].clone(), children[3].clone()],
+                                );
+                            }
+                        }
+                    }
+                }
+            }
             if children.len() == 3 {
                 if let (Node::Leaf(h), Node::Leaf(m)) = (&children[0], &children[1]) {
                     if h == "type" && m == "of" {
@@ -1549,8 +1962,35 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                     if result.is_type_query() {
                         return result;
                     }
+                    if let EvalResult::Term(term) = result {
+                        return EvalResult::TypeQuery(key_of(&term));
+                    }
                     let v = result.as_f64();
                     return EvalResult::Query(env.clamp(v));
+                }
+            }
+
+            // Kernel substitution primitive: (subst term x replacement)
+            if children.len() == 4 {
+                if let (Node::Leaf(ref head), Node::Leaf(ref var_name)) =
+                    (&children[0], &children[2])
+                {
+                    if head == "subst" {
+                        let term = eval_term_node(node, env);
+                        let _ = var_name;
+                        return EvalResult::Term(term);
+                    }
+                }
+            }
+
+            // Freshness binder: (fresh x in body)
+            if children.len() == 4 {
+                if let (Node::Leaf(ref head), Node::Leaf(ref var_name), Node::Leaf(ref in_kw)) =
+                    (&children[0], &children[1], &children[2])
+                {
+                    if head == "fresh" && in_kw == "in" {
+                        return eval_fresh(var_name, &children[3], env);
+                    }
                 }
             }
 
@@ -1614,39 +2054,41 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             if children.len() == 3 {
                 if let Node::Leaf(ref op_name) = children[1] {
                     if op_name == "=" {
+                        let left_term = eval_term_node(&children[0], env);
+                        let right_term = eval_term_node(&children[2], env);
                         match env.ops.get("=").cloned() {
                             Some(Op::Compose { outer, inner }) => {
                                 let inner_val = apply_named_op_on_nodes(
                                     env,
                                     &inner,
-                                    &children[0],
-                                    &children[2],
+                                    &left_term,
+                                    &right_term,
                                 );
                                 let outer_val = env.apply_op(&outer, &[inner_val]);
                                 return EvalResult::Value(env.clamp(outer_val));
                             }
                             _ => {
-                                let raw = env.apply_eq(&children[0], &children[2]);
+                                let raw = env.apply_eq(&left_term, &right_term);
                                 // If there's an explicit assignment or structural match, trust it
                                 let k_prefix = key_of(&Node::List(vec![
                                     Node::Leaf("=".to_string()),
-                                    children[0].clone(),
-                                    children[2].clone(),
+                                    left_term.clone(),
+                                    right_term.clone(),
                                 ]));
                                 let k_infix = key_of(&Node::List(vec![
-                                    children[0].clone(),
+                                    left_term.clone(),
                                     Node::Leaf("=".to_string()),
-                                    children[2].clone(),
+                                    right_term.clone(),
                                 ]));
                                 if env.assign.contains_key(&k_prefix)
                                     || env.assign.contains_key(&k_infix)
-                                    || is_structurally_same(&children[0], &children[2])
+                                    || is_structurally_same(&left_term, &right_term)
                                 {
                                     return EvalResult::Value(env.clamp(raw));
                                 }
                                 // No explicit assignment — try numeric comparison (decimal-precision)
-                                let l = eval_arith(&children[0], env);
-                                let r = eval_arith(&children[2], env);
+                                let l = eval_arith(&left_term, env);
+                                let r = eval_arith(&right_term, env);
                                 let num_eq = if dec_round(l) == dec_round(r) {
                                     env.hi
                                 } else {
@@ -1657,13 +2099,15 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                         }
                     }
                     if op_name == "!=" {
+                        let left_term = eval_term_node(&children[0], env);
+                        let right_term = eval_term_node(&children[2], env);
                         match env.ops.get("!=").cloned() {
                             Some(Op::Compose { outer, inner }) => {
                                 let inner_val = apply_named_op_on_nodes(
                                     env,
                                     &inner,
-                                    &children[0],
-                                    &children[2],
+                                    &left_term,
+                                    &right_term,
                                 );
                                 let outer_val = env.apply_op(&outer, &[inner_val]);
                                 return EvalResult::Value(env.clamp(outer_val));
@@ -1672,24 +2116,24 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                                 // Check explicit assignment or structural match first
                                 let k_prefix = key_of(&Node::List(vec![
                                     Node::Leaf("=".to_string()),
-                                    children[0].clone(),
-                                    children[2].clone(),
+                                    left_term.clone(),
+                                    right_term.clone(),
                                 ]));
                                 let k_infix = key_of(&Node::List(vec![
-                                    children[0].clone(),
+                                    left_term.clone(),
                                     Node::Leaf("=".to_string()),
-                                    children[2].clone(),
+                                    right_term.clone(),
                                 ]));
                                 if env.assign.contains_key(&k_prefix)
                                     || env.assign.contains_key(&k_infix)
-                                    || is_structurally_same(&children[0], &children[2])
+                                    || is_structurally_same(&left_term, &right_term)
                                 {
-                                    let neq = env.apply_neq(&children[0], &children[2]);
+                                    let neq = env.apply_neq(&left_term, &right_term);
                                     return EvalResult::Value(env.clamp(neq));
                                 }
                                 // No explicit assignment — try numeric comparison
-                                let l = eval_arith(&children[0], env);
-                                let r = eval_arith(&children[2], env);
+                                let l = eval_arith(&left_term, env);
+                                let r = eval_arith(&right_term, env);
                                 let num_eq = if dec_round(l) == dec_round(r) {
                                     env.hi
                                 } else {
@@ -1792,7 +2236,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                                             parse_binding(&fn_children[1])
                                         {
                                             let body = &fn_children[2];
-                                            let result = substitute(body, &param_name, arg);
+                                            let result = subst(body, &param_name, arg);
                                             return eval_node(&result, env);
                                         }
                                     }
@@ -1803,7 +2247,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                         // Check if fn is a named lambda
                         if let Node::Leaf(ref fn_name) = fn_node {
                             if let Some(lambda) = env.get_lambda(fn_name).cloned() {
-                                let result = substitute(&lambda.body, &lambda.param, arg);
+                                let result = subst(&lambda.body, &lambda.param, arg);
                                 return eval_node(&result, env);
                             }
                         }
@@ -1872,12 +2316,34 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                 // Named lambda application: (name arg ...)
                 if children.len() >= 2 {
                     if let Some(lambda) = env.get_lambda(&head_str).cloned() {
-                        let result = substitute(&lambda.body, &lambda.param, &children[1]);
+                        let result = subst(&lambda.body, &lambda.param, &children[1]);
                         if children.len() == 2 {
                             return eval_node(&result, env);
                         }
                         // For now, just apply first argument
                         return eval_node(&result, env);
+                    }
+                }
+            }
+
+            // Prefix application with an inline lambda head: ((lambda (A x) body) arg)
+            if children.len() >= 2 {
+                if let Node::List(head_children) = &children[0] {
+                    if head_children.len() == 3 {
+                        if let Node::Leaf(fn_head) = &head_children[0] {
+                            if fn_head == "lambda" {
+                                if let Some((param_name, _)) = parse_binding(&head_children[1]) {
+                                    let result =
+                                        subst(&head_children[2], &param_name, &children[1]);
+                                    if children.len() == 2 {
+                                        return eval_node(&result, env);
+                                    }
+                                    let mut next = vec![result];
+                                    next.extend_from_slice(&children[2..]);
+                                    return eval_node(&Node::List(next), env);
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -2976,6 +3442,9 @@ fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &Evalu
                             EvalResult::Value(v) => {
                                 format!("{} → {}", form_key, format_trace_value(*v))
                             }
+                            EvalResult::Term(term) => {
+                                format!("{} → term {}", form_key, key_of(term))
+                            }
                         };
                         env.trace_events
                             .push(TraceEvent::new("eval", summary, span.clone()));
@@ -3079,6 +3548,11 @@ fn decode_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> (String, Str
         ("E001".to_string(), raw_msg)
     } else if raw_msg.starts_with("Unknown aggregator") {
         ("E004".to_string(), raw_msg)
+    } else if raw_msg.starts_with("Freshness error:") {
+        (
+            "E010".to_string(),
+            raw_msg.replacen("Freshness error: ", "", 1),
+        )
     } else {
         ("E000".to_string(), raw_msg)
     }

--- a/rust/tests/check_tests.rs
+++ b/rust/tests/check_tests.rs
@@ -57,12 +57,14 @@ fn matches_proofs_emitted_by_evaluator() {
         "(? (neither 0 nor 0))",
         "(? (1 = 2))",
         "(? (1 != 2))",
+        "(? (subst (x + 0.1) x 0.2))",
+        "(? (fresh z in z))",
     ]
     .join("\n");
     let proofs = proofs_from(&program);
     let r = check_program(&program, &proofs);
     assert!(r.is_ok(), "{:?}", r);
-    assert_eq!(r.ok.len(), 13);
+    assert_eq!(r.ok.len(), 15);
 }
 
 // ===== Mutation: rule names =====

--- a/rust/tests/diagnostics_tests.rs
+++ b/rust/tests/diagnostics_tests.rs
@@ -2,9 +2,7 @@
 // Mirrors js/tests/diagnostics.test.mjs so any drift between the two
 // implementations fails both test suites.
 
-use rml::{
-    compute_form_spans, evaluate, format_diagnostic, Diagnostic, RunResult, Span,
-};
+use rml::{compute_form_spans, evaluate, format_diagnostic, Diagnostic, RunResult, Span};
 
 #[test]
 fn evaluate_clean_input_returns_results_and_no_diagnostics() {
@@ -47,6 +45,39 @@ fn unknown_aggregator_surfaces_as_e004() {
         d.message
     );
     assert_eq!(d.span.line, 1);
+}
+
+#[test]
+fn fresh_variable_collision_surfaces_as_e010() {
+    let out = evaluate(
+        "(Natural: (Type 0) Natural)\n(x: Natural x)\n(? (fresh x in x))",
+        Some("fresh.lino"),
+        None,
+    );
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E010");
+    assert!(
+        d.message
+            .contains("fresh variable \"x\" already appears in context"),
+        "msg was: {}",
+        d.message
+    );
+    assert_eq!(d.span.file.as_deref(), Some("fresh.lino"));
+    assert_eq!(d.span.line, 3);
+}
+
+#[test]
+fn fresh_variable_is_restored_when_body_reports_a_diagnostic() {
+    let out = evaluate(
+        "(? (fresh z in (=: missing identity)))\n(? (fresh z in z))",
+        Some("fresh-error.lino"),
+        None,
+    );
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E001");
+    assert_eq!(out.diagnostics[0].span.line, 1);
+    assert_eq!(out.results.len(), 1);
 }
 
 #[test]

--- a/rust/tests/kernel_tests.rs
+++ b/rust/tests/kernel_tests.rs
@@ -1,7 +1,8 @@
-// Typed kernel rules for issue #37.
+// Typed kernel rules for issues #37 and #38.
 //
 // These tests keep the documented D1 surface honest: Pi formation, lambda
-// formation, application by beta-reduction, and type membership/query links.
+// formation, application by beta-reduction, capture-avoiding substitution,
+// freshness, and type membership/query links.
 
 use rml::{evaluate, RunResult};
 
@@ -81,6 +82,61 @@ fn applies_lambdas_by_beta_reducing_argument_into_body() {
 "#,
     );
     assert_eq!(results, vec![RunResult::Num(1.0), RunResult::Num(0.3)]);
+}
+
+#[test]
+fn exposes_substitution_as_capture_avoiding_kernel_primitive() {
+    let results = evaluate_clean(
+        r#"
+(? (subst (lambda (Natural y) (x + y)) x y))
+(? ((subst (lambda (Natural y) (x + y)) x y) = (lambda (Natural y_1) (y + y_1))))
+(? ((subst (x + 0.1) x 0.2) = 0.3))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Type("(lambda (Natural y_1) (y + y_1))".to_string()),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn scopes_fresh_variables_and_rejects_names_already_in_context() {
+    let ok = evaluate(
+        r#"
+(? (fresh y in ((lambda (Natural x) (x + y)) y)))
+(? (y of Natural))
+"#,
+        None,
+        None,
+    );
+    assert!(
+        ok.diagnostics.is_empty(),
+        "unexpected diagnostics: {:?}",
+        ok.diagnostics
+    );
+    assert_eq!(ok.results, vec![RunResult::Num(1.0), RunResult::Num(0.0)]);
+
+    let bad = evaluate(
+        r#"
+(Natural: (Type 0) Natural)
+(y: Natural y)
+(? (fresh y in y))
+"#,
+        None,
+        None,
+    );
+    assert!(bad.results.is_empty());
+    assert_eq!(bad.diagnostics.len(), 1);
+    assert_eq!(bad.diagnostics[0].code, "E010");
+    assert!(
+        bad.diagnostics[0].message.contains("fresh variable \"y\""),
+        "message: {}",
+        bad.diagnostics[0].message
+    );
 }
 
 #[test]

--- a/rust/tests/rml_tests.rs
+++ b/rust/tests/rml_tests.rs
@@ -2013,6 +2013,12 @@ fn example_belnap_four_valued() {
 // --- substitute (beta-reduction helper) ---
 
 #[test]
+fn subst_alias_matches_kernel_substitution_primitive() {
+    let result = subst(&Node::Leaf("x".into()), "x", &Node::Leaf("y".into()));
+    assert_eq!(result, Node::Leaf("y".into()));
+}
+
+#[test]
 fn subst_variable_in_leaf() {
     let result = substitute(&Node::Leaf("x".into()), "x", &Node::Leaf("y".into()));
     assert_eq!(result, Node::Leaf("y".into()));
@@ -2121,6 +2127,86 @@ fn subst_free_var_in_lambda() {
             Node::Leaf("lambda".into()),
             Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("y".into()),]),
             Node::Leaf("5".into()),
+        ])
+    );
+}
+
+#[test]
+fn subst_alpha_renames_lambda_binder_to_avoid_capture() {
+    let expr = Node::List(vec![
+        Node::Leaf("lambda".into()),
+        Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("y".into())]),
+        Node::List(vec![
+            Node::Leaf("x".into()),
+            Node::Leaf("+".into()),
+            Node::Leaf("y".into()),
+        ]),
+    ]);
+    let result = subst(&expr, "x", &Node::Leaf("y".into()));
+    assert_eq!(
+        result,
+        Node::List(vec![
+            Node::Leaf("lambda".into()),
+            Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("y_1".into())]),
+            Node::List(vec![
+                Node::Leaf("y".into()),
+                Node::Leaf("+".into()),
+                Node::Leaf("y_1".into()),
+            ]),
+        ])
+    );
+}
+
+#[test]
+fn subst_alpha_renames_pi_binder_to_avoid_capture() {
+    let expr = Node::List(vec![
+        Node::Leaf("Pi".into()),
+        Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("y".into())]),
+        Node::List(vec![
+            Node::Leaf("Vec".into()),
+            Node::Leaf("x".into()),
+            Node::Leaf("y".into()),
+        ]),
+    ]);
+    let result = subst(&expr, "x", &Node::Leaf("y".into()));
+    assert_eq!(
+        result,
+        Node::List(vec![
+            Node::Leaf("Pi".into()),
+            Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("y_1".into())]),
+            Node::List(vec![
+                Node::Leaf("Vec".into()),
+                Node::Leaf("y".into()),
+                Node::Leaf("y_1".into()),
+            ]),
+        ])
+    );
+}
+
+#[test]
+fn subst_alpha_renames_fresh_binder_to_avoid_capture() {
+    let expr = Node::List(vec![
+        Node::Leaf("fresh".into()),
+        Node::Leaf("y".into()),
+        Node::Leaf("in".into()),
+        Node::List(vec![
+            Node::Leaf("x".into()),
+            Node::Leaf("+".into()),
+            Node::Leaf("y".into()),
+        ]),
+    ]);
+    let result = subst(&expr, "x", &Node::Leaf("y".into()));
+    assert_eq!(
+        result,
+        Node::List(vec![
+            Node::Leaf("fresh".into()),
+            Node::Leaf("y_1".into()),
+            Node::Leaf("in".into()),
+            Node::List(vec![
+                Node::Leaf("y".into()),
+                Node::Leaf("+".into()),
+                Node::Leaf("y_1".into()),
+            ]),
         ])
     );
 }


### PR DESCRIPTION
## Summary
- Implements capture-avoiding `subst(...)` in JavaScript and Rust, including deterministic alpha-renaming for `lambda`, `Pi`, and `fresh` binders.
- Adds the LiNo forms `(subst term x replacement)` and `(fresh x in body)`, including `E010` when a fresh name already appears in the evaluator context.
- Updates beta-reduction, proof generation/replay, REPL completions, tests, and docs for the new kernel surface.

## Reproduction
Before this PR, substituting `y` into `(lambda (Natural y) (x + y))` could capture the replacement variable instead of alpha-renaming the binder, and `(fresh y in body)` was not enforced as a scoped freshness form.

## Tests
- `cd js && npm test`
- `cd rust && cargo test`
- `cd js && npm run lint:english`

Fixes #38
