### PR TITLE
[D5] Universe hierarchy as a checked layer

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-02T22:13:13.090Z for PR creation at branch issue-41-698cc57b0f1f for issue https://github.com/link-foundation/relative-meta-logic/issues/41

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-02T22:13:13.090Z for PR creation at branch issue-41-698cc57b0f1f for issue https://github.com/link-foundation/relative-meta-logic/issues/41

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,9 +1,10 @@
 # Typed Kernel
 
 This document specifies the typed-kernel surface implemented by the
-JavaScript and Rust evaluators. It is the D1 contract from issue #37:
-the rules for `Pi`, `lambda`, `apply`, capture-avoiding substitution,
-freshness, type membership with `of`, and type queries with `(type of ...)`.
+JavaScript and Rust evaluators. It covers the D1 contract from issue #37
+and the D5 universe hierarchy from issue #41: the rules for `Pi`, `lambda`,
+`apply`, capture-avoiding substitution, freshness, checked universe levels,
+type membership with `of`, and type queries with `(type of ...)`.
 
 RML remains a dynamic axiomatic system. These rules install and query type
 facts in the evaluator environment; they are not yet a full bidirectional
@@ -52,6 +53,7 @@ The stratified universe form is also supported:
 (Type 0)
 (Type 1)
 (? ((Type 0) of (Type 1)))  # -> hi
+(? ((Type 1) of (Type 0)))  # -> lo
 ```
 
 Universe rule:
@@ -59,6 +61,35 @@ Universe rule:
 ```text
 -------------------------------
 Gamma |- (Type N) : (Type N+1)
+```
+
+Universe membership and type queries infer this rule directly, so callers do
+not need to evaluate `(Type N)` before asking about it:
+
+| Query | Result |
+|-------|--------|
+| `(? ((Type 0) of (Type 1)))` | `hi` |
+| `(? ((Type 1) of (Type 2)))` | `hi` |
+| `(? ((Type 2) of (Type 3)))` | `hi` |
+| `(? ((Type 1) of (Type 0)))` | `lo` |
+| `(? ((Type 2) of (Type 1)))` | `lo` |
+| `(? ((Type 0) of (Type 2)))` | `lo` |
+| `(? (type of (Type 0)))` | `(Type 1)` |
+| `(? (type of (Type 2)))` | `(Type 3)` |
+
+This checked hierarchy is separate from the self-referential root declaration.
+Both modes can coexist in one environment:
+
+```lino
+(Type: Type Type)
+(Natural: (Type 0) Natural)
+(Boolean: Type Boolean)
+
+(? (Type of Type))           # -> hi
+(? (Natural of (Type 0)))    # -> hi
+(? (Boolean of Type))        # -> hi
+(? ((Type 0) of (Type 1)))   # -> hi
+(? ((Type 1) of (Type 0)))   # -> lo
 ```
 
 ## Pi Formation

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -153,6 +153,31 @@ function isStructurallySame(a,b){
   return String(a) === String(b);
 }
 
+function parseUniverseLevelToken(token) {
+  if (typeof token !== 'string' || !/^(0|[1-9]\d*)$/.test(token)) return null;
+  const level = Number(token);
+  return Number.isSafeInteger(level) ? level : null;
+}
+
+function universeTypeKey(node) {
+  if (!Array.isArray(node) || node.length !== 2 || node[0] !== 'Type') return null;
+  const level = parseUniverseLevelToken(node[1]);
+  return level === null ? null : `(Type ${level + 1})`;
+}
+
+function inferTypeKey(node, env) {
+  const recorded = env.getType(node);
+  if (recorded) return recorded;
+
+  const universeType = universeTypeKey(node);
+  if (universeType) {
+    env.setType(node, universeType);
+    return universeType;
+  }
+
+  return null;
+}
+
 // ---------- Quantization for N-valued logics ----------
 // Given N discrete levels and a range [lo, hi], quantize a value to the nearest level.
 // For N=2 (Boolean): levels are {lo, hi} (e.g. {0, 1} or {-1, 1})
@@ -1029,7 +1054,8 @@ function evalNode(node, env){
 
   // Type universe: (Type N) — the sort at universe level N
   if (node.length === 2 && node[0] === 'Type') {
-    const level = isNum(node[1]) ? parseInt(node[1], 10) : 0;
+    const level = parseUniverseLevelToken(node[1]);
+    if (level === null) return 0;
     // (Type N) has type (Type N+1)
     env.setType(node, ['Type', String(level + 1)]);
     return 1; // valid expression
@@ -1112,7 +1138,7 @@ function evalNode(node, env){
   // e.g. (? (type of x)) → returns the type string
   if (node.length === 3 && node[0] === 'type' && node[1] === 'of') {
     const expr = node[2];
-    const typeStr = env.getType(expr);
+    const typeStr = inferTypeKey(expr, env);
     if (typeStr) {
       return { query: true, value: typeStr, typeQuery: true };
     }
@@ -1124,7 +1150,7 @@ function evalNode(node, env){
   if (node.length === 3 && node[1] === 'of') {
     const expr = node[0];
     const expectedType = node[2];
-    const actualType = env.getType(expr);
+    const actualType = inferTypeKey(expr, env);
     if (actualType) {
       const expectedKey = typeof expectedType === 'string' ? expectedType : keyOf(expectedType);
       return actualType === expectedKey ? env.hi : env.lo;

--- a/js/tests/kernel.test.mjs
+++ b/js/tests/kernel.test.mjs
@@ -1,4 +1,4 @@
-// Typed kernel rules for issues #37 and #38.
+// Typed kernel rules for issues #37, #38, and #41.
 //
 // These tests keep the documented D1 surface honest: Pi formation, lambda
 // formation, application by beta-reduction, capture-avoiding substitution,
@@ -117,5 +117,33 @@ describe('kernel typing rules', () => {
 (? ((Type 0) of (Type 1)))
 `);
     assert.deepStrictEqual(results, [1, 1, 'Natural', 1]);
+  });
+
+  it('checks the universe hierarchy directly across adjacent levels', () => {
+    const results = evaluateClean(`
+(? ((Type 0) of (Type 1)))
+(? ((Type 1) of (Type 2)))
+(? ((Type 2) of (Type 3)))
+(? ((Type 1) of (Type 0)))
+(? ((Type 2) of (Type 1)))
+(? ((Type 0) of (Type 2)))
+(? (type of (Type 0)))
+(? (type of (Type 2)))
+`);
+    assert.deepStrictEqual(results, [1, 1, 1, 0, 0, 0, '(Type 1)', '(Type 3)']);
+  });
+
+  it('keeps self-referential Type separate from stratified universes', () => {
+    const results = evaluateClean(`
+(Type: Type Type)
+(Natural: (Type 0) Natural)
+(Boolean: Type Boolean)
+(? (Type of Type))
+(? (Natural of (Type 0)))
+(? (Boolean of Type))
+(? ((Type 0) of (Type 1)))
+(? ((Type 1) of (Type 0)))
+`);
+    assert.deepStrictEqual(results, [1, 1, 1, 1, 0]);
   });
 });

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -471,6 +471,48 @@ pub fn key_of(node: &Node) -> String {
     }
 }
 
+fn parse_universe_level_token(token: &str) -> Option<u64> {
+    if token.is_empty() || !token.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    if token.len() > 1 && token.starts_with('0') {
+        return None;
+    }
+    token.parse::<u64>().ok()
+}
+
+fn universe_type_key(node: &Node) -> Option<String> {
+    let Node::List(children) = node else {
+        return None;
+    };
+    if children.len() != 2 {
+        return None;
+    }
+    let (Node::Leaf(head), Node::Leaf(level_s)) = (&children[0], &children[1]) else {
+        return None;
+    };
+    if head != "Type" {
+        return None;
+    }
+    let level = parse_universe_level_token(level_s)?;
+    Some(format!("(Type {})", level.checked_add(1)?))
+}
+
+fn infer_type_key(node: &Node, env: &mut Env) -> Option<String> {
+    let key = match node {
+        Node::Leaf(s) => s.clone(),
+        other => key_of(other),
+    };
+    if let Some(recorded) = env.get_type(&key) {
+        return Some(recorded.clone());
+    }
+    if let Some(type_key) = universe_type_key(node) {
+        env.set_type(&key, &type_key);
+        return Some(type_key);
+    }
+    None
+}
+
 /// Check structural equality of two nodes.
 pub fn is_structurally_same(a: &Node, b: &Node) -> bool {
     match (a, b) {
@@ -2187,10 +2229,13 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                 if let Node::Leaf(ref first) = children[0] {
                     if first == "Type" {
                         if let Node::Leaf(ref level_s) = children[1] {
-                            let level: i64 = level_s.parse().unwrap_or(0);
-                            let key = key_of(&Node::List(children.clone()));
-                            env.set_type(&key, &format!("(Type {})", level + 1));
-                            return EvalResult::Value(1.0);
+                            if let Some(level) = parse_universe_level_token(level_s) {
+                                if let Some(next_level) = level.checked_add(1) {
+                                    let key = key_of(&Node::List(children.clone()));
+                                    env.set_type(&key, &format!("(Type {})", next_level));
+                                    return EvalResult::Value(1.0);
+                                }
+                            }
                         }
                     }
                 }
@@ -2297,13 +2342,7 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             if children.len() == 3 {
                 if let (Node::Leaf(ref first), Node::Leaf(ref mid)) = (&children[0], &children[1]) {
                     if first == "type" && mid == "of" {
-                        let expr_key = match &children[2] {
-                            Node::Leaf(s) => s.clone(),
-                            other => key_of(other),
-                        };
-                        let type_str = env
-                            .get_type(&expr_key)
-                            .cloned()
+                        let type_str = infer_type_key(&children[2], env)
                             .unwrap_or_else(|| "unknown".to_string());
                         return EvalResult::TypeQuery(type_str);
                     }
@@ -2315,16 +2354,12 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
             if children.len() == 3 {
                 if let Node::Leaf(ref mid) = children[1] {
                     if mid == "of" {
-                        let expr_key = match &children[0] {
-                            Node::Leaf(s) => s.clone(),
-                            other => key_of(other),
-                        };
                         let expected_key = match &children[2] {
                             Node::Leaf(s) => s.clone(),
                             other => key_of(other),
                         };
-                        if let Some(actual) = env.get_type(&expr_key) {
-                            return EvalResult::Value(if *actual == expected_key {
+                        if let Some(actual) = infer_type_key(&children[0], env) {
+                            return EvalResult::Value(if actual == expected_key {
                                 env.hi
                             } else {
                                 env.lo

--- a/rust/tests/kernel_tests.rs
+++ b/rust/tests/kernel_tests.rs
@@ -1,4 +1,4 @@
-// Typed kernel rules for issues #37 and #38.
+// Typed kernel rules for issues #37, #38, and #41.
 //
 // These tests keep the documented D1 surface honest: Pi formation, lambda
 // formation, application by beta-reduction, capture-avoiding substitution,
@@ -194,6 +194,61 @@ fn checks_type_membership_and_returns_stored_types_through_of_links() {
             RunResult::Num(1.0),
             RunResult::Type("Natural".to_string()),
             RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn checks_universe_hierarchy_directly_across_adjacent_levels() {
+    let results = evaluate_clean(
+        r#"
+(? ((Type 0) of (Type 1)))
+(? ((Type 1) of (Type 2)))
+(? ((Type 2) of (Type 3)))
+(? ((Type 1) of (Type 0)))
+(? ((Type 2) of (Type 1)))
+(? ((Type 0) of (Type 2)))
+(? (type of (Type 0)))
+(? (type of (Type 2)))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.0),
+            RunResult::Num(0.0),
+            RunResult::Num(0.0),
+            RunResult::Type("(Type 1)".to_string()),
+            RunResult::Type("(Type 3)".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn keeps_self_referential_type_separate_from_stratified_universes() {
+    let results = evaluate_clean(
+        r#"
+(Type: Type Type)
+(Natural: (Type 0) Natural)
+(Boolean: Type Boolean)
+(? (Type of Type))
+(? (Natural of (Type 0)))
+(? (Boolean of Type))
+(? ((Type 0) of (Type 1)))
+(? ((Type 1) of (Type 0)))
+"#,
+    );
+    assert_eq!(
+        results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.0),
         ]
     );
 }


### PR DESCRIPTION
Fixes #41

## Summary
- Infers stratified universe levels directly in JavaScript and Rust type queries: `(Type N)` checks as a member of `(Type N+1)` without requiring a prior top-level `(Type N)` form.
- Adds mirrored kernel test matrices for adjacent universe levels, reverse-level failures, skipped-level failures, and `(type of (Type N))` queries.
- Documents the checked universe hierarchy and its coexistence with self-referential `(Type: Type Type)` in `docs/KERNEL.md`.

## Reproduction
Before this PR, direct queries like `(? ((Type 0) of (Type 1)))` returned `0`, and `(? (type of (Type 0)))` returned `unknown` unless `(Type 0)` had already been evaluated. The new tests cover those direct queries.

## Tests
- `node --test --test-name-pattern="universe hierarchy|self-referential Type" tests/kernel.test.mjs`
- `cd rust && cargo test --test kernel_tests`
- `cd js && npm test`
- `cd rust && cargo test`
- `cd js && npm run lint:english`
