### PR TITLE
[D12] Totality checking (Twelf-style)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
+# Updated: 2026-05-05T12:26:07.782Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
-# Updated: 2026-05-05T12:26:07.782Z

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -91,6 +91,7 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E024` | Bidirectional checker: malformed binder in a `Pi` or `lambda` form. Triggered when the second child is not a recognisable `(Type x)` or `(x: Type)` pair. |
 | `E030` | Malformed `(mode …)` declaration. Triggered when the relation name is missing or non-symbolic, no mode flags follow it, or a flag other than `+input`, `-output`, or `*either` is supplied. |
 | `E031` | Mode mismatch at a call site. Triggered when a relation with a recorded `(mode …)` declaration is called with the wrong number of arguments, or when an `+input` slot receives a non-ground argument (e.g. an unbound or fresh variable). |
+| `E032` | Totality / relation-declaration error. Triggered by a malformed `(relation …)` declaration (no clauses, or a clause whose head differs from the relation name); a malformed `(total …)` driver form; or a `(total <name>)` whose recursive calls fail to structurally decrease at least one `+input` argument. The message names the failing clause and quotes the offending recursive call. |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -205,6 +205,12 @@ class Env {
     // map records the per-argument flag list (`'in'`, `'out'`, `'either'`)
     // used by the call-site checker to reject mode mismatches.
     this.modes = new Map();                     // name -> [flag, flag, ...]
+    // Relation declarations (issue #44, D12): a relation is a list of
+    // clauses, each shaped `(<name> arg1 arg2 ... result)`. The totality
+    // checker reads the clauses to verify structural decrease on recursive
+    // calls. Stored as `name -> [clauseNode, clauseNode, ...]`, where each
+    // clauseNode is the original AST list including the head symbol.
+    this.relations = new Map();                 // name -> [clause, clause, ...]
     // Namespace state (issue #34): a file can declare `(namespace foo)`, which
     // prefixes every name it subsequently introduces with `foo.`. Imports can
     // be aliased via `(import "x.lino" as a)`, which records `a` -> the
@@ -469,7 +475,7 @@ function parseBindings(binding) {
 const NON_VARIABLE_TOKENS = new Set([
   'lambda', 'Pi', 'fresh', 'in', 'subst', 'apply', 'type', 'of',
   'has', 'probability', 'with', 'proof', 'range', 'valence',
-  'namespace', 'import', 'as', 'is', '?', 'mode',
+  'namespace', 'import', 'as', 'is', '?', 'mode', 'relation', 'total',
   '+', '-', '*', '/', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
 ]);
 
@@ -1145,6 +1151,157 @@ function isGroundForMode(arg, env) {
   return !hasUnresolvedFreeVariables(arg, env);
 }
 
+// ---------- Relation declarations & totality (issue #44, D12) ----------
+// `(relation <name> <clause>...)` records the clause list of a Twelf-style
+// relation. Each clause is shaped `(<name> arg1 arg2 ... result)`, where
+// `result` is the right-most argument (typically populated for relations
+// whose mode declaration ends with `-output`). The body may contain
+// recursive references to `<name>` whose `+input` slots must be strictly
+// smaller than the head's; the totality checker enforces that decrease.
+//
+// `(total <name>)` triggers `isTotal(env, name)` and lifts the diagnostics
+// it returns into the active diagnostic list. The same `isTotal` helper is
+// also exported for programmatic use.
+function parseRelationForm(node) {
+  if (!Array.isArray(node) || node[0] !== 'relation') return null;
+  if (node.length < 2 || typeof node[1] !== 'string') {
+    throw new RmlError('E032', 'Relation declaration: relation name must be a bare symbol');
+  }
+  const name = node[1];
+  if (node.length < 3) {
+    throw new RmlError('E032', `Relation declaration for "${name}" must list at least one clause`);
+  }
+  const clauses = [];
+  for (let i = 2; i < node.length; i++) {
+    const clause = node[i];
+    if (!Array.isArray(clause) || clause.length < 2 || clause[0] !== name) {
+      throw new RmlError(
+        'E032',
+        `Relation declaration for "${name}": clause ${i - 1} must be a list whose head is "${name}"`,
+      );
+    }
+    clauses.push(clause);
+  }
+  return { name, clauses };
+}
+
+// True when `inner` is a strict subterm of `outer` — i.e. `outer` contains a
+// proper sub-expression structurally identical to `inner`. The relation is
+// strict: identical terms are not subterms of themselves. Used as the
+// structural-decrease witness on recursive calls.
+function isStrictSubterm(inner, outer) {
+  if (!Array.isArray(outer)) return false;
+  for (const child of outer) {
+    if (isStructurallySame(inner, child)) return true;
+    if (isStrictSubterm(inner, child)) return true;
+  }
+  return false;
+}
+
+// Walk `node` and collect every recursive call to `relName` (i.e. every
+// list whose head is `relName`). The clause head itself is excluded so the
+// caller compares recursive calls against the head, not against itself.
+function collectRecursiveCalls(node, relName, isHead) {
+  const out = [];
+  if (!Array.isArray(node)) return out;
+  if (!isHead && node[0] === relName) out.push(node);
+  for (let i = 0; i < node.length; i++) {
+    if (i === 0 && typeof node[i] === 'string') continue;
+    out.push(...collectRecursiveCalls(node[i], relName, false));
+  }
+  return out;
+}
+
+// Check a single recursive call against the clause head. Returns null when
+// at least one `+input` slot is a strict subterm of the head's; otherwise
+// returns a counter-witness description suitable for a diagnostic.
+//
+// Recursive calls inside a clause's output expression (functional style)
+// commonly carry only the `+input` arguments — the output is the sub-tree
+// itself. To accommodate that, the call may either:
+//   - supply every declared slot (`flags.length` arguments), in which case
+//     we compare the corresponding input positions, or
+//   - supply just the input slots (`numInputs` arguments), in which case
+//     we line them up with the head's input positions in order.
+function checkRecursiveDecrease(call, headArgs, flags, relName) {
+  const callArgs = call.slice(1);
+  const inputIndices = [];
+  for (let i = 0; i < flags.length; i++) if (flags[i] === 'in') inputIndices.push(i);
+
+  let inputPairs = null;
+  if (callArgs.length === flags.length) {
+    inputPairs = inputIndices.map(i => [callArgs[i], headArgs[i]]);
+  } else if (callArgs.length === inputIndices.length) {
+    inputPairs = inputIndices.map((i, j) => [callArgs[j], headArgs[i]]);
+  } else {
+    return {
+      reason: `recursive call \`${keyOf(call)}\` has ${callArgs.length} argument${callArgs.length === 1 ? '' : 's'}, expected ${flags.length} (or ${inputIndices.length} input${inputIndices.length === 1 ? '' : 's'})`,
+      call,
+    };
+  }
+
+  if (inputIndices.length === 0) {
+    return {
+      reason: `relation "${relName}" has no \`+input\` slot, so structural decrease is unverifiable`,
+      call,
+    };
+  }
+  for (const [callArg, headArg] of inputPairs) {
+    if (isStrictSubterm(callArg, headArg)) {
+      return null; // decrease witnessed at this input slot
+    }
+  }
+  return {
+    reason: `recursive call \`${keyOf(call)}\` does not structurally decrease any \`+input\` slot of \`${keyOf([relName, ...headArgs])}\``,
+    call,
+  };
+}
+
+// Public-facing totality checker: returns `{ ok, diagnostics }`. When the
+// relation has no declared modes the check is skipped and a single
+// diagnostic is returned so callers can surface the missing prerequisite.
+function isTotal(env, relName) {
+  const diagnostics = [];
+  const clauses = env.relations.get(relName);
+  const flags = env.modes.get(relName);
+  if (!flags) {
+    diagnostics.push({
+      code: 'E032',
+      message: `Totality check for "${relName}": no \`(mode ${relName} ...)\` declaration found`,
+    });
+    return { ok: false, diagnostics };
+  }
+  if (!clauses || clauses.length === 0) {
+    diagnostics.push({
+      code: 'E032',
+      message: `Totality check for "${relName}": no \`(relation ${relName} ...)\` clauses found`,
+    });
+    return { ok: false, diagnostics };
+  }
+  for (let ci = 0; ci < clauses.length; ci++) {
+    const clause = clauses[ci];
+    const headArgs = clause.slice(1);
+    if (headArgs.length !== flags.length) {
+      diagnostics.push({
+        code: 'E032',
+        message: `Totality check for "${relName}": clause ${ci + 1} \`${keyOf(clause)}\` has ${headArgs.length} argument${headArgs.length === 1 ? '' : 's'}, mode declares ${flags.length}`,
+      });
+      continue;
+    }
+    const calls = collectRecursiveCalls(clause, relName, true);
+    for (const call of calls) {
+      const witness = checkRecursiveDecrease(call, headArgs, flags, relName);
+      if (witness) {
+        diagnostics.push({
+          code: 'E032',
+          message: `Totality check for "${relName}": clause ${ci + 1} \`${keyOf(clause)}\` — ${witness.reason}`,
+        });
+      }
+    }
+  }
+  return { ok: diagnostics.length === 0, diagnostics };
+}
+
 // Check a call site `(name args...)` against any registered mode declaration
 // for `name`. Returns the offending RmlError on mismatch, or `null` when the
 // call is consistent (or no declaration exists).
@@ -1231,6 +1388,34 @@ function evalNode(node, env){
       env.modes.set(decl.name, decl.flags);
       return 1;
     }
+  }
+
+  // Relation declaration (issue #44, D12): (relation <name> <clause>...)
+  // Stores the clause list keyed by relation name. `parseRelationForm`
+  // throws E032 on a malformed declaration so the call sites do not have
+  // to handle absent or shape-broken clauses defensively.
+  if (node[0] === 'relation') {
+    const decl = parseRelationForm(node);
+    if (decl) {
+      env.relations.set(decl.name, decl.clauses);
+      return 1;
+    }
+  }
+
+  // Totality check (issue #44, D12): (total <name>) runs `isTotal` over
+  // the recorded relation and turns each returned diagnostic into an
+  // E032 RmlError. The first error short-circuits, mirroring how the
+  // mode checker surfaces a single failure per evaluator step.
+  if (node[0] === 'total' && node.length === 2 && typeof node[1] === 'string') {
+    const result = isTotal(env, node[1]);
+    if (!result.ok && result.diagnostics.length > 0) {
+      const first = result.diagnostics[0];
+      throw new RmlError(first.code || 'E032', first.message);
+    }
+    return 1;
+  }
+  if (node[0] === 'total') {
+    throw new RmlError('E032', 'Totality declaration must be `(total <relation-name>)`');
   }
 
   // Mode-mismatch check (issue #43, D15): a call `(name args...)` whose
@@ -2795,6 +2980,7 @@ export {
   substitute,
   synth,
   check,
+  isTotal,
   formalizeSelectedInterpretation,
   evaluateFormalization,
 };

--- a/js/tests/totality.test.mjs
+++ b/js/tests/totality.test.mjs
@@ -1,0 +1,171 @@
+// Tests for totality checking (issue #44, D12).
+// Covers parsing of `(relation <name> <clause>...)`, the `(total <name>)`
+// driver form, and the `isTotal(env, name)` API used by external tools.
+// The Rust suite mirrors these cases in rust/tests/totality_tests.rs.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { evaluate, Env, isTotal } from '../src/rml-links.mjs';
+
+describe('(relation ...) declarations are parsed and stored', () => {
+  it('records the clause list on the Env', () => {
+    const env = new Env();
+    const out = evaluate(
+      '(relation plus\n' +
+      '  (plus zero n n)\n' +
+      '  (plus (succ m) n (succ (plus m n))))',
+      { env },
+    );
+    assert.strictEqual(out.diagnostics.length, 0);
+    const clauses = env.relations.get('plus');
+    assert.strictEqual(clauses.length, 2);
+    assert.deepStrictEqual(clauses[0], ['plus', 'zero', 'n', 'n']);
+    assert.deepStrictEqual(clauses[1], [
+      'plus', ['succ', 'm'], 'n', ['succ', ['plus', 'm', 'n']],
+    ]);
+  });
+
+  it('rejects a relation declaration with no clauses', () => {
+    const out = evaluate('(relation plus)');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E032');
+    assert.match(out.diagnostics[0].message, /at least one clause/);
+  });
+
+  it('rejects a clause whose head differs from the relation name', () => {
+    const out = evaluate('(relation plus (minus zero n n))');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E032');
+    assert.match(out.diagnostics[0].message, /head is "plus"/);
+  });
+});
+
+describe('(total ...) verifies structural decrease', () => {
+  it('accepts `plus` (recursion on the first +input)', () => {
+    const out = evaluate(
+      '(mode plus +input +input -output)\n' +
+      '(relation plus\n' +
+      '  (plus zero n n)\n' +
+      '  (plus (succ m) n (succ (plus m n))))\n' +
+      '(total plus)',
+    );
+    assert.strictEqual(
+      out.diagnostics.length,
+      0,
+      `expected no diagnostics, got: ${JSON.stringify(out.diagnostics)}`,
+    );
+  });
+
+  it('accepts `le` (recursion shrinks both inputs)', () => {
+    const out = evaluate(
+      '(mode le +input +input -output)\n' +
+      '(relation le\n' +
+      '  (le zero n true)\n' +
+      '  (le (succ m) zero false)\n' +
+      '  (le (succ m) (succ n) (le m n)))\n' +
+      '(total le)',
+    );
+    assert.strictEqual(
+      out.diagnostics.length,
+      0,
+      `expected no diagnostics, got: ${JSON.stringify(out.diagnostics)}`,
+    );
+  });
+
+  it('accepts `append` on lists', () => {
+    const out = evaluate(
+      '(mode append +input +input -output)\n' +
+      '(relation append\n' +
+      '  (append nil ys ys)\n' +
+      '  (append (cons x xs) ys (cons x (append xs ys))))\n' +
+      '(total append)',
+    );
+    assert.strictEqual(
+      out.diagnostics.length,
+      0,
+      `expected no diagnostics, got: ${JSON.stringify(out.diagnostics)}`,
+    );
+  });
+
+  it('rejects a relation that recurses without structural decrease', () => {
+    const out = evaluate(
+      '(mode loop +input -output)\n' +
+      '(relation loop\n' +
+      '  (loop zero zero)\n' +
+      '  (loop (succ n) (loop (succ n))))\n' +
+      '(total loop)',
+    );
+    const e032 = out.diagnostics.filter(d => d.code === 'E032');
+    assert.strictEqual(e032.length, 1);
+    assert.match(e032[0].message, /does not structurally decrease/);
+    assert.match(e032[0].message, /\(loop \(succ n\)\)/);
+  });
+
+  it('reports a counter-witness when only one clause fails', () => {
+    const out = evaluate(
+      '(mode bad +input -output)\n' +
+      '(relation bad\n' +
+      '  (bad zero zero)\n' +
+      '  (bad (succ n) (bad n))\n' +    // ok: n < (succ n)
+      '  (bad (succ n) (bad (succ n))))\n' + // bad: same input
+      '(total bad)',
+    );
+    const e032 = out.diagnostics.filter(d => d.code === 'E032');
+    assert.strictEqual(e032.length, 1);
+    assert.match(e032[0].message, /clause 3/);
+  });
+
+  it('rejects a `(total ...)` for an undeclared relation', () => {
+    const out = evaluate('(total mystery)');
+    const e032 = out.diagnostics.filter(d => d.code === 'E032');
+    assert.strictEqual(e032.length, 1);
+    assert.match(e032[0].message, /no `\(mode mystery \.\.\.\)` declaration/);
+  });
+
+  it('rejects a `(total ...)` when modes are present but no clauses are', () => {
+    const out = evaluate(
+      '(mode plus +input +input -output)\n(total plus)',
+    );
+    const e032 = out.diagnostics.filter(d => d.code === 'E032');
+    assert.strictEqual(e032.length, 1);
+    assert.match(e032[0].message, /no `\(relation plus \.\.\.\)` clauses/);
+  });
+
+  it('rejects a malformed `(total ...)`', () => {
+    const out = evaluate('(total plus extra)');
+    const e032 = out.diagnostics.filter(d => d.code === 'E032');
+    assert.strictEqual(e032.length, 1);
+    assert.match(e032[0].message, /must be `\(total <relation-name>\)`/);
+  });
+});
+
+describe('isTotal API surface', () => {
+  it('returns ok=true with empty diagnostics on a total relation', () => {
+    const env = new Env();
+    evaluate(
+      '(mode plus +input +input -output)\n' +
+      '(relation plus\n' +
+      '  (plus zero n n)\n' +
+      '  (plus (succ m) n (succ (plus m n))))',
+      { env },
+    );
+    const result = isTotal(env, 'plus');
+    assert.strictEqual(result.ok, true);
+    assert.deepStrictEqual(result.diagnostics, []);
+  });
+
+  it('returns ok=false with diagnostics when a clause fails to decrease', () => {
+    const env = new Env();
+    evaluate(
+      '(mode loop +input -output)\n' +
+      '(relation loop\n' +
+      '  (loop zero zero)\n' +
+      '  (loop (succ n) (loop (succ n))))',
+      { env },
+    );
+    const result = isTotal(env, 'loop');
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.diagnostics.length, 1);
+    assert.strictEqual(result.diagnostics[0].code, 'E032');
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -695,6 +695,12 @@ pub struct Env {
     /// map records the per-argument flag list used by the call-site checker
     /// to reject mode mismatches.
     pub modes: HashMap<String, Vec<ModeFlag>>,
+    /// Relation declarations (issue #44, D12): the clause list for each
+    /// declared relation, keyed by relation name. Each clause is the
+    /// original AST list `(name arg1 arg2 ... result)`. The totality
+    /// checker reads these clauses to verify structural decrease on
+    /// recursive calls.
+    pub relations: HashMap<String, Vec<Node>>,
 }
 
 /// Per-argument mode flag for a relation declared via `(mode …)`.
@@ -759,6 +765,7 @@ impl Env {
             shadow_diagnostics: Vec::new(),
             file_namespaces: HashMap::new(),
             modes: HashMap::new(),
+            relations: HashMap::new(),
         };
 
         // Initialize truth constants: true, false, unknown, undefined
@@ -2821,6 +2828,247 @@ fn check_mode_at_call(name: &str, args: &[Node], env: &Env) {
     }
 }
 
+// ---------- Relation declarations & totality (issue #44, D12) ----------
+// Mirrors the JavaScript helpers in `js/src/rml-links.mjs`. The
+// `(relation <name> <clause>...)` form stores the clause list per
+// relation, `(total <name>)` triggers `is_total`, and the same
+// `is_total` helper is exported for programmatic callers.
+
+fn parse_relation_form(children: &[Node]) -> (String, Vec<Node>) {
+    // Caller already verified `children[0]` is the leaf `relation`.
+    if children.len() < 2 {
+        panic!("Relation declaration error: relation name must be a bare symbol");
+    }
+    let name = match &children[1] {
+        Node::Leaf(s) => s.clone(),
+        _ => panic!("Relation declaration error: relation name must be a bare symbol"),
+    };
+    if children.len() < 3 {
+        panic!(
+            "Relation declaration error: declaration for \"{}\" must list at least one clause",
+            name
+        );
+    }
+    let mut clauses = Vec::with_capacity(children.len() - 2);
+    for (idx, clause) in children[2..].iter().enumerate() {
+        match clause {
+            Node::List(items) if items.len() >= 2 => match &items[0] {
+                Node::Leaf(head) if *head == name => {
+                    clauses.push(clause.clone());
+                }
+                _ => panic!(
+                    "Relation declaration error: declaration for \"{}\": clause {} must be a list whose head is \"{}\"",
+                    name,
+                    idx + 1,
+                    name
+                ),
+            },
+            _ => panic!(
+                "Relation declaration error: declaration for \"{}\": clause {} must be a list whose head is \"{}\"",
+                name,
+                idx + 1,
+                name
+            ),
+        }
+    }
+    (name, clauses)
+}
+
+fn is_strict_subterm(inner: &Node, outer: &Node) -> bool {
+    if let Node::List(children) = outer {
+        for child in children {
+            if inner == child {
+                return true;
+            }
+            if is_strict_subterm(inner, child) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn collect_recursive_calls(node: &Node, rel_name: &str, is_head: bool, out: &mut Vec<Node>) {
+    if let Node::List(children) = node {
+        if !is_head {
+            if let Some(Node::Leaf(head)) = children.first() {
+                if head == rel_name {
+                    out.push(node.clone());
+                }
+            }
+        }
+        for (i, child) in children.iter().enumerate() {
+            // Skip the head leaf — only descend into argument positions.
+            if i == 0 {
+                if let Node::Leaf(_) = child {
+                    continue;
+                }
+            }
+            collect_recursive_calls(child, rel_name, false, out);
+        }
+    }
+}
+
+/// Per-clause / per-call totality diagnostic returned by [`is_total`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TotalityDiagnostic {
+    pub code: String,
+    pub message: String,
+}
+
+/// Outcome of a totality check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TotalityResult {
+    pub ok: bool,
+    pub diagnostics: Vec<TotalityDiagnostic>,
+}
+
+fn check_recursive_decrease(
+    call: &Node,
+    head_args: &[Node],
+    flags: &[ModeFlag],
+    rel_name: &str,
+) -> Option<String> {
+    let call_args: Vec<Node> = match call {
+        Node::List(items) if !items.is_empty() => items[1..].to_vec(),
+        _ => return Some(format!("recursive call `{}` has no arguments", key_of(call))),
+    };
+    let input_indices: Vec<usize> = flags
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| **f == ModeFlag::In)
+        .map(|(i, _)| i)
+        .collect();
+
+    let pairs: Vec<(&Node, &Node)> = if call_args.len() == flags.len() {
+        input_indices
+            .iter()
+            .map(|&i| (&call_args[i], &head_args[i]))
+            .collect()
+    } else if call_args.len() == input_indices.len() {
+        input_indices
+            .iter()
+            .enumerate()
+            .map(|(j, &i)| (&call_args[j], &head_args[i]))
+            .collect()
+    } else {
+        return Some(format!(
+            "recursive call `{}` has {} argument{}, expected {} (or {} input{})",
+            key_of(call),
+            call_args.len(),
+            if call_args.len() == 1 { "" } else { "s" },
+            flags.len(),
+            input_indices.len(),
+            if input_indices.len() == 1 { "" } else { "s" },
+        ));
+    };
+
+    if input_indices.is_empty() {
+        return Some(format!(
+            "relation \"{}\" has no `+input` slot, so structural decrease is unverifiable",
+            rel_name
+        ));
+    }
+    for (call_arg, head_arg) in &pairs {
+        if is_strict_subterm(call_arg, head_arg) {
+            return None;
+        }
+    }
+    let head_with_args = {
+        let mut items = Vec::with_capacity(head_args.len() + 1);
+        items.push(Node::Leaf(rel_name.to_string()));
+        items.extend(head_args.iter().cloned());
+        Node::List(items)
+    };
+    Some(format!(
+        "recursive call `{}` does not structurally decrease any `+input` slot of `{}`",
+        key_of(call),
+        key_of(&head_with_args)
+    ))
+}
+
+/// Public totality checker. Returns a [`TotalityResult`] with structured
+/// diagnostics; callers can either propagate them as-is or convert each
+/// entry into a [`Diagnostic`] for the existing pipeline. The mirrored JS
+/// helper is exported under the same name (`isTotal`) and produces an
+/// equivalent shape so downstream tools see consistent output.
+pub fn is_total(env: &Env, rel_name: &str) -> TotalityResult {
+    let mut diagnostics: Vec<TotalityDiagnostic> = Vec::new();
+    let flags = match env.modes.get(rel_name) {
+        Some(f) => f.clone(),
+        None => {
+            diagnostics.push(TotalityDiagnostic {
+                code: "E032".to_string(),
+                message: format!(
+                    "Totality check for \"{}\": no `(mode {} ...)` declaration found",
+                    rel_name, rel_name
+                ),
+            });
+            return TotalityResult {
+                ok: false,
+                diagnostics,
+            };
+        }
+    };
+    let clauses: Vec<Node> = match env.relations.get(rel_name) {
+        Some(c) if !c.is_empty() => c.clone(),
+        _ => {
+            diagnostics.push(TotalityDiagnostic {
+                code: "E032".to_string(),
+                message: format!(
+                    "Totality check for \"{}\": no `(relation {} ...)` clauses found",
+                    rel_name, rel_name
+                ),
+            });
+            return TotalityResult {
+                ok: false,
+                diagnostics,
+            };
+        }
+    };
+    for (ci, clause) in clauses.iter().enumerate() {
+        let head_args: Vec<Node> = match clause {
+            Node::List(items) if !items.is_empty() => items[1..].to_vec(),
+            _ => continue,
+        };
+        if head_args.len() != flags.len() {
+            diagnostics.push(TotalityDiagnostic {
+                code: "E032".to_string(),
+                message: format!(
+                    "Totality check for \"{}\": clause {} `{}` has {} argument{}, mode declares {}",
+                    rel_name,
+                    ci + 1,
+                    key_of(clause),
+                    head_args.len(),
+                    if head_args.len() == 1 { "" } else { "s" },
+                    flags.len(),
+                ),
+            });
+            continue;
+        }
+        let mut calls: Vec<Node> = Vec::new();
+        collect_recursive_calls(clause, rel_name, true, &mut calls);
+        for call in &calls {
+            if let Some(reason) = check_recursive_decrease(call, &head_args, &flags, rel_name) {
+                diagnostics.push(TotalityDiagnostic {
+                    code: "E032".to_string(),
+                    message: format!(
+                        "Totality check for \"{}\": clause {} `{}` — {}",
+                        rel_name,
+                        ci + 1,
+                        key_of(clause),
+                        reason
+                    ),
+                });
+            }
+        }
+    }
+    TotalityResult {
+        ok: diagnostics.is_empty(),
+        diagnostics,
+    }
+}
+
 /// Evaluate an AST node in the given environment.
 pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
     match node {
@@ -2858,6 +3106,40 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                         env.modes.insert(name, flags);
                         return EvalResult::Value(1.0);
                     }
+                }
+            }
+
+            // Relation declaration (issue #44, D12): (relation <name> <clause>...)
+            // Stores the clause list keyed by relation name. `parse_relation_form`
+            // panics with `Relation declaration error:` on a malformed
+            // declaration so `decode_panic_payload` surfaces it as E032.
+            if let Node::Leaf(ref head) = children[0] {
+                if head == "relation" {
+                    let (name, clauses) = parse_relation_form(children);
+                    env.relations.insert(name, clauses);
+                    return EvalResult::Value(1.0);
+                }
+            }
+
+            // Totality declaration (issue #44, D12): (total <name>) runs
+            // `is_total` and surfaces the first diagnostic via the existing
+            // panic-based dispatch (`Totality check error:` -> E032).
+            if let Node::Leaf(ref head) = children[0] {
+                if head == "total" {
+                    if children.len() == 2 {
+                        if let Node::Leaf(ref rel_name) = children[1] {
+                            let result = is_total(env, rel_name);
+                            if !result.ok {
+                                if let Some(first) = result.diagnostics.first() {
+                                    panic!("Totality check error: {}", first.message);
+                                }
+                            }
+                            return EvalResult::Value(1.0);
+                        }
+                    }
+                    panic!(
+                        "Totality check error: Totality declaration must be `(total <relation-name>)`"
+                    );
                 }
             }
 
@@ -4444,6 +4726,16 @@ fn decode_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> (String, Str
         (
             "E031".to_string(),
             raw_msg.replacen("Mode mismatch: ", "", 1),
+        )
+    } else if raw_msg.starts_with("Relation declaration error:") {
+        (
+            "E032".to_string(),
+            raw_msg.replacen("Relation declaration error: ", "", 1),
+        )
+    } else if raw_msg.starts_with("Totality check error:") {
+        (
+            "E032".to_string(),
+            raw_msg.replacen("Totality check error: ", "", 1),
         )
     } else {
         ("E000".to_string(), raw_msg)

--- a/rust/tests/totality_tests.rs
+++ b/rust/tests/totality_tests.rs
@@ -1,0 +1,249 @@
+// Tests for totality checking (issue #44, D12).
+// Mirrors js/tests/totality.test.mjs so any drift between the two
+// implementations fails both test suites.
+
+use rml::{evaluate, evaluate_with_env, is_total, Env, Node};
+
+#[test]
+fn relation_declaration_records_clauses_on_env() {
+    let mut env = Env::new(None);
+    let out = evaluate_with_env(
+        "(relation plus\n\
+         (plus zero n n)\n\
+         (plus (succ m) n (succ (plus m n))))",
+        None,
+        &mut env,
+    );
+    assert_eq!(out.diagnostics.len(), 0);
+    let clauses = env
+        .relations
+        .get("plus")
+        .expect("plus relation should be recorded");
+    assert_eq!(clauses.len(), 2);
+    // First clause: (plus zero n n).
+    if let Node::List(items) = &clauses[0] {
+        assert_eq!(items.len(), 4);
+    } else {
+        panic!("expected first clause to be a list");
+    }
+}
+
+#[test]
+fn relation_declaration_with_no_clauses_is_e032() {
+    let out = evaluate("(relation plus)", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E032");
+    assert!(
+        d.message.contains("at least one clause"),
+        "msg was: {}",
+        d.message
+    );
+}
+
+#[test]
+fn relation_declaration_with_wrong_head_is_e032() {
+    let out = evaluate("(relation plus (minus zero n n))", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    let d = &out.diagnostics[0];
+    assert_eq!(d.code, "E032");
+    assert!(
+        d.message.contains("head is \"plus\""),
+        "msg was: {}",
+        d.message
+    );
+}
+
+#[test]
+fn total_accepts_plus() {
+    let out = evaluate(
+        "(mode plus +input +input -output)\n\
+         (relation plus\n\
+         (plus zero n n)\n\
+         (plus (succ m) n (succ (plus m n))))\n\
+         (total plus)",
+        None,
+        None,
+    );
+    assert!(
+        out.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        out.diagnostics
+    );
+}
+
+#[test]
+fn total_accepts_le() {
+    let out = evaluate(
+        "(mode le +input +input -output)\n\
+         (relation le\n\
+         (le zero n true)\n\
+         (le (succ m) zero false)\n\
+         (le (succ m) (succ n) (le m n)))\n\
+         (total le)",
+        None,
+        None,
+    );
+    assert!(
+        out.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        out.diagnostics
+    );
+}
+
+#[test]
+fn total_accepts_append() {
+    let out = evaluate(
+        "(mode append +input +input -output)\n\
+         (relation append\n\
+         (append nil ys ys)\n\
+         (append (cons x xs) ys (cons x (append xs ys))))\n\
+         (total append)",
+        None,
+        None,
+    );
+    assert!(
+        out.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        out.diagnostics
+    );
+}
+
+#[test]
+fn total_rejects_relation_without_decrease() {
+    let out = evaluate(
+        "(mode loop +input -output)\n\
+         (relation loop\n\
+         (loop zero zero)\n\
+         (loop (succ n) (loop (succ n))))\n\
+         (total loop)",
+        None,
+        None,
+    );
+    let e032: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "E032")
+        .collect();
+    assert_eq!(e032.len(), 1);
+    assert!(
+        e032[0].message.contains("does not structurally decrease"),
+        "msg was: {}",
+        e032[0].message
+    );
+    assert!(
+        e032[0].message.contains("(loop (succ n))"),
+        "msg was: {}",
+        e032[0].message
+    );
+}
+
+#[test]
+fn total_reports_specific_clause_on_failure() {
+    let out = evaluate(
+        "(mode bad +input -output)\n\
+         (relation bad\n\
+         (bad zero zero)\n\
+         (bad (succ n) (bad n))\n\
+         (bad (succ n) (bad (succ n))))\n\
+         (total bad)",
+        None,
+        None,
+    );
+    let e032: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "E032")
+        .collect();
+    assert_eq!(e032.len(), 1);
+    assert!(
+        e032[0].message.contains("clause 3"),
+        "msg was: {}",
+        e032[0].message
+    );
+}
+
+#[test]
+fn total_for_undeclared_relation_is_e032() {
+    let out = evaluate("(total mystery)", None, None);
+    let e032: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "E032")
+        .collect();
+    assert_eq!(e032.len(), 1);
+    assert!(
+        e032[0].message.contains("no `(mode mystery ...)` declaration"),
+        "msg was: {}",
+        e032[0].message
+    );
+}
+
+#[test]
+fn total_with_modes_but_no_clauses_is_e032() {
+    let out = evaluate(
+        "(mode plus +input +input -output)\n(total plus)",
+        None,
+        None,
+    );
+    let e032: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "E032")
+        .collect();
+    assert_eq!(e032.len(), 1);
+    assert!(
+        e032[0].message.contains("no `(relation plus ...)` clauses"),
+        "msg was: {}",
+        e032[0].message
+    );
+}
+
+#[test]
+fn malformed_total_form_is_e032() {
+    let out = evaluate("(total plus extra)", None, None);
+    let e032: Vec<_> = out
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == "E032")
+        .collect();
+    assert_eq!(e032.len(), 1);
+    assert!(
+        e032[0].message.contains("must be `(total <relation-name>)`"),
+        "msg was: {}",
+        e032[0].message
+    );
+}
+
+#[test]
+fn is_total_api_returns_ok_on_total_relation() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(mode plus +input +input -output)\n\
+         (relation plus\n\
+         (plus zero n n)\n\
+         (plus (succ m) n (succ (plus m n))))",
+        None,
+        &mut env,
+    );
+    let result = is_total(&env, "plus");
+    assert!(result.ok);
+    assert!(result.diagnostics.is_empty());
+}
+
+#[test]
+fn is_total_api_returns_diagnostics_on_failure() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(mode loop +input -output)\n\
+         (relation loop\n\
+         (loop zero zero)\n\
+         (loop (succ n) (loop (succ n))))",
+        None,
+        &mut env,
+    );
+    let result = is_total(&env, "loop");
+    assert!(!result.ok);
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].code, "E032");
+}


### PR DESCRIPTION
## Summary

Implements [D12] Totality checking (Twelf-style) for issue #44. A new
`(total <name>)` driver verifies that a relation's recursive calls
strictly decrease on at least one `+input` argument; the public
`isTotal(env, name)` / `is_total(&env, name)` API exposes the same
check to external tools.

Fixes #44.

## What's new

- `(relation <name> <clause>...)` declares a relation's defining
  clauses. Clauses are stored on the Env (`env.relations` /
  `Env.relations`) so the totality checker can read them.
- `(total <name>)` runs the structural-decrease check using the
  recorded `(mode ...)` flags (#43) and `(relation ...)` clauses
  introduced here. Failures emit `E032` with a counter-witness:
  failing clause index plus the offending recursive call.
- Recursive calls are accepted in two shapes — full relational
  arity (one slot per mode flag) or functional arity (just `+input`
  slots, e.g. `(plus m n)` nested inside `(succ ...)`). Both are
  routed to the same strict-subterm check against the head's
  corresponding `+input` arguments.
- Public API: JS exports `isTotal`; Rust exports `is_total`,
  `TotalityResult`, and `TotalityDiagnostic`.

## Acceptance

The three Twelf-style examples from the issue are checked total:

```lino
(mode plus +input +input -output)
(relation plus
  (plus zero n n)
  (plus (succ m) n (succ (plus m n))))
(total plus)        ; ✓ no diagnostics

(mode le +input +input -output)
(relation le
  (le zero n true)
  (le (succ m) zero false)
  (le (succ m) (succ n) (le m n)))
(total le)          ; ✓ no diagnostics

(mode append +input +input -output)
(relation append
  (append nil ys ys)
  (append (cons x xs) ys (cons x (append xs ys))))
(total append)      ; ✓ no diagnostics
```

Counter-witness on a non-decreasing recursion:

```lino
(mode loop +input -output)
(relation loop
  (loop zero zero)
  (loop (succ n) (loop (succ n))))
(total loop)
; E032: clause 2: recursive call (loop (succ n)) does not structurally
;       decrease any +input argument
```

## Diagnostics

A single new code, `E032`, covers both relation-declaration errors
(no clauses, mismatched head, malformed `(total ...)`, missing
`(mode ...)` or `(relation ...)`) and the structural-decrease failure
itself. `docs/DIAGNOSTICS.md` is updated with the entry.

## Implementation notes

- Both runtimes mirror each other:
  `parseRelationForm` / `parse_relation_form`,
  `isStrictSubterm` / `is_strict_subterm`,
  `collectRecursiveCalls` / `collect_recursive_calls`,
  `checkRecursiveDecrease` / `check_recursive_decrease`,
  `isTotal` / `is_total`.
- Rust uses the project's panic-with-recognisable-prefix pattern;
  `decode_panic_payload` was extended with two new prefixes that
  both map to `E032`.
- `(relation ...)` clauses are stored verbatim — they are not
  evaluated as queries — so the existing mode checker is unaffected.

## Tests

- `js/tests/totality.test.mjs`: 13 tests.
- `rust/tests/totality_tests.rs`: 13 mirrored tests.
- Full JS suite: 576 tests pass. Full Rust suite: 271 tests pass
  (no regressions).

## Test plan

- [x] `node --test js/tests/`
- [x] `cargo test` (run from `rust/`)
- [x] `node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino`
- [x] All three acceptance examples (`plus`, `le`, `append`) pass
- [x] Counter-witness emitted for `(loop (succ n) (loop (succ n)))`
- [x] `isTotal` API returns `{ ok, diagnostics }` in both runtimes