### PR TITLE
[D2] Beta reduction in the evaluator

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-02T21:13:07.677Z for PR creation at branch issue-39-543001dfedc6 for issue https://github.com/link-foundation/relative-meta-logic/issues/39

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-02T21:13:07.677Z for PR creation at branch issue-39-543001dfedc6 for issue https://github.com/link-foundation/relative-meta-logic/issues/39

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -137,9 +137,31 @@ Gamma |- a : A
 Gamma |- (apply f a) => body[x := a]
 ```
 
-The implemented reduction substitutes the argument into the lambda body and
-evaluates the result. Named lambdas and inline lambdas both use the same
-capture-avoiding substitution helper.
+The implemented reduction substitutes the argument into the lambda body with
+the same capture-avoiding helper used by `subst`. If the reduct is closed and
+numeric, evaluation continues to a value:
+
+```lino
+(? (apply (lambda (Natural x) (x + 1)) 0))  # -> 1
+```
+
+If the reduct still contains names that are not available in the evaluator
+context, the query reports the reduced open term instead of treating those
+names as default-probability symbols:
+
+```lino
+(? (apply (lambda (Natural x) (x + y)) z))  # -> (z + y)
+```
+
+Nested binders are alpha-renamed when needed so beta-reduction does not
+capture free variables from the argument:
+
+```lino
+(? (apply (lambda (Natural x) (lambda (Natural y) (x + y))) y))
+# -> (lambda (Natural y_1) (y + y_1))
+```
+
+Named lambdas and inline lambdas both use this reduction path.
 
 The intended typing rule is the standard dependent application rule:
 

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -511,6 +511,33 @@ function containsFree(expr, name) {
   return freeVariables(expr).has(name);
 }
 
+function envCanEvaluateName(env, name) {
+  if (
+    env.symbolProb.has(name) ||
+    env.terms.has(name) ||
+    env.types.has(name) ||
+    env.lambdas.has(name) ||
+    env.ops.has(name)
+  ) {
+    return true;
+  }
+  const resolved = env._resolveQualified(name);
+  return resolved !== name && (
+    env.symbolProb.has(resolved) ||
+    env.terms.has(resolved) ||
+    env.types.has(resolved) ||
+    env.lambdas.has(resolved) ||
+    env.ops.has(resolved)
+  );
+}
+
+function hasUnresolvedFreeVariables(expr, env) {
+  for (const name of freeVariables(expr)) {
+    if (!envCanEvaluateName(env, name)) return true;
+  }
+  return false;
+}
+
 function collectNames(expr, out = new Set()) {
   if (typeof expr === 'string') {
     const base = tokenBaseName(expr);
@@ -824,6 +851,12 @@ function evalTermNode(node, env) {
   return node;
 }
 
+function evalReducedTerm(reduced, env) {
+  const term = evalTermNode(reduced, env);
+  if (hasUnresolvedFreeVariables(term, env)) return { term };
+  return evalNode(term, env);
+}
+
 function contextHasName(env, name) {
   if (env.terms.has(name) || env.types.has(name) || env.lambdas.has(name) || env.symbolProb.has(name) || env.ops.has(name)) {
     return true;
@@ -1056,7 +1089,7 @@ function evalNode(node, env){
       if (parsed) {
         const body = fn[2];
         const result = subst(body, parsed.paramName, arg);
-        return evalNode(result, env);
+        return evalReducedTerm(result, env);
       }
     }
 
@@ -1065,7 +1098,7 @@ function evalNode(node, env){
       const lambda = env.getLambda(fn);
       if (lambda) {
         const result = subst(lambda.body, lambda.param, arg);
-        return evalNode(result, env);
+        return evalReducedTerm(result, env);
       }
     }
 
@@ -1114,15 +1147,9 @@ function evalNode(node, env){
       // Apply first argument, then recursively apply rest
       let result = subst(lambda.body, lambda.param, args[0]);
       if (args.length === 1) {
-        return evalNode(result, env);
+        return evalReducedTerm(result, env);
       }
-      // Curry: apply remaining args
-      let current = evalNode(result, env);
-      for (let i = 1; i < args.length; i++) {
-        // If current result is a lambda, apply next arg
-        current = evalNode(args[i], env);
-      }
-      return current;
+      return evalReducedTerm([result, ...args.slice(1)], env);
     }
   }
 
@@ -1131,8 +1158,8 @@ function evalNode(node, env){
     const parsed = parseBinding(head[1]);
     if (parsed) {
       const result = subst(head[2], parsed.paramName, args[0]);
-      if (args.length === 1) return evalNode(result, env);
-      return evalNode([result, ...args.slice(1)], env);
+      if (args.length === 1) return evalReducedTerm(result, env);
+      return evalReducedTerm([result, ...args.slice(1)], env);
     }
   }
 

--- a/js/tests/kernel.test.mjs
+++ b/js/tests/kernel.test.mjs
@@ -52,9 +52,24 @@ describe('kernel typing rules', () => {
 (zero: Natural zero)
 (identity: lambda (Natural x) x)
 (? ((apply identity zero) = zero))
+(? (apply (lambda (Natural x) (x + 1)) 0))
 (? (apply (lambda (Natural x) (x + 0.1)) 0.2))
 `);
-    assert.deepStrictEqual(results, [1, 0.3]);
+    assert.deepStrictEqual(results, [1, 1, 0.3]);
+  });
+
+  it('beta-reduces open terms without evaluating free variables as probabilities', () => {
+    const results = evaluateClean(`
+(? (apply (lambda (Natural x) (x + y)) z))
+`);
+    assert.deepStrictEqual(results, ['(z + y)']);
+  });
+
+  it('keeps beta-reduction capture-avoiding for open replacements', () => {
+    const results = evaluateClean(`
+(? (apply (lambda (Natural x) (lambda (Natural y) (x + y))) y))
+`);
+    assert.deepStrictEqual(results, ['(lambda (Natural y_1) (y + y_1))']);
   });
 
   it('exposes substitution as a capture-avoiding kernel primitive', () => {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1251,6 +1251,30 @@ fn contains_free(expr: &Node, name: &str) -> bool {
     free_variables(expr).contains(name)
 }
 
+fn env_can_evaluate_name(env: &Env, name: &str) -> bool {
+    if env.symbol_prob.contains_key(name)
+        || env.terms.contains(name)
+        || env.types.contains_key(name)
+        || env.lambdas.contains_key(name)
+        || env.ops.contains_key(name)
+    {
+        return true;
+    }
+    let resolved = env.resolve_qualified(name);
+    resolved != name
+        && (env.symbol_prob.contains_key(&resolved)
+            || env.terms.contains(&resolved)
+            || env.types.contains_key(&resolved)
+            || env.lambdas.contains_key(&resolved)
+            || env.ops.contains_key(&resolved))
+}
+
+fn has_unresolved_free_variables(expr: &Node, env: &Env) -> bool {
+    free_variables(expr)
+        .iter()
+        .any(|name| !env_can_evaluate_name(env, name))
+}
+
 fn collect_names(expr: &Node, out: &mut HashSet<String>) {
     match expr {
         Node::Leaf(s) => {
@@ -1473,6 +1497,15 @@ fn eval_term_node(node: &Node, env: &mut Env) -> Node {
         }
     }
     node.clone()
+}
+
+fn eval_reduced_term(reduced: &Node, env: &mut Env) -> EvalResult {
+    let term = eval_term_node(reduced, env);
+    if has_unresolved_free_variables(&term, env) {
+        EvalResult::Term(term)
+    } else {
+        eval_node(&term, env)
+    }
 }
 
 fn context_has_name(env: &Env, name: &str) -> bool {
@@ -2237,7 +2270,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                                         {
                                             let body = &fn_children[2];
                                             let result = subst(body, &param_name, arg);
-                                            return eval_node(&result, env);
+                                            return eval_reduced_term(&result, env);
                                         }
                                     }
                                 }
@@ -2248,7 +2281,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                         if let Node::Leaf(ref fn_name) = fn_node {
                             if let Some(lambda) = env.get_lambda(fn_name).cloned() {
                                 let result = subst(&lambda.body, &lambda.param, arg);
-                                return eval_node(&result, env);
+                                return eval_reduced_term(&result, env);
                             }
                         }
 
@@ -2318,10 +2351,11 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                     if let Some(lambda) = env.get_lambda(&head_str).cloned() {
                         let result = subst(&lambda.body, &lambda.param, &children[1]);
                         if children.len() == 2 {
-                            return eval_node(&result, env);
+                            return eval_reduced_term(&result, env);
                         }
-                        // For now, just apply first argument
-                        return eval_node(&result, env);
+                        let mut next = vec![result];
+                        next.extend_from_slice(&children[2..]);
+                        return eval_reduced_term(&Node::List(next), env);
                     }
                 }
             }
@@ -2336,11 +2370,11 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                                     let result =
                                         subst(&head_children[2], &param_name, &children[1]);
                                     if children.len() == 2 {
-                                        return eval_node(&result, env);
+                                        return eval_reduced_term(&result, env);
                                     }
                                     let mut next = vec![result];
                                     next.extend_from_slice(&children[2..]);
-                                    return eval_node(&Node::List(next), env);
+                                    return eval_reduced_term(&Node::List(next), env);
                                 }
                             }
                         }

--- a/rust/tests/kernel_tests.rs
+++ b/rust/tests/kernel_tests.rs
@@ -78,10 +78,43 @@ fn applies_lambdas_by_beta_reducing_argument_into_body() {
 (zero: Natural zero)
 (identity: lambda (Natural x) x)
 (? ((apply identity zero) = zero))
+(? (apply (lambda (Natural x) (x + 1)) 0))
 (? (apply (lambda (Natural x) (x + 0.1)) 0.2))
 "#,
     );
-    assert_eq!(results, vec![RunResult::Num(1.0), RunResult::Num(0.3)]);
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.3)
+        ]
+    );
+}
+
+#[test]
+fn beta_reduces_open_terms_without_evaluating_free_variables_as_probabilities() {
+    let results = evaluate_clean(
+        r#"
+(? (apply (lambda (Natural x) (x + y)) z))
+"#,
+    );
+    assert_eq!(results, vec![RunResult::Type("(z + y)".to_string())]);
+}
+
+#[test]
+fn beta_reduction_is_capture_avoiding_for_open_replacements() {
+    let results = evaluate_clean(
+        r#"
+(? (apply (lambda (Natural x) (lambda (Natural y) (x + y))) y))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![RunResult::Type(
+            "(lambda (Natural y_1) (y + y_1))".to_string()
+        )]
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #39

## Summary
- Routes explicit and prefix lambda application through a shared beta-reduction result path in JavaScript and Rust.
- Keeps closed numeric reducts evaluating to values, including `(? (apply (lambda (Natural x) (x + 1)) 0)) -> 1`.
- Returns unresolved open reducts as kernel terms instead of evaluating free variables through default symbol probabilities.
- Adds mirrored kernel tests for closed beta-reduction, open terms, and capture-avoiding beta-reduction, and documents the behavior in `docs/KERNEL.md`.

## Reproduction
Before this PR, a direct query like `(? (apply (lambda (Natural x) (x + y)) z))` returned `1` because the reduced free variables were evaluated as default-probability symbols. Similarly, applying a lambda that returns another lambda could hide the capture-avoiding reduct behind the lambda formation truth value.

## Tests
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
- `npm run --prefix js lint:english`
