### PR TITLE
[D15] Mode declarations

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
+# Updated: 2026-05-05T12:10:25.688Z

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -89,6 +89,8 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E022` | Bidirectional checker: application head does not synthesise to a Pi-type. Triggered by `(apply f a)` where `f` lacks a Pi annotation. |
 | `E023` | Bidirectional checker: lambda checked against a non-Pi expected type. Triggered by `check((lambda (A x) body), T)` where `T` is not of the form `(Pi (...) ...)`. |
 | `E024` | Bidirectional checker: malformed binder in a `Pi` or `lambda` form. Triggered when the second child is not a recognisable `(Type x)` or `(x: Type)` pair. |
+| `E030` | Malformed `(mode …)` declaration. Triggered when the relation name is missing or non-symbolic, no mode flags follow it, or a flag other than `+input`, `-output`, or `*either` is supplied. |
+| `E031` | Mode mismatch at a call site. Triggered when a relation with a recorded `(mode …)` declaration is called with the wrong number of arguments, or when an `+input` slot receives a non-ground argument (e.g. an unbound or fresh variable). |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -200,6 +200,11 @@ class Env {
     this.symbolProb = new Map();                // optional symbol priors if you want (x: 0.7)
     this.types = new Map();                     // key(expr) -> type expression (as string)
     this.lambdas = new Map();                   // name -> { param, paramType, body } for named lambdas
+    // Mode declarations (issue #43, D15): each relation may declare an
+    // argument mode pattern via `(mode <name> +input -output ...)`. The
+    // map records the per-argument flag list (`'in'`, `'out'`, `'either'`)
+    // used by the call-site checker to reject mode mismatches.
+    this.modes = new Map();                     // name -> [flag, flag, ...]
     // Namespace state (issue #34): a file can declare `(namespace foo)`, which
     // prefixes every name it subsequently introduces with `foo.`. Imports can
     // be aliased via `(import "x.lino" as a)`, which records `a` -> the
@@ -464,7 +469,7 @@ function parseBindings(binding) {
 const NON_VARIABLE_TOKENS = new Set([
   'lambda', 'Pi', 'fresh', 'in', 'subst', 'apply', 'type', 'of',
   'has', 'probability', 'with', 'proof', 'range', 'valence',
-  'namespace', 'import', 'as', 'is', '?',
+  'namespace', 'import', 'as', 'is', '?', 'mode',
   '+', '-', '*', '/', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
 ]);
 
@@ -1085,6 +1090,84 @@ function evalReducedTerm(reduced, env) {
   return evalNode(term, env);
 }
 
+// ---------- Mode declarations (issue #43, D15) ----------
+// `(mode plus +input +input -output)` records the per-argument mode pattern
+// for relation `plus`. Each flag is normalised to one of:
+//   'in'     — `+input`  : caller must supply a ground argument here
+//   'out'    — `-output` : the relation is expected to produce a value here
+//   'either' — `*either` : no directionality constraint
+// Any other token is rejected with a structured `E030` diagnostic at the
+// declaration site so the parser does not silently accept typos.
+const MODE_FLAG_TOKENS = {
+  '+input': 'in',
+  '-output': 'out',
+  '*either': 'either',
+};
+
+function parseModeFlag(token) {
+  if (typeof token !== 'string') return null;
+  return Object.prototype.hasOwnProperty.call(MODE_FLAG_TOKENS, token)
+    ? MODE_FLAG_TOKENS[token]
+    : null;
+}
+
+function parseModeForm(node) {
+  if (!Array.isArray(node) || node.length < 2) return null;
+  if (node[0] !== 'mode') return null;
+  if (typeof node[1] !== 'string') {
+    throw new RmlError('E030', 'Mode declaration: relation name must be a bare symbol');
+  }
+  const name = node[1];
+  if (node.length < 3) {
+    throw new RmlError('E030', `Mode declaration for "${name}" must list at least one mode flag`);
+  }
+  const flags = [];
+  for (let i = 2; i < node.length; i++) {
+    const flag = parseModeFlag(node[i]);
+    if (flag === null) {
+      throw new RmlError('E030', `Mode declaration for "${name}": unknown flag "${node[i]}" (expected +input, -output, or *either)`);
+    }
+    flags.push(flag);
+  }
+  return { name, flags };
+}
+
+// Decide whether an argument occupying a `+input` slot is "ground" enough.
+// A ground argument has no free variables that the env cannot evaluate —
+// numeric literals, declared terms, and known symbols are all fine; a fresh
+// or otherwise unbound name is not.
+function isGroundForMode(arg, env) {
+  if (typeof arg === 'string') {
+    if (isNum(arg)) return true;
+    return contextHasName(env, arg);
+  }
+  if (!Array.isArray(arg)) return true;
+  return !hasUnresolvedFreeVariables(arg, env);
+}
+
+// Check a call site `(name args...)` against any registered mode declaration
+// for `name`. Returns the offending RmlError on mismatch, or `null` when the
+// call is consistent (or no declaration exists).
+function checkModeAtCall(name, args, env) {
+  const flags = env.modes.get(name);
+  if (!flags) return null;
+  if (args.length !== flags.length) {
+    return new RmlError(
+      'E031',
+      `Mode mismatch for "${name}": expected ${flags.length} argument${flags.length === 1 ? '' : 's'}, got ${args.length}`,
+    );
+  }
+  for (let i = 0; i < flags.length; i++) {
+    if (flags[i] === 'in' && !isGroundForMode(args[i], env)) {
+      return new RmlError(
+        'E031',
+        `Mode mismatch for "${name}": argument ${i + 1} (+input) is not ground`,
+      );
+    }
+  }
+  return null;
+}
+
 function contextHasName(env, name) {
   if (env.terms.has(name) || env.types.has(name) || env.lambdas.has(name) || env.symbolProb.has(name) || env.ops.has(name)) {
     return true;
@@ -1138,6 +1221,26 @@ function evalNode(node, env){
   }
   // Note: (x : A) with spaces as a standalone colon separator is NOT supported.
   // Use (x: A) instead — the colon must be part of the link name.
+
+  // Mode declaration (issue #43, D15): (mode <name> +input -output ...)
+  // Records the per-argument mode pattern for a relation. Validation lives
+  // in `parseModeForm`, which throws `E030` on a malformed declaration.
+  if (node[0] === 'mode') {
+    const decl = parseModeForm(node);
+    if (decl) {
+      env.modes.set(decl.name, decl.flags);
+      return 1;
+    }
+  }
+
+  // Mode-mismatch check (issue #43, D15): a call `(name args...)` whose
+  // head has a registered mode declaration must agree with the declared
+  // flags. The check runs before the head's evaluation so the diagnostic
+  // points at the call rather than at a downstream beta-reduction.
+  if (typeof node[0] === 'string' && env.modes.has(node[0])) {
+    const err = checkModeAtCall(node[0], node.slice(1), env);
+    if (err) throw err;
+  }
 
   // Assignment: ((expr) has probability p)
   if (node.length === 4 && node[1] === 'has' && node[2] === 'probability' && isNum(node[3])) {

--- a/js/tests/modes.test.mjs
+++ b/js/tests/modes.test.mjs
@@ -1,0 +1,101 @@
+// Tests for mode declarations (issue #43, D15).
+// Covers parsing of `(mode <name> +input -output ...)`, storage on the Env,
+// and the mode-mismatch checker that fires at call sites. The Rust suite
+// mirrors these cases in rust/tests/modes_tests.rs to keep the two
+// implementations in lock-step.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { evaluate, Env } from '../src/rml-links.mjs';
+
+describe('(mode ...) declarations are parsed and stored', () => {
+  it('records the per-argument flag list on the Env', () => {
+    const env = new Env();
+    const out = evaluate('(mode plus +input +input -output)', { env });
+    assert.strictEqual(out.diagnostics.length, 0);
+    assert.deepStrictEqual(env.modes.get('plus'), ['in', 'in', 'out']);
+  });
+
+  it('accepts the *either flag', () => {
+    const env = new Env();
+    const out = evaluate('(mode lookup +input *either -output)', { env });
+    assert.strictEqual(out.diagnostics.length, 0);
+    assert.deepStrictEqual(env.modes.get('lookup'), ['in', 'either', 'out']);
+  });
+});
+
+describe('(mode ...) rejects malformed declarations with E030', () => {
+  it('rejects unknown flag tokens', () => {
+    const out = evaluate('(mode plus +input ~maybe -output)');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E030');
+    assert.match(out.diagnostics[0].message, /unknown flag "~maybe"/);
+  });
+
+  it('rejects a declaration with no flags', () => {
+    const out = evaluate('(mode plus)');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E030');
+    assert.match(out.diagnostics[0].message, /at least one mode flag/);
+  });
+
+  it('rejects a non-symbolic relation name', () => {
+    const out = evaluate('(mode (foo bar) +input -output)');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E030');
+    assert.match(out.diagnostics[0].message, /must be a bare symbol/);
+  });
+});
+
+describe('mode mismatches fire E031 at call sites', () => {
+  it('rejects a call with the wrong arity', () => {
+    const out = evaluate(
+      '(mode plus +input +input -output)\n(? (plus 1 2))',
+    );
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 1);
+    assert.match(e031[0].message, /expected 3 arguments, got 2/);
+  });
+
+  it('rejects a +input slot supplied with an unbound variable', () => {
+    const out = evaluate(
+      '(mode plus +input +input -output)\n(? (plus 1 unbound result))',
+    );
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 1);
+    assert.match(e031[0].message, /argument 2 \(\+input\) is not ground/);
+  });
+
+  it('accepts a call where every +input is ground', () => {
+    const out = evaluate(
+      '(Natural: Type Natural)\n' +
+      '(zero: Natural zero)\n' +
+      '(mode plus +input +input -output)\n' +
+      '(? (plus zero zero result))',
+    );
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 0);
+  });
+
+  it('treats numeric literals in +input slots as ground', () => {
+    const out = evaluate(
+      '(mode plus +input +input -output)\n(? (plus 1 2 result))',
+    );
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 0);
+  });
+
+  it('lets *either slots accept anything, even unbound names', () => {
+    const out = evaluate(
+      '(mode lookup *either *either)\n(? (lookup whatever else))',
+    );
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 0);
+  });
+
+  it('does not flag relations that have no mode declaration', () => {
+    const out = evaluate('(? (mystery a b c))');
+    const e031 = out.diagnostics.filter(d => d.code === 'E031');
+    assert.strictEqual(e031.length, 0);
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -690,6 +690,33 @@ pub struct Env {
     pub imported: HashSet<String>,
     pub shadow_diagnostics: Vec<Diagnostic>,
     pub file_namespaces: HashMap<PathBuf, String>,
+    /// Mode declarations (issue #43, D15): each relation may declare an
+    /// argument mode pattern via `(mode <name> +input -output ...)`. The
+    /// map records the per-argument flag list used by the call-site checker
+    /// to reject mode mismatches.
+    pub modes: HashMap<String, Vec<ModeFlag>>,
+}
+
+/// Per-argument mode flag for a relation declared via `(mode …)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModeFlag {
+    /// `+input`: caller must supply a ground argument here.
+    In,
+    /// `-output`: the relation is expected to produce a value here.
+    Out,
+    /// `*either`: no directionality constraint.
+    Either,
+}
+
+impl ModeFlag {
+    pub fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "+input" => Some(ModeFlag::In),
+            "-output" => Some(ModeFlag::Out),
+            "*either" => Some(ModeFlag::Either),
+            _ => None,
+        }
+    }
 }
 
 impl Env {
@@ -731,6 +758,7 @@ impl Env {
             imported: HashSet::new(),
             shadow_diagnostics: Vec::new(),
             file_namespaces: HashMap::new(),
+            modes: HashMap::new(),
         };
 
         // Initialize truth constants: true, false, unknown, undefined
@@ -1161,6 +1189,7 @@ fn non_variable_token(s: &str) -> bool {
             | "as"
             | "is"
             | "?"
+            | "mode"
             | "+"
             | "-"
             | "*"
@@ -2713,6 +2742,85 @@ pub fn build_proof(node: &Node, env: &Env) -> Node {
     }
 }
 
+// ---------- Mode declarations (issue #43, D15) ----------
+// `(mode plus +input +input -output)` records the per-argument mode
+// pattern for relation `plus`. `parse_mode_form` validates the shape and
+// returns the normalised `(name, flags)` pair; `check_mode_at_call`
+// inspects every call against any registered declaration. Both surface
+// errors as panics with a recognisable prefix so the existing diagnostic
+// dispatch in `decode_panic_payload` can map them to E030 / E031.
+
+fn parse_mode_form(children: &[Node]) -> Option<(String, Vec<ModeFlag>)> {
+    // Caller already verified `children[0]` is the leaf `mode`.
+    if children.len() < 2 {
+        return None;
+    }
+    let name = match &children[1] {
+        Node::Leaf(s) => s.clone(),
+        _ => panic!("Mode declaration error: relation name must be a bare symbol"),
+    };
+    if children.len() < 3 {
+        panic!(
+            "Mode declaration error: declaration for \"{}\" must list at least one mode flag",
+            name
+        );
+    }
+    let mut flags = Vec::with_capacity(children.len() - 2);
+    for child in &children[2..] {
+        match child {
+            Node::Leaf(token) => match ModeFlag::from_token(token) {
+                Some(flag) => flags.push(flag),
+                None => panic!(
+                    "Mode declaration error: declaration for \"{}\": unknown flag \"{}\" (expected +input, -output, or *either)",
+                    name, token
+                ),
+            },
+            _ => panic!(
+                "Mode declaration error: declaration for \"{}\" contains a non-token flag",
+                name
+            ),
+        }
+    }
+    Some((name, flags))
+}
+
+fn is_ground_for_mode(arg: &Node, env: &Env) -> bool {
+    match arg {
+        Node::Leaf(s) => {
+            if is_num(s) {
+                return true;
+            }
+            env_can_evaluate_name(env, s)
+        }
+        Node::List(_) => !has_unresolved_free_variables(arg, env),
+    }
+}
+
+fn check_mode_at_call(name: &str, args: &[Node], env: &Env) {
+    let flags = match env.modes.get(name) {
+        Some(f) => f.clone(),
+        None => return,
+    };
+    if args.len() != flags.len() {
+        panic!(
+            "Mode mismatch: \"{}\" expected {} argument{}, got {}",
+            name,
+            flags.len(),
+            if flags.len() == 1 { "" } else { "s" },
+            args.len()
+        );
+    }
+    for (i, flag) in flags.iter().enumerate() {
+        if *flag == ModeFlag::In && !is_ground_for_mode(&args[i], env) {
+            panic!(
+                "Mode mismatch: \"{}\" argument {} (+input) is not ground",
+                name,
+                i + 1
+            );
+        }
+    }
+}
+
 /// Evaluate an AST node in the given environment.
 pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
     match node {
@@ -2738,6 +2846,32 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
 
             // Note: (x : A) with spaces as a standalone colon separator is NOT supported.
             // Use (x: A) instead — the colon must be part of the link name.
+
+            // Mode declaration (issue #43, D15): (mode <name> +input -output ...)
+            // Records the per-argument mode pattern for a relation. Validation
+            // lives in `parse_mode_form`, which panics with `Mode declaration
+            // error:` on a malformed declaration so `decode_panic_payload`
+            // surfaces it as E030.
+            if let Node::Leaf(ref head) = children[0] {
+                if head == "mode" {
+                    if let Some((name, flags)) = parse_mode_form(children) {
+                        env.modes.insert(name, flags);
+                        return EvalResult::Value(1.0);
+                    }
+                }
+            }
+
+            // Mode-mismatch check (issue #43, D15): a call `(name args...)`
+            // whose head has a registered mode declaration must agree with the
+            // declared flags. Run before head evaluation so the diagnostic
+            // points at the call site rather than at a downstream reduction.
+            if let Node::Leaf(ref head) = children[0] {
+                if env.modes.contains_key(head) {
+                    let head_owned = head.clone();
+                    let args: Vec<Node> = children[1..].to_vec();
+                    check_mode_at_call(&head_owned, &args, env);
+                }
+            }
 
             // Assignment: ((expr) has probability p)
             if children.len() == 4 {
@@ -4300,6 +4434,16 @@ fn decode_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> (String, Str
         (
             "E010".to_string(),
             raw_msg.replacen("Freshness error: ", "", 1),
+        )
+    } else if raw_msg.starts_with("Mode declaration error:") {
+        (
+            "E030".to_string(),
+            raw_msg.replacen("Mode declaration error: ", "", 1),
+        )
+    } else if raw_msg.starts_with("Mode mismatch:") {
+        (
+            "E031".to_string(),
+            raw_msg.replacen("Mode mismatch: ", "", 1),
         )
     } else {
         ("E000".to_string(), raw_msg)

--- a/rust/tests/modes_tests.rs
+++ b/rust/tests/modes_tests.rs
@@ -1,0 +1,150 @@
+// Tests for mode declarations (issue #43, D15).
+// Mirrors js/tests/modes.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{evaluate, ModeFlag};
+
+#[test]
+fn mode_declaration_records_per_argument_flag_list() {
+    // We need access to the same Env across the declaration to inspect the
+    // recorded modes; `evaluate` builds an env internally, so we use it for
+    // call-site behaviour and assert via a follow-up E031 test below. The
+    // simplest direct check: declare modes and confirm the diagnostics list
+    // is empty.
+    let out = evaluate("(mode plus +input +input -output)", None, None);
+    assert_eq!(out.diagnostics.len(), 0);
+}
+
+#[test]
+fn mode_flag_token_round_trip() {
+    assert_eq!(ModeFlag::from_token("+input"), Some(ModeFlag::In));
+    assert_eq!(ModeFlag::from_token("-output"), Some(ModeFlag::Out));
+    assert_eq!(ModeFlag::from_token("*either"), Some(ModeFlag::Either));
+    assert_eq!(ModeFlag::from_token("+other"), None);
+}
+
+#[test]
+fn mode_declaration_accepts_either_flag() {
+    let out = evaluate("(mode lookup +input *either -output)", None, None);
+    assert_eq!(out.diagnostics.len(), 0);
+}
+
+#[test]
+fn mode_declaration_rejects_unknown_flag_with_e030() {
+    let out = evaluate("(mode plus +input ~maybe -output)", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E030");
+    assert!(
+        d.message.contains("unknown flag \"~maybe\""),
+        "msg was: {}",
+        d.message
+    );
+}
+
+#[test]
+fn mode_declaration_with_no_flags_is_e030() {
+    let out = evaluate("(mode plus)", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E030");
+    assert!(
+        d.message.contains("at least one mode flag"),
+        "msg was: {}",
+        d.message
+    );
+}
+
+#[test]
+fn mode_declaration_with_non_symbolic_name_is_e030() {
+    let out = evaluate("(mode (foo bar) +input -output)", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E030");
+    assert!(
+        d.message.contains("must be a bare symbol"),
+        "msg was: {}",
+        d.message
+    );
+}
+
+#[test]
+fn mode_arity_mismatch_at_call_site_is_e031() {
+    let out = evaluate(
+        "(mode plus +input +input -output)\n(? (plus 1 2))",
+        None,
+        None,
+    );
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert_eq!(e031.len(), 1);
+    assert!(
+        e031[0].message.contains("expected 3 arguments, got 2"),
+        "msg was: {}",
+        e031[0].message
+    );
+}
+
+#[test]
+fn mode_input_with_unbound_variable_is_e031() {
+    let out = evaluate(
+        "(mode plus +input +input -output)\n(? (plus 1 unbound result))",
+        None,
+        None,
+    );
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert_eq!(e031.len(), 1);
+    assert!(
+        e031[0]
+            .message
+            .contains("argument 2 (+input) is not ground"),
+        "msg was: {}",
+        e031[0].message
+    );
+}
+
+#[test]
+fn mode_call_with_only_ground_inputs_is_accepted() {
+    let out = evaluate(
+        "(Natural: Type Natural)\n\
+         (zero: Natural zero)\n\
+         (mode plus +input +input -output)\n\
+         (? (plus zero zero result))",
+        None,
+        None,
+    );
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert!(
+        e031.is_empty(),
+        "unexpected E031 diagnostics: {:?}",
+        e031.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn mode_input_accepts_numeric_literals_as_ground() {
+    let out = evaluate(
+        "(mode plus +input +input -output)\n(? (plus 1 2 result))",
+        None,
+        None,
+    );
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert!(e031.is_empty());
+}
+
+#[test]
+fn mode_either_accepts_anything_including_unbound_names() {
+    let out = evaluate(
+        "(mode lookup *either *either)\n(? (lookup whatever else))",
+        None,
+        None,
+    );
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert!(e031.is_empty());
+}
+
+#[test]
+fn mode_does_not_flag_relations_without_a_declaration() {
+    let out = evaluate("(? (mystery a b c))", None, None);
+    let e031: Vec<_> = out.diagnostics.iter().filter(|d| d.code == "E031").collect();
+    assert!(e031.is_empty());
+}


### PR DESCRIPTION
## Summary
Implements the [D15] mode declarations from issue #43 in both reference runtimes. The parser recognises the LiNo surface form

```
(mode plus +input +input -output)
```

storing the per-argument mode flag list on the evaluator environment, and the checker rejects mode mismatches at call sites.

Each argument may be one of:
- `+input` — must be ground (no unbound/fresh variables) at the call site
- `-output` — no groundness requirement
- `*either` — accepts anything

## What's covered

**Parsing & storage**
- JS: `env.modes` is a `Map<string, ('in'|'out'|'either')[]>`.
- Rust: `Env.modes` is a `HashMap<String, Vec<ModeFlag>>` with a public `ModeFlag` enum (`In`, `Out`, `Either`) and a `from_token` helper.
- `mode` is registered as a non-variable token so it never participates in pattern unification.

**Call-site checker**
- Fires only for relations that have a recorded `(mode …)` declaration — relations without a declaration are unaffected.
- Reports an arity mismatch when the call has the wrong number of arguments.
- Reports an `+input` violation when the corresponding argument contains an unbound free variable.
- Numeric literals are treated as ground.

## New stable diagnostic codes

| Code   | Trigger |
|--------|---------|
| `E030` | Malformed `(mode …)` declaration. The relation name is missing or non-symbolic, no mode flags follow it, or a flag other than `+input`/`-output`/`*either` is supplied. |
| `E031` | Mode mismatch at a call site: wrong number of arguments, or an `+input` slot supplied with a non-ground argument. |

## Tests

- `js/tests/modes.test.mjs` — 11 new tests covering parsing, storage, all three E030 triggers, and all five E031 scenarios.
- `rust/tests/modes_tests.rs` — 12 mirrored Rust tests (adds a `ModeFlag::from_token` round-trip) so any drift between runtimes fails CI.
- Full JS suite: **563/563 passing**.
- Full Rust suite: all suites green (lib + integration + trace + shared examples).

## Documentation

- `docs/DIAGNOSTICS.md` documents codes `E030` and `E031`.

## How to reproduce

```sh
# JS
cd js && npm install && npm test

# Rust
cd rust && cargo test
```

## Test plan
- [x] `cd js && node --test tests/modes.test.mjs` passes (11/11)
- [x] `cd rust && cargo test --test modes_tests` passes (12/12)
- [x] `cd js && node --test tests/` passes (563/563)
- [x] `cd rust && cargo test` passes (all suites)
- [x] `(mode plus +input +input -output)` followed by `(? (plus 1 2))` reports `E031: expected 3 arguments, got 2`
- [x] `(? (mystery a b c))` without a mode declaration reports no `E031`

Fixes #43