### PR TITLE
[D3] Definitional equality / convertibility

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-02T22:13:03.523Z for PR creation at branch issue-40-393ffab736f9 for issue https://github.com/link-foundation/relative-meta-logic/issues/40

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-02T22:13:03.523Z for PR creation at branch issue-40-393ffab736f9 for issue https://github.com/link-foundation/relative-meta-logic/issues/40

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ The test suites cover:
 - Belnap operators (`both...and`, `neither...nor`): default aggregators, redefinition, composite/prefix/infix forms, fuzzy values, range changes
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
-- Dependent type system: universes, Pi-types, lambdas, application, type queries, prefix type notation
+- Dependent type system: universes, Pi-types, lambdas, application, definitional equality, type queries, prefix type notation
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types, coexistence with universe hierarchy
 - Bayesian inference: Bayes' theorem, law of total probability, conditional probability, complement rule
 - Bayesian networks: joint probability (product), probabilistic sum (probabilistic_sum), multi-node networks, chain rule decomposition

--- a/docs/CONCEPTS-COMPARISION.md
+++ b/docs/CONCEPTS-COMPARISION.md
@@ -66,7 +66,7 @@ automated prover.
 | Lambda abstraction | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
 | Function application | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Yes | Yes | No |
 | Beta reduction | Part: beta for link lambdas | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Yes | No |
-| Definitional equality / conversion | Part | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Part: beta conversion | No |
+| Definitional equality / conversion | Yes: beta convertibility; eta opt-in API | Yes | Yes | Yes | Yes | Yes | Yes | Host | Host | Part | Part: beta conversion | No |
 | Full normalization | No: evaluator is not a normalizer | Yes for LF canonical forms | Yes in theory | Part | Yes where defined by logic/tools | Yes | Yes | Host | Host | Part | Part | No |
 | Universe hierarchy | Part: `(Type 0)`, `(Type 1)` | No: LF has kinds/types | No | No | No in HOL; object theories possible | Yes | Yes | Host | Host | No | No | No |
 | Sorts / kinds | Part | Yes | Yes | Yes | Yes: types/classes/logics | Yes | Yes | Host | Host | Yes: type declarations | Yes | Domain sorts |

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -3,7 +3,8 @@
 This document specifies the typed-kernel surface implemented by the
 JavaScript and Rust evaluators. It is the D1 contract from issue #37:
 the rules for `Pi`, `lambda`, `apply`, capture-avoiding substitution,
-freshness, type membership with `of`, and type queries with `(type of ...)`.
+freshness, type membership with `of`, type queries with `(type of ...)`,
+and the D3 convertibility check used by equality.
 
 RML remains a dynamic axiomatic system. These rules install and query type
 facts in the evaluator environment; they are not yet a full bidirectional
@@ -174,6 +175,39 @@ Gamma |- (apply f a) : B[x := a]
 
 The evaluator realizes the reduction path today. Full type checking of the
 argument against the domain belongs to the later bidirectional checker.
+
+## Definitional Equality
+
+`isConvertible(t1, t2, ctx)` decides whether two terms are equal after
+kernel reduction. The JavaScript API is exported as `isConvertible`; the
+Rust API is `is_convertible`.
+
+Default conversion:
+
+1. Look up explicit equality assignments, in both prefix and infix forms.
+2. Beta-normalize both terms, including redexes nested inside larger terms.
+3. Compare the normalized terms structurally.
+
+For evaluator equality queries, assignment lookup still takes precedence
+over conversion:
+
+```lino
+(((apply identity zero) = zero) has probability 0.5)
+(? ((apply identity zero) = zero))  # -> 0.5
+```
+
+If no assignment or conversion applies, equality falls back to numeric
+comparison only when both sides are explicitly numeric or computable from
+numeric operators. Unassigned symbolic terms do not collapse to the default
+unknown probability:
+
+```lino
+(? ((pair (apply (lambda (Natural x) x) y)) = (pair y)))  # -> 1
+(? ((pair x) = (pair y)))                                # -> 0
+```
+
+Eta-conversion is available only through the convertibility API option
+(`{ eta: true }` in JavaScript, `ConvertOptions { eta: true }` in Rust).
 
 ## Substitution
 

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,7 +1,7 @@
 # Typed Kernel
 
 This document specifies the typed-kernel surface implemented by the
-JavaScript and Rust evaluators. It covers the D1 contract from issue #37
+JavaScript and Rust evaluators. It covers the D1 contract from issue #37,
 the D3 convertibility check from issue #40, and the D5 universe hierarchy
 from issue #41: the rules for `Pi`, `lambda`, `apply`, capture-avoiding
 substitution, freshness, checked universe levels, type membership with `of`,

--- a/js/README.md
+++ b/js/README.md
@@ -125,7 +125,7 @@ The test suite covers:
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
-- Dependent type system: universes, Pi-types, lambdas, application, capture-avoiding substitution, freshness, type queries
+- Dependent type system: universes, Pi-types, lambdas, application, definitional equality, capture-avoiding substitution, freshness, type queries
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Dependencies

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -851,8 +851,211 @@ function evalTermNode(node, env) {
   return node;
 }
 
+function conversionOptionsFrom(ctx, options) {
+  const opts = options || {};
+  const ctxOpts = ctx && !(ctx instanceof Env) ? ctx : {};
+  return {
+    eta: Boolean(opts.eta || opts.etaConversion || ctxOpts.eta || ctxOpts.etaConversion),
+  };
+}
+
+function parseTermInput(term) {
+  if (Array.isArray(term)) return term;
+  if (typeof term !== 'string') return String(term);
+  const trimmed = term.trim();
+  if (trimmed.startsWith('(')) {
+    try {
+      return parseOne(tokenizeOne(trimmed));
+    } catch (_) {
+      return term;
+    }
+  }
+  return term;
+}
+
+function normalizeTerm(node, env, options = {}) {
+  if (!Array.isArray(node)) return node;
+  if (node.length === 0) return [];
+
+  if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+    const term = normalizeTerm(node[1], env, options);
+    const replacement = normalizeTerm(node[3], env, options);
+    return normalizeTerm(subst(term, node[2], replacement), env, options);
+  }
+
+  if (node.length === 3 && node[0] === 'apply') {
+    const fn = node[1];
+    const arg = normalizeTerm(node[2], env, options);
+    if (Array.isArray(fn) && fn.length === 3 && fn[0] === 'lambda') {
+      const parsed = parseBinding(fn[1]);
+      if (parsed) return normalizeTerm(subst(fn[2], parsed.paramName, arg), env, options);
+    }
+    if (typeof fn === 'string') {
+      const lambda = env.getLambda(fn) || env.getLambda(env._resolveQualified(fn));
+      if (lambda) return normalizeTerm(subst(lambda.body, lambda.param, arg), env, options);
+    }
+    return ['apply', normalizeTerm(fn, env, options), arg];
+  }
+
+  if (node.length === 3 && node[0] === 'lambda') {
+    const candidate = ['lambda', normalizeTerm(node[1], env, options), normalizeTerm(node[2], env, options)];
+    return etaContract(candidate, env, options);
+  }
+
+  const [head, ...args] = node;
+  if (Array.isArray(head) && head.length === 3 && head[0] === 'lambda' && args.length >= 1) {
+    const parsed = parseBinding(head[1]);
+    if (parsed) {
+      const first = normalizeTerm(args[0], env, options);
+      const reduced = subst(head[2], parsed.paramName, first);
+      if (args.length === 1) return normalizeTerm(reduced, env, options);
+      return normalizeTerm([reduced, ...args.slice(1)], env, options);
+    }
+  }
+
+  if (typeof head === 'string' && args.length >= 1) {
+    const lambda = env.getLambda(head) || env.getLambda(env._resolveQualified(head));
+    if (lambda) {
+      const first = normalizeTerm(args[0], env, options);
+      const reduced = subst(lambda.body, lambda.param, first);
+      if (args.length === 1) return normalizeTerm(reduced, env, options);
+      return normalizeTerm([reduced, ...args.slice(1)], env, options);
+    }
+  }
+
+  return node.map(child => normalizeTerm(child, env, options));
+}
+
+function etaContract(term, env, options) {
+  if (!options.eta || !Array.isArray(term) || term.length !== 3 || term[0] !== 'lambda') {
+    return term;
+  }
+  const bindings = parseBindings(term[1]);
+  if (!bindings || bindings.length !== 1) return term;
+  const param = bindings[0].paramName;
+  const body = term[2];
+  let fn = null;
+  if (Array.isArray(body) && body.length === 3 && body[0] === 'apply' && isStructurallySame(body[2], param)) {
+    fn = body[1];
+  } else if (Array.isArray(body) && body.length === 2 && isStructurallySame(body[1], param)) {
+    fn = body[0];
+  }
+  if (fn !== null && !freeVariables(fn).has(param)) {
+    return normalizeTerm(fn, env, options);
+  }
+  return term;
+}
+
+function lookupAssignedInfix(env, op, left, right) {
+  for (const expr of [[op, left, right], [left, op, right]]) {
+    const key = keyOf(expr);
+    if (env.assign.has(key)) {
+      const value = env.assign.get(key);
+      env.trace('lookup', `${key} → ${formatTraceValue(value)}`);
+      return value;
+    }
+  }
+  return null;
+}
+
+function sameNormalizedInput(left, right, leftTerm, rightTerm) {
+  return isStructurallySame(left, leftTerm) && isStructurallySame(right, rightTerm);
+}
+
+function explicitSymbolNumber(node, env) {
+  if (typeof node !== 'string') return null;
+  if (env.symbolProb.has(node)) return env.symbolProb.get(node);
+  const resolved = env._resolveQualified(node);
+  if (resolved !== node && env.symbolProb.has(resolved)) return env.symbolProb.get(resolved);
+  return null;
+}
+
+function tryEvalNumeric(node, env, options = {}) {
+  const term = normalizeTerm(node, env, options);
+  if (typeof term === 'string') {
+    if (isNum(term)) return parseFloat(term);
+    return explicitSymbolNumber(term, env);
+  }
+  if (!Array.isArray(term) || term.length === 0) return null;
+
+  if (term.length === 3 && typeof term[1] === 'string' && ['+','-','*','/'].includes(term[1])) {
+    const left = tryEvalNumeric(term[0], env, options);
+    const right = tryEvalNumeric(term[2], env, options);
+    if (left === null || right === null) return null;
+    return env.getOp(term[1])(left, right);
+  }
+
+  if (term.length === 3 && typeof term[1] === 'string' && ['and','or','both','neither'].includes(term[1])) {
+    const left = tryEvalNumeric(term[0], env, options);
+    const right = tryEvalNumeric(term[2], env, options);
+    if (left === null || right === null) return null;
+    return env.clamp(env.getOp(term[1])(left, right));
+  }
+
+  const [head, ...args] = term;
+  if (typeof head === 'string' && env.hasOp(head) && head !== '=' && head !== '!=') {
+    const vals = [];
+    for (const arg of args) {
+      const value = tryEvalNumeric(arg, env, options);
+      if (value === null) return null;
+      vals.push(value);
+    }
+    return env.clamp(env.getOp(head)(...vals));
+  }
+
+  return null;
+}
+
+function equalityTruthValue(left, right, leftTerm, rightTerm, env, options = {}) {
+  const assigned = lookupAssignedInfix(env, '=', left, right);
+  if (assigned !== null) return env.clamp(assigned);
+  if (!sameNormalizedInput(left, right, leftTerm, rightTerm)) {
+    const normalizedAssigned = lookupAssignedInfix(env, '=', leftTerm, rightTerm);
+    if (normalizedAssigned !== null) return env.clamp(normalizedAssigned);
+  }
+  if (isStructurallySame(leftTerm, rightTerm)) return env.hi;
+  const leftNum = tryEvalNumeric(leftTerm, env, options);
+  const rightNum = tryEvalNumeric(rightTerm, env, options);
+  if (leftNum !== null && rightNum !== null) {
+    return decRound(leftNum) === decRound(rightNum) ? env.hi : env.lo;
+  }
+  return env.lo;
+}
+
+function evalEqualityNode(left, op, right, env, options = {}) {
+  const direct = lookupAssignedInfix(env, op, left, right);
+  if (direct !== null) return env.clamp(direct);
+  const leftTerm = normalizeTerm(left, env, options);
+  const rightTerm = normalizeTerm(right, env, options);
+  if (!sameNormalizedInput(left, right, leftTerm, rightTerm)) {
+    const normalizedDirect = lookupAssignedInfix(env, op, leftTerm, rightTerm);
+    if (normalizedDirect !== null) return env.clamp(normalizedDirect);
+  }
+  if (op === '=') {
+    return env.clamp(equalityTruthValue(left, right, leftTerm, rightTerm, env, options));
+  }
+  const eq = equalityTruthValue(left, right, leftTerm, rightTerm, env, options);
+  return env.clamp(env.getOp('not')(eq));
+}
+
+function isConvertible(left, right, ctx, options) {
+  const env = ctx instanceof Env ? ctx : new Env(ctx && ctx.env ? ctx.env : ctx);
+  const opts = conversionOptionsFrom(ctx, options);
+  const leftNode = parseTermInput(left);
+  const rightNode = parseTermInput(right);
+  const assigned = lookupAssignedInfix(env, '=', leftNode, rightNode);
+  if (assigned !== null) return env.clamp(assigned) === env.hi;
+  const leftTerm = normalizeTerm(leftNode, env, opts);
+  const rightTerm = normalizeTerm(rightNode, env, opts);
+  if (!sameNormalizedInput(leftNode, rightNode, leftTerm, rightTerm)) {
+    const normalizedAssigned = lookupAssignedInfix(env, '=', leftTerm, rightTerm);
+    if (normalizedAssigned !== null) return env.clamp(normalizedAssigned) === env.hi;
+  }
+  return isStructurallySame(leftTerm, rightTerm);
+}
+
 function evalReducedTerm(reduced, env) {
-  const term = evalTermNode(reduced, env);
+  const term = normalizeTerm(reduced, env);
   if (hasUnresolvedFreeVariables(term, env)) return { term };
   return evalNode(term, env);
 }
@@ -1001,28 +1204,7 @@ function evalNode(node, env){
 
   // Infix equality/inequality: (L = R), (L != R)
   if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='=' || node[1]==='!=')) {
-    const op = env.getOp(node[1]);
-    const leftTerm = evalTermNode(node[0], env);
-    const rightTerm = evalTermNode(node[2], env);
-    // Equality checks assigned probability first, then structural equality,
-    // then falls back to numeric comparison of evaluated values (decimal-precision)
-    const raw = op(leftTerm, rightTerm, keyOf);
-    // If structural/assigned equality already gave a definitive answer, use it
-    if (raw === env.hi || raw === env.lo) {
-      // Check if there's an explicit assignment — if so, trust it
-      const kPrefix = keyOf(['=',leftTerm,rightTerm]);
-      const kInfix = keyOf([leftTerm,'=',rightTerm]);
-      if (env.assign.has(kPrefix) || env.assign.has(kInfix) || isStructurallySame(leftTerm, rightTerm)) {
-        return env.clamp(raw);
-      }
-      // No explicit assignment and not structurally same — try numeric comparison
-      const L = evalArith(leftTerm, env);
-      const R = evalArith(rightTerm, env);
-      const numEq = decRound(L) === decRound(R) ? env.hi : env.lo;
-      if (node[1] === '!=') return env.clamp(env.getOp('not')(numEq));
-      return env.clamp(numEq);
-    }
-    return env.clamp(raw);
+    return evalEqualityNode(node[0], node[1], node[2], env);
   }
 
   // ---------- Type System: "everything is a link" ----------
@@ -1134,6 +1316,9 @@ function evalNode(node, env){
 
   // Prefix: (not X), (and X Y ...), (or X Y ...)
   const [head, ...args] = node;
+  if (typeof head === 'string' && (head === '=' || head === '!=') && args.length === 2) {
+    return evalEqualityNode(args[0], head, args[1], env);
+  }
   if (typeof head === 'string' && env.hasOp(head)) {
     const op = env.getOp(head);
     const vals = args.map(a => evalNode(a, env));
@@ -2077,6 +2262,7 @@ export {
   keyOf,
   isNum,
   isStructurallySame,
+  isConvertible,
   parseBinding,
   parseBindings,
   subst,

--- a/js/tests/kernel.test.mjs
+++ b/js/tests/kernel.test.mjs
@@ -6,7 +6,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { evaluate } from '../src/rml-links.mjs';
+import { Env, evaluate, evalNode, isConvertible } from '../src/rml-links.mjs';
 
 function evaluateClean(src) {
   const out = evaluate(src);
@@ -56,6 +56,43 @@ describe('kernel typing rules', () => {
 (? (apply (lambda (Natural x) (x + 0.1)) 0.2))
 `);
     assert.deepStrictEqual(results, [1, 1, 0.3]);
+  });
+
+  it('decides definitional equality by beta-normalizing terms', () => {
+    const results = evaluateClean(`
+(? ((apply (lambda (Natural x) x) 0) = 0))
+(? ((pair (apply (lambda (Natural x) x) y)) = (pair y)))
+(? ((pair x) = (pair y)))
+`);
+    assert.deepStrictEqual(results, [1, 1, 0]);
+  });
+
+  it('uses explicit equality assignments before conversion', () => {
+    const results = evaluateClean(`
+(Natural: (Type 0) Natural)
+(zero: Natural zero)
+(identity: lambda (Natural x) x)
+(((apply identity zero) = zero) has probability 0.5)
+(? ((apply identity zero) = zero))
+`);
+    assert.deepStrictEqual(results, [0.5]);
+  });
+
+  it('exposes isConvertible for beta, assignment lookup, and opt-in eta', () => {
+    const env = new Env();
+    evalNode(['zero:', 'Natural', 'zero'], env);
+    evalNode(['identity:', 'lambda', ['Natural', 'x'], 'x'], env);
+    evalNode([['zero', '=', 'alias'], 'has', 'probability', '1'], env);
+    assert.strictEqual(isConvertible(['apply', 'identity', 'zero'], 'zero', env), true);
+    assert.strictEqual(isConvertible('zero', 'alias', env), true);
+    assert.strictEqual(
+      isConvertible(['lambda', ['Natural', 'x'], ['apply', 'f', 'x']], 'f', env),
+      false,
+    );
+    assert.strictEqual(
+      isConvertible(['lambda', ['Natural', 'x'], ['apply', 'f', 'x']], 'f', env, { eta: true }),
+      true,
+    );
   });
 
   it('beta-reduces open terms without evaluating free variables as probabilities', () => {

--- a/rust/README.md
+++ b/rust/README.md
@@ -108,7 +108,7 @@ The test suite covers:
 - Both `[0, 1]` and `[-1, 1]` ranges
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
-- Dependent type system: universes, Pi-types, lambdas, application, capture-avoiding substitution, freshness, type queries
+- Dependent type system: universes, Pi-types, lambdas, application, definitional equality, capture-avoiding substitution, freshness, type queries
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Implementation Notes

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -599,6 +599,14 @@ impl Default for EnvOptions {
     }
 }
 
+/// Options for definitional equality / convertibility checks.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ConvertOptions {
+    /// Enable eta-contraction, e.g. `(lambda (A x) (apply f x)) == f`
+    /// when `x` is not free in `f`.
+    pub eta: bool,
+}
+
 /// A stored lambda definition (param name, param type, body).
 #[derive(Debug, Clone)]
 pub struct Lambda {
@@ -919,38 +927,13 @@ impl Env {
     /// Apply equality operator, checking assigned probabilities first.
     /// Takes `&mut self` so it can emit `lookup` trace events.
     pub fn apply_eq(&mut self, left: &Node, right: &Node) -> f64 {
-        // Check prefix form: (= L R)
-        let k_prefix = key_of(&Node::List(vec![
-            Node::Leaf("=".to_string()),
-            left.clone(),
-            right.clone(),
-        ]));
-        if let Some(&v) = self.assign.get(&k_prefix) {
-            self.trace(
-                "lookup",
-                format!("{} → {}", k_prefix, format_trace_value(v)),
-            );
-            return v;
+        if let Some(value) = lookup_assigned_infix(self, "=", left, right) {
+            return self.clamp(value);
         }
-        // Check infix form: (L = R)
-        let k_infix = key_of(&Node::List(vec![
-            left.clone(),
-            Node::Leaf("=".to_string()),
-            right.clone(),
-        ]));
-        if let Some(&v) = self.assign.get(&k_infix) {
-            self.trace(
-                "lookup",
-                format!("{} → {}", k_infix, format_trace_value(v)),
-            );
-            return v;
-        }
-        // Default: syntactic equality
-        if is_structurally_same(left, right) {
-            self.hi
-        } else {
-            self.lo
-        }
+        let options = ConvertOptions::default();
+        let left_term = normalize_term(left, self, options);
+        let right_term = normalize_term(right, self, options);
+        equality_truth_value(left, right, &left_term, &right_term, self, options)
     }
 
     /// Apply inequality operator: not(eq(L, R))
@@ -1499,8 +1482,323 @@ fn eval_term_node(node: &Node, env: &mut Env) -> Node {
     node.clone()
 }
 
+fn normalize_term(node: &Node, env: &mut Env, options: ConvertOptions) -> Node {
+    if let Node::List(children) = node {
+        if children.is_empty() {
+            return Node::List(vec![]);
+        }
+
+        if children.len() == 4 {
+            if let (Node::Leaf(head), Node::Leaf(var_name)) = (&children[0], &children[2]) {
+                if head == "subst" {
+                    let term = normalize_term(&children[1], env, options);
+                    let replacement = normalize_term(&children[3], env, options);
+                    let reduced = subst(&term, var_name, &replacement);
+                    return normalize_term(&reduced, env, options);
+                }
+            }
+        }
+
+        if children.len() == 3 {
+            if let Node::Leaf(head) = &children[0] {
+                if head == "apply" {
+                    let fn_node = &children[1];
+                    let arg = normalize_term(&children[2], env, options);
+                    if let Node::List(fn_children) = fn_node {
+                        if fn_children.len() == 3 {
+                            if let Node::Leaf(fn_head) = &fn_children[0] {
+                                if fn_head == "lambda" {
+                                    if let Some((param_name, _)) = parse_binding(&fn_children[1]) {
+                                        let reduced = subst(&fn_children[2], &param_name, &arg);
+                                        return normalize_term(&reduced, env, options);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if let Node::Leaf(fn_name) = fn_node {
+                        let resolved = env.resolve_qualified(fn_name);
+                        let lambda = env
+                            .get_lambda(fn_name)
+                            .cloned()
+                            .or_else(|| env.get_lambda(&resolved).cloned());
+                        if let Some(lambda) = lambda {
+                            let reduced = subst(&lambda.body, &lambda.param, &arg);
+                            return normalize_term(&reduced, env, options);
+                        }
+                    }
+                    return Node::List(vec![
+                        Node::Leaf("apply".into()),
+                        normalize_term(fn_node, env, options),
+                        arg,
+                    ]);
+                }
+
+                if head == "lambda" {
+                    let candidate = Node::List(vec![
+                        Node::Leaf("lambda".into()),
+                        normalize_term(&children[1], env, options),
+                        normalize_term(&children[2], env, options),
+                    ]);
+                    return eta_contract(&candidate, env, options);
+                }
+            }
+        }
+
+        if children.len() >= 2 {
+            if let Node::List(head_children) = &children[0] {
+                if head_children.len() == 3 {
+                    if let Node::Leaf(fn_head) = &head_children[0] {
+                        if fn_head == "lambda" {
+                            if let Some((param_name, _)) = parse_binding(&head_children[1]) {
+                                let arg = normalize_term(&children[1], env, options);
+                                let reduced = subst(&head_children[2], &param_name, &arg);
+                                if children.len() == 2 {
+                                    return normalize_term(&reduced, env, options);
+                                }
+                                let mut next = vec![reduced];
+                                next.extend_from_slice(&children[2..]);
+                                return normalize_term(&Node::List(next), env, options);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if children.len() >= 2 {
+            if let Node::Leaf(head) = &children[0] {
+                let resolved = env.resolve_qualified(head);
+                let lambda = env
+                    .get_lambda(head)
+                    .cloned()
+                    .or_else(|| env.get_lambda(&resolved).cloned());
+                if let Some(lambda) = lambda {
+                    let arg = normalize_term(&children[1], env, options);
+                    let reduced = subst(&lambda.body, &lambda.param, &arg);
+                    if children.len() == 2 {
+                        return normalize_term(&reduced, env, options);
+                    }
+                    let mut next = vec![reduced];
+                    next.extend_from_slice(&children[2..]);
+                    return normalize_term(&Node::List(next), env, options);
+                }
+            }
+        }
+
+        return Node::List(
+            children
+                .iter()
+                .map(|child| normalize_term(child, env, options))
+                .collect(),
+        );
+    }
+    node.clone()
+}
+
+fn eta_contract(term: &Node, env: &mut Env, options: ConvertOptions) -> Node {
+    if !options.eta {
+        return term.clone();
+    }
+    let children = match term {
+        Node::List(children) if children.len() == 3 => children,
+        _ => return term.clone(),
+    };
+    if !matches!(&children[0], Node::Leaf(head) if head == "lambda") {
+        return term.clone();
+    }
+    let bindings = parse_bindings(&children[1]).unwrap_or_default();
+    if bindings.len() != 1 {
+        return term.clone();
+    }
+    let param = &bindings[0].0;
+    let body = &children[2];
+    let fn_node = match body {
+        Node::List(body_children) if body_children.len() == 3 => {
+            if matches!(&body_children[0], Node::Leaf(head) if head == "apply")
+                && is_structurally_same(&body_children[2], &Node::Leaf(param.clone()))
+            {
+                Some(body_children[1].clone())
+            } else {
+                None
+            }
+        }
+        Node::List(body_children) if body_children.len() == 2 => {
+            if is_structurally_same(&body_children[1], &Node::Leaf(param.clone())) {
+                Some(body_children[0].clone())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    };
+    if let Some(fn_node) = fn_node {
+        if !free_variables(&fn_node).contains(param) {
+            return normalize_term(&fn_node, env, options);
+        }
+    }
+    term.clone()
+}
+
+fn lookup_assigned_infix(env: &mut Env, op: &str, left: &Node, right: &Node) -> Option<f64> {
+    let candidates = [
+        Node::List(vec![
+            Node::Leaf(op.to_string()),
+            left.clone(),
+            right.clone(),
+        ]),
+        Node::List(vec![
+            left.clone(),
+            Node::Leaf(op.to_string()),
+            right.clone(),
+        ]),
+    ];
+    for candidate in candidates {
+        let key = key_of(&candidate);
+        if let Some(&value) = env.assign.get(&key) {
+            env.trace("lookup", format!("{} → {}", key, format_trace_value(value)));
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn same_normalized_input(left: &Node, right: &Node, left_term: &Node, right_term: &Node) -> bool {
+    is_structurally_same(left, left_term) && is_structurally_same(right, right_term)
+}
+
+fn explicit_symbol_number(node: &Node, env: &Env) -> Option<f64> {
+    if let Node::Leaf(name) = node {
+        if let Some(value) = env.symbol_prob.get(name) {
+            return Some(*value);
+        }
+        let resolved = env.resolve_qualified(name);
+        if resolved != *name {
+            return env.symbol_prob.get(&resolved).copied();
+        }
+    }
+    None
+}
+
+fn try_eval_numeric(node: &Node, env: &mut Env, options: ConvertOptions) -> Option<f64> {
+    let term = normalize_term(node, env, options);
+    match &term {
+        Node::Leaf(s) if is_num(s) => s.parse::<f64>().ok(),
+        Node::Leaf(_) => explicit_symbol_number(&term, env),
+        Node::List(children) if children.is_empty() => None,
+        Node::List(children) => {
+            if children.len() == 3 {
+                if let Node::Leaf(op) = &children[1] {
+                    if matches!(op.as_str(), "+" | "-" | "*" | "/") {
+                        let left = try_eval_numeric(&children[0], env, options)?;
+                        let right = try_eval_numeric(&children[2], env, options)?;
+                        return Some(env.apply_op(op, &[left, right]));
+                    }
+                    if matches!(op.as_str(), "and" | "or" | "both" | "neither") {
+                        let left = try_eval_numeric(&children[0], env, options)?;
+                        let right = try_eval_numeric(&children[2], env, options)?;
+                        let value = env.apply_op(op, &[left, right]);
+                        return Some(env.clamp(value));
+                    }
+                }
+            }
+            if let Node::Leaf(head) = &children[0] {
+                if head != "=" && head != "!=" && env.has_op(head) {
+                    let mut values = Vec::new();
+                    for arg in &children[1..] {
+                        values.push(try_eval_numeric(arg, env, options)?);
+                    }
+                    let value = env.apply_op(head, &values);
+                    return Some(env.clamp(value));
+                }
+            }
+            None
+        }
+    }
+}
+
+fn equality_truth_value(
+    left: &Node,
+    right: &Node,
+    left_term: &Node,
+    right_term: &Node,
+    env: &mut Env,
+    options: ConvertOptions,
+) -> f64 {
+    if let Some(value) = lookup_assigned_infix(env, "=", left, right) {
+        return env.clamp(value);
+    }
+    if !same_normalized_input(left, right, left_term, right_term) {
+        if let Some(value) = lookup_assigned_infix(env, "=", left_term, right_term) {
+            return env.clamp(value);
+        }
+    }
+    if is_structurally_same(left_term, right_term) {
+        return env.hi;
+    }
+    let left_num = try_eval_numeric(left_term, env, options);
+    let right_num = try_eval_numeric(right_term, env, options);
+    if let (Some(left_num), Some(right_num)) = (left_num, right_num) {
+        if dec_round(left_num) == dec_round(right_num) {
+            env.hi
+        } else {
+            env.lo
+        }
+    } else {
+        env.lo
+    }
+}
+
+fn eval_equality_node(left: &Node, op: &str, right: &Node, env: &mut Env) -> EvalResult {
+    let options = ConvertOptions::default();
+    if let Some(value) = lookup_assigned_infix(env, op, left, right) {
+        return EvalResult::Value(env.clamp(value));
+    }
+    let left_term = normalize_term(left, env, options);
+    let right_term = normalize_term(right, env, options);
+    if !same_normalized_input(left, right, &left_term, &right_term) {
+        if let Some(value) = lookup_assigned_infix(env, op, &left_term, &right_term) {
+            return EvalResult::Value(env.clamp(value));
+        }
+    }
+    if op == "=" {
+        let value = equality_truth_value(left, right, &left_term, &right_term, env, options);
+        EvalResult::Value(env.clamp(value))
+    } else {
+        let eq = equality_truth_value(left, right, &left_term, &right_term, env, options);
+        let value = env.apply_op("not", &[eq]);
+        EvalResult::Value(env.clamp(value))
+    }
+}
+
+/// Decide whether two terms are definitionally equal under the current
+/// environment using beta-normalization and explicit equality assignments.
+pub fn is_convertible(left: &Node, right: &Node, env: &mut Env) -> bool {
+    is_convertible_with_options(left, right, env, ConvertOptions::default())
+}
+
+/// Variant of [`is_convertible`] with opt-in conversion features.
+pub fn is_convertible_with_options(
+    left: &Node,
+    right: &Node,
+    env: &mut Env,
+    options: ConvertOptions,
+) -> bool {
+    if let Some(value) = lookup_assigned_infix(env, "=", left, right) {
+        return env.clamp(value) == env.hi;
+    }
+    let left_term = normalize_term(left, env, options);
+    let right_term = normalize_term(right, env, options);
+    if !same_normalized_input(left, right, &left_term, &right_term) {
+        if let Some(value) = lookup_assigned_infix(env, "=", &left_term, &right_term) {
+            return env.clamp(value) == env.hi;
+        }
+    }
+    is_structurally_same(&left_term, &right_term)
+}
+
 fn eval_reduced_term(reduced: &Node, env: &mut Env) -> EvalResult {
-    let term = eval_term_node(reduced, env);
+    let term = normalize_term(reduced, env, ConvertOptions::default());
     if has_unresolved_free_variables(&term, env) {
         EvalResult::Term(term)
     } else {
@@ -2087,95 +2385,10 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             if children.len() == 3 {
                 if let Node::Leaf(ref op_name) = children[1] {
                     if op_name == "=" {
-                        let left_term = eval_term_node(&children[0], env);
-                        let right_term = eval_term_node(&children[2], env);
-                        match env.ops.get("=").cloned() {
-                            Some(Op::Compose { outer, inner }) => {
-                                let inner_val = apply_named_op_on_nodes(
-                                    env,
-                                    &inner,
-                                    &left_term,
-                                    &right_term,
-                                );
-                                let outer_val = env.apply_op(&outer, &[inner_val]);
-                                return EvalResult::Value(env.clamp(outer_val));
-                            }
-                            _ => {
-                                let raw = env.apply_eq(&left_term, &right_term);
-                                // If there's an explicit assignment or structural match, trust it
-                                let k_prefix = key_of(&Node::List(vec![
-                                    Node::Leaf("=".to_string()),
-                                    left_term.clone(),
-                                    right_term.clone(),
-                                ]));
-                                let k_infix = key_of(&Node::List(vec![
-                                    left_term.clone(),
-                                    Node::Leaf("=".to_string()),
-                                    right_term.clone(),
-                                ]));
-                                if env.assign.contains_key(&k_prefix)
-                                    || env.assign.contains_key(&k_infix)
-                                    || is_structurally_same(&left_term, &right_term)
-                                {
-                                    return EvalResult::Value(env.clamp(raw));
-                                }
-                                // No explicit assignment — try numeric comparison (decimal-precision)
-                                let l = eval_arith(&left_term, env);
-                                let r = eval_arith(&right_term, env);
-                                let num_eq = if dec_round(l) == dec_round(r) {
-                                    env.hi
-                                } else {
-                                    env.lo
-                                };
-                                return EvalResult::Value(env.clamp(num_eq));
-                            }
-                        }
+                        return eval_equality_node(&children[0], "=", &children[2], env);
                     }
                     if op_name == "!=" {
-                        let left_term = eval_term_node(&children[0], env);
-                        let right_term = eval_term_node(&children[2], env);
-                        match env.ops.get("!=").cloned() {
-                            Some(Op::Compose { outer, inner }) => {
-                                let inner_val = apply_named_op_on_nodes(
-                                    env,
-                                    &inner,
-                                    &left_term,
-                                    &right_term,
-                                );
-                                let outer_val = env.apply_op(&outer, &[inner_val]);
-                                return EvalResult::Value(env.clamp(outer_val));
-                            }
-                            _ => {
-                                // Check explicit assignment or structural match first
-                                let k_prefix = key_of(&Node::List(vec![
-                                    Node::Leaf("=".to_string()),
-                                    left_term.clone(),
-                                    right_term.clone(),
-                                ]));
-                                let k_infix = key_of(&Node::List(vec![
-                                    left_term.clone(),
-                                    Node::Leaf("=".to_string()),
-                                    right_term.clone(),
-                                ]));
-                                if env.assign.contains_key(&k_prefix)
-                                    || env.assign.contains_key(&k_infix)
-                                    || is_structurally_same(&left_term, &right_term)
-                                {
-                                    let neq = env.apply_neq(&left_term, &right_term);
-                                    return EvalResult::Value(env.clamp(neq));
-                                }
-                                // No explicit assignment — try numeric comparison
-                                let l = eval_arith(&left_term, env);
-                                let r = eval_arith(&right_term, env);
-                                let num_eq = if dec_round(l) == dec_round(r) {
-                                    env.hi
-                                } else {
-                                    env.lo
-                                };
-                                let neq = env.apply_op("not", &[num_eq]);
-                                return EvalResult::Value(env.clamp(neq));
-                            }
-                        }
+                        return eval_equality_node(&children[0], "!=", &children[2], env);
                     }
                 }
             }
@@ -2338,6 +2551,9 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             // Prefix: (not X), (and X Y ...), (or X Y ...)
             if let Node::Leaf(ref head) = children[0] {
                 let head_str = head.clone();
+                if (head_str == "=" || head_str == "!=") && children.len() == 3 {
+                    return eval_equality_node(&children[1], &head_str, &children[2], env);
+                }
                 if env.has_op(&head_str) {
                     let vals: Vec<f64> = children[1..]
                         .iter()
@@ -2384,16 +2600,6 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
 
             EvalResult::Value(0.0)
         }
-    }
-}
-
-/// Helper for applying a named op when dealing with node-based equality.
-fn apply_named_op_on_nodes(env: &mut Env, op_name: &str, left: &Node, right: &Node) -> f64 {
-    let op = env.ops.get(op_name).cloned();
-    match op {
-        Some(Op::Eq) => env.apply_eq(left, right),
-        Some(Op::Neq) => env.apply_neq(left, right),
-        _ => env.lo,
     }
 }
 

--- a/rust/tests/kernel_tests.rs
+++ b/rust/tests/kernel_tests.rs
@@ -4,7 +4,10 @@
 // formation, application by beta-reduction, capture-avoiding substitution,
 // freshness, and type membership/query links.
 
-use rml::{evaluate, RunResult};
+use rml::{
+    eval_node, evaluate, is_convertible, is_convertible_with_options, ConvertOptions, Env, Node,
+    RunResult,
+};
 
 fn evaluate_clean(src: &str) -> Vec<RunResult> {
     let out = evaluate(src, None, None);
@@ -90,6 +93,107 @@ fn applies_lambdas_by_beta_reducing_argument_into_body() {
             RunResult::Num(0.3)
         ]
     );
+}
+
+#[test]
+fn decides_definitional_equality_by_beta_normalizing_terms() {
+    let results = evaluate_clean(
+        r#"
+(? ((apply (lambda (Natural x) x) 0) = 0))
+(? ((pair (apply (lambda (Natural x) x) y)) = (pair y)))
+(? ((pair x) = (pair y)))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.0)
+        ]
+    );
+}
+
+#[test]
+fn uses_explicit_equality_assignments_before_conversion() {
+    let results = evaluate_clean(
+        r#"
+(Natural: (Type 0) Natural)
+(zero: Natural zero)
+(identity: lambda (Natural x) x)
+(((apply identity zero) = zero) has probability 0.5)
+(? ((apply identity zero) = zero))
+"#,
+    );
+    assert_eq!(results, vec![RunResult::Num(0.5)]);
+}
+
+#[test]
+fn exposes_is_convertible_for_beta_assignment_lookup_and_opt_in_eta() {
+    let mut env = Env::new(None);
+    eval_node(
+        &Node::List(vec![
+            Node::Leaf("zero:".into()),
+            Node::Leaf("Natural".into()),
+            Node::Leaf("zero".into()),
+        ]),
+        &mut env,
+    );
+    eval_node(
+        &Node::List(vec![
+            Node::Leaf("identity:".into()),
+            Node::Leaf("lambda".into()),
+            Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("x".into())]),
+            Node::Leaf("x".into()),
+        ]),
+        &mut env,
+    );
+    eval_node(
+        &Node::List(vec![
+            Node::List(vec![
+                Node::Leaf("zero".into()),
+                Node::Leaf("=".into()),
+                Node::Leaf("alias".into()),
+            ]),
+            Node::Leaf("has".into()),
+            Node::Leaf("probability".into()),
+            Node::Leaf("1".into()),
+        ]),
+        &mut env,
+    );
+
+    assert!(is_convertible(
+        &Node::List(vec![
+            Node::Leaf("apply".into()),
+            Node::Leaf("identity".into()),
+            Node::Leaf("zero".into()),
+        ]),
+        &Node::Leaf("zero".into()),
+        &mut env,
+    ));
+    assert!(is_convertible(
+        &Node::Leaf("zero".into()),
+        &Node::Leaf("alias".into()),
+        &mut env,
+    ));
+
+    let eta_lhs = Node::List(vec![
+        Node::Leaf("lambda".into()),
+        Node::List(vec![Node::Leaf("Natural".into()), Node::Leaf("x".into())]),
+        Node::List(vec![
+            Node::Leaf("apply".into()),
+            Node::Leaf("f".into()),
+            Node::Leaf("x".into()),
+        ]),
+    ]);
+    let eta_rhs = Node::Leaf("f".into());
+    assert!(!is_convertible(&eta_lhs, &eta_rhs, &mut env));
+    assert!(is_convertible_with_options(
+        &eta_lhs,
+        &eta_rhs,
+        &mut env,
+        ConvertOptions { eta: true },
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #40

## Summary
- Added JS/Rust convertibility APIs (`isConvertible`, `is_convertible`, `is_convertible_with_options`) with beta-normalization and opt-in eta conversion.
- Routed evaluator equality/inequality through definitional equality while preserving explicit assignment precedence.
- Restricted numeric equality fallback to explicitly numeric/computable terms so unrelated symbolic terms no longer collapse through the default unknown midpoint.
- Added mirrored JS/Rust tests and updated kernel docs/README coverage notes.

## Reproduction And Coverage
The new tests cover nested beta conversion and the previous symbolic false positive:

```lino
(? ((pair (apply (lambda (Natural x) x) y)) = (pair y)))  # -> 1
(? ((pair x) = (pair y)))                                # -> 0
```

They also verify explicit equality assignments override conversion and eta conversion remains opt-in through the API.

## Validation
- `npm test`
- `cargo test`
- `node --test scripts/`
- `git diff --check`