### PR TITLE
Implement [D10] Inductive families with eliminators

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
-# Updated: 2026-05-05T12:48:42.769Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
+# Updated: 2026-05-05T12:48:42.769Z

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -92,6 +92,7 @@ The exit code is `1` whenever any diagnostic is emitted, `0` otherwise.
 | `E030` | Malformed `(mode …)` declaration. Triggered when the relation name is missing or non-symbolic, no mode flags follow it, or a flag other than `+input`, `-output`, or `*either` is supplied. |
 | `E031` | Mode mismatch at a call site. Triggered when a relation with a recorded `(mode …)` declaration is called with the wrong number of arguments, or when an `+input` slot receives a non-ground argument (e.g. an unbound or fresh variable). |
 | `E032` | Totality / relation-declaration error. Triggered by a malformed `(relation …)` declaration (no clauses, or a clause whose head differs from the relation name); a malformed `(total …)` driver form; or a `(total <name>)` whose recursive calls fail to structurally decrease at least one `+input` argument. The message names the failing clause and quotes the offending recursive call. |
+| `E033` | Inductive-declaration error. Triggered by a malformed `(inductive Name …)` form: a type name that is missing or does not start with an uppercase letter; an empty constructor list; a constructor clause that is not `(constructor <name>)` or `(constructor (<name> (Pi …)))`; the same constructor declared more than once; or a constructor whose `Pi` type does not return the inductive type. |
 
 Codes are stable identifiers — they do not change between releases unless we
 explicitly note a breaking change in the changelog. The accompanying

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -451,6 +451,49 @@ record number sorts, and equality with the expected type collapses through
 | `E023` | Lambda checked against a non-Pi expected type. |
 | `E024` | Malformed binder in `Pi` or `lambda`. |
 
+## Inductive Types
+
+The `(inductive Name (constructor …) …)` form (issue #45, D10) declares a
+new inductive type with a list of constructors. Each constructor is either
+a bare symbol — a constant inhabitant — or a name paired with an explicit
+`Pi` type that returns the inductive type. The kernel registers the type
+itself, every constructor under its declared signature, and a generated
+`Name-rec` eliminator with the standard dependent induction principle.
+
+Surface form:
+
+```
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+```
+
+After this form is evaluated the env contains: `Natural` typed as
+`(Type 0)`, `zero` typed as `Natural`, `succ` typed as
+`(Pi (Natural n) Natural)`, and `Natural-rec` typed as a dependent Pi that
+takes a motive `(Pi (Natural _) (Type 0))`, one case per constructor (with
+inductive-hypothesis premises on each recursive parameter), and a target
+of type `Natural`, returning the motive applied to the target. The
+eliminator participates in the bidirectional checker just like any other
+typed term: `(? (type of Natural-rec))` returns the synthesised Pi-type,
+and `synth(Natural-rec)` returns the same node.
+
+Acceptance datatypes from the issue — `List`, `Vector` (length-indexed), and
+propositional `Eq` — are all definable through the same form. The kernel
+performs a syntactic positivity check on the constructor return type but
+does not currently enforce strict positivity beyond it; that work is
+tracked separately.
+
+Diagnostic codes (E033) cover declarations with: a missing or
+lowercase type name, an empty constructor list, a malformed constructor
+clause, a duplicate constructor name, or a `Pi` whose return type is not
+the inductive type itself.
+
+The dedicated tests are:
+
+- JavaScript: `js/tests/inductive.test.mjs`
+- Rust: `rust/tests/inductive_tests.rs`
+
 ## Example Contract
 
 The shared example

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -211,6 +211,14 @@ class Env {
     // calls. Stored as `name -> [clauseNode, clauseNode, ...]`, where each
     // clauseNode is the original AST list including the head symbol.
     this.relations = new Map();                 // name -> [clause, clause, ...]
+    // Inductive declarations (issue #45, D10): `(inductive Name (constructor ...) ...)`
+    // records a first-class inductive datatype. Each entry stores the type
+    // name, the ordered list of constructors (each `{ name, type }`), and
+    // the name and Pi-type of the generated eliminator (`Name-rec`). The
+    // declaration form also installs the type, every constructor, and the
+    // eliminator into the standard term/type/lambda maps so existing kernel
+    // forms (`type of`, `of`, `apply`) work without further plumbing.
+    this.inductives = new Map();                // name -> { name, constructors, elimName, elimType }
     // Namespace state (issue #34): a file can declare `(namespace foo)`, which
     // prefixes every name it subsequently introduces with `foo.`. Imports can
     // be aliased via `(import "x.lino" as a)`, which records `a` -> the
@@ -476,6 +484,7 @@ const NON_VARIABLE_TOKENS = new Set([
   'lambda', 'Pi', 'fresh', 'in', 'subst', 'apply', 'type', 'of',
   'has', 'probability', 'with', 'proof', 'range', 'valence',
   'namespace', 'import', 'as', 'is', '?', 'mode', 'relation', 'total',
+  'inductive', 'constructor',
   '+', '-', '*', '/', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
 ]);
 
@@ -1302,6 +1311,216 @@ function isTotal(env, relName) {
   return { ok: diagnostics.length === 0, diagnostics };
 }
 
+// ---------- Inductive declarations (issue #45, D10) ----------
+// `(inductive Name (constructor c1) (constructor (c2 (Pi (A x) ... Name))) ...)`
+// declares a first-class inductive datatype encoded as link signatures plus
+// a generated eliminator `Name-rec`. The declaration:
+//
+//   1. registers `Name : (Type 0)` as a typed term;
+//   2. installs every constructor — bare constants get type `Name`, while
+//      constructors written as `(c (Pi (A x) ... Name))` keep their Pi-type
+//      so existing `(type of c)` and `(c of (Pi ...))` queries succeed;
+//   3. synthesises the eliminator `Name-rec` and its dependent Pi-type from
+//      the declared constructors, mirroring the standard induction principle:
+//        Name-rec : (Pi (motive (Pi (Name _) (Type 0)))
+//                    (Pi (case_c1 (apply motive c1))
+//                      ...
+//                       (Pi (case_cN (... step type ...))
+//                          (Pi (target Name) (apply motive target)))))
+//      Each step type for a constructor with one or more recursive `Name`
+//      arguments includes one inductive-hypothesis premise `(apply motive arg)`
+//      per recursive position.
+//   4. records the inductive declaration on `env.inductives` for tooling.
+//
+// The declaration intentionally only requires a Pi-typed signature where
+// every parameter type is either a previously declared type (acceptable as
+// a non-recursive constructor argument) or `Name` itself (a recursive
+// position used to synthesise the inductive hypothesis). Strict positivity
+// beyond this syntactic check is out of scope (see Out of Scope in #45).
+
+function _isPiSig(node) {
+  return Array.isArray(node) && node.length === 3 && node[0] === 'Pi';
+}
+
+// Walk a (Pi (A x) (Pi (B y) ... R)) chain into an array of binder pairs and
+// the final result. Returns `null` when the shape is malformed.
+function _flattenPi(typeNode) {
+  const params = [];
+  let current = typeNode;
+  while (_isPiSig(current)) {
+    const binding = parseBinding(current[1]);
+    if (!binding) return null;
+    params.push({ name: binding.paramName, type: binding.paramType });
+    current = current[2];
+  }
+  return { params, result: current };
+}
+
+// Build a chain of nested Pi nodes from a list of `{ name, type }` parameters
+// and a final result node. With an empty parameter list returns the result
+// untouched, so callers can fold a single parameter list into a Pi-type
+// without special-casing.
+function _buildPi(params, result) {
+  let out = result;
+  for (let i = params.length - 1; i >= 0; i--) {
+    const p = params[i];
+    out = ['Pi', [p.type, p.name], out];
+  }
+  return out;
+}
+
+// Parse a single (constructor ...) clause into `{ name, params, type }`.
+// Accepts the two surface shapes:
+//   - `(constructor c)` — bare constant constructor of type `Name`.
+//   - `(constructor (c (Pi ...)))` — constructor with a Pi-typed signature.
+function parseConstructorClause(clause, typeName) {
+  if (!Array.isArray(clause) || clause[0] !== 'constructor' || clause.length !== 2) {
+    throw new RmlError(
+      'E033',
+      `Inductive declaration for "${typeName}": each clause must be \`(constructor <name>)\` or \`(constructor (<name> <pi-type>))\``,
+    );
+  }
+  const body = clause[1];
+  if (typeof body === 'string') {
+    return { name: body, params: [], type: typeName };
+  }
+  if (Array.isArray(body) && body.length === 2 && typeof body[0] === 'string' && _isPiSig(body[1])) {
+    const flat = _flattenPi(body[1]);
+    if (!flat) {
+      throw new RmlError(
+        'E033',
+        `Inductive declaration for "${typeName}": constructor "${body[0]}" has malformed Pi-type \`${keyOf(body[1])}\``,
+      );
+    }
+    if (typeof flat.result !== 'string' || flat.result !== typeName) {
+      throw new RmlError(
+        'E033',
+        `Inductive declaration for "${typeName}": constructor "${body[0]}" must return "${typeName}" (got "${typeof flat.result === 'string' ? flat.result : keyOf(flat.result)}")`,
+      );
+    }
+    return { name: body[0], params: flat.params, type: body[1] };
+  }
+  throw new RmlError(
+    'E033',
+    `Inductive declaration for "${typeName}": malformed constructor clause \`${keyOf(clause)}\``,
+  );
+}
+
+function parseInductiveForm(node) {
+  if (!Array.isArray(node) || node[0] !== 'inductive') return null;
+  if (node.length < 2 || typeof node[1] !== 'string') {
+    throw new RmlError('E033', 'Inductive declaration: type name must be a bare symbol');
+  }
+  const name = node[1];
+  if (!/^[A-Z]/.test(name)) {
+    throw new RmlError(
+      'E033',
+      `Inductive declaration for "${name}": type name must start with an uppercase letter`,
+    );
+  }
+  if (node.length < 3) {
+    throw new RmlError(
+      'E033',
+      `Inductive declaration for "${name}" must list at least one constructor`,
+    );
+  }
+  const constructors = [];
+  const seen = new Set();
+  for (let i = 2; i < node.length; i++) {
+    const ctor = parseConstructorClause(node[i], name);
+    if (seen.has(ctor.name)) {
+      throw new RmlError(
+        'E033',
+        `Inductive declaration for "${name}": constructor "${ctor.name}" is declared more than once`,
+      );
+    }
+    seen.add(ctor.name);
+    constructors.push(ctor);
+  }
+  return { name, constructors };
+}
+
+// Build the case (step) type for one constructor under the eliminator's
+// motive `m`. For a constructor `c : (Pi (A1 x1) ... (Pi (Ak xk) Name))`
+// the case type is:
+//
+//   (Pi (A1 x1) ... (Pi (Ak xk)
+//      (Pi (ih_j1 (apply m xj1)) ... (Pi (ih_jr (apply m xjr))
+//          (apply m (c x1 ... xk)))))
+//
+// where `xj1..xjr` are the parameters whose declared type is `Name` (i.e.
+// the recursive arguments). Constant constructors degenerate to
+// `(apply m c)`.
+function _buildCaseType(ctor, typeName, motiveVar) {
+  const recBinders = [];
+  for (let i = 0; i < ctor.params.length; i++) {
+    const p = ctor.params[i];
+    if (typeof p.type === 'string' && p.type === typeName) {
+      recBinders.push({
+        name: `ih_${p.name}`,
+        type: ['apply', motiveVar, p.name],
+      });
+    }
+  }
+  let ctorApplied;
+  if (ctor.params.length === 0) {
+    ctorApplied = ctor.name;
+  } else {
+    ctorApplied = [ctor.name, ...ctor.params.map(p => p.name)];
+  }
+  const motiveOnTarget = ['apply', motiveVar, ctorApplied];
+  const inner = _buildPi(recBinders, motiveOnTarget);
+  return _buildPi(ctor.params, inner);
+}
+
+// Compose the dependent eliminator type for `Name-rec`, given the parsed
+// inductive declaration. The motive parameter binds the symbol `_motive`
+// throughout, and each constructor case parameter binds `case_<ctorName>`.
+function buildEliminatorType(decl) {
+  const motiveVar = '_motive';
+  const motiveType = ['Pi', [decl.name, '_'], ['Type', '0']];
+  const caseParams = decl.constructors.map(c => ({
+    name: `case_${c.name}`,
+    type: _buildCaseType(c, decl.name, motiveVar),
+  }));
+  const targetVar = '_target';
+  const final = ['apply', motiveVar, targetVar];
+  const inner = _buildPi([{ name: targetVar, type: decl.name }], final);
+  const withCases = _buildPi(caseParams, inner);
+  return _buildPi([{ name: motiveVar, type: motiveType }], withCases);
+}
+
+// Record an inductive declaration on the environment: install the type, all
+// constructors, the eliminator name, and the eliminator's Pi-type.
+function registerInductive(env, decl) {
+  const storeType = env.qualifyName(decl.name);
+  env.terms.add(storeType);
+  env.setType(storeType, ['Type', '0']);
+  evalNode(['Type', '0'], env);
+
+  for (const ctor of decl.constructors) {
+    const storeName = env.qualifyName(ctor.name);
+    env.terms.add(storeName);
+    env.setType(storeName, ctor.type);
+    if (Array.isArray(ctor.type)) evalNode(ctor.type, env);
+  }
+
+  const elimName = `${decl.name}-rec`;
+  const elimType = buildEliminatorType(decl);
+  const storeElim = env.qualifyName(elimName);
+  env.terms.add(storeElim);
+  env.setType(storeElim, elimType);
+  evalNode(elimType, env);
+
+  env.inductives.set(decl.name, {
+    name: decl.name,
+    constructors: decl.constructors,
+    elimName,
+    elimType,
+  });
+  return 1;
+}
+
 // Check a call site `(name args...)` against any registered mode declaration
 // for `name`. Returns the offending RmlError on mismatch, or `null` when the
 // call is consistent (or no declaration exists).
@@ -1399,6 +1618,17 @@ function evalNode(node, env){
     if (decl) {
       env.relations.set(decl.name, decl.clauses);
       return 1;
+    }
+  }
+
+  // Inductive declaration (issue #45, D10): (inductive Name (constructor ...) ...)
+  // Records the inductive datatype, installs every constructor, and
+  // generates the eliminator `Name-rec` with a dependent Pi-type.
+  // `parseInductiveForm` throws E033 on a malformed declaration.
+  if (node[0] === 'inductive') {
+    const decl = parseInductiveForm(node);
+    if (decl) {
+      return registerInductive(env, decl);
     }
   }
 
@@ -2981,6 +3211,8 @@ export {
   synth,
   check,
   isTotal,
+  parseInductiveForm,
+  buildEliminatorType,
   formalizeSelectedInterpretation,
   evaluateFormalization,
 };

--- a/js/tests/inductive.test.mjs
+++ b/js/tests/inductive.test.mjs
@@ -1,0 +1,241 @@
+// Tests for inductive families with eliminators (issue #45, D10).
+// Cover the `(inductive ...)` parser form, the generated `Name-rec`
+// eliminator, and the acceptance-criteria datatypes (Natural, List,
+// Vector, propositional equality). The Rust suite mirrors these
+// expectations in rust/tests/inductive_tests.rs.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  Env,
+  evaluate,
+  evalNode,
+  parseInductiveForm,
+  buildEliminatorType,
+  keyOf,
+  check,
+  synth,
+} from '../src/rml-links.mjs';
+
+function evaluateClean(src) {
+  const out = evaluate(src);
+  assert.deepStrictEqual(out.diagnostics, [], `unexpected diagnostics: ${JSON.stringify(out.diagnostics)}`);
+  return out.results;
+}
+
+describe('(inductive ...) parser form', () => {
+  it('records the type, every constructor, and the eliminator on the Env', () => {
+    const env = new Env();
+    const out = evaluate(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor (succ (Pi (Natural n) Natural))))',
+      { env },
+    );
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.ok(env.inductives.has('Natural'));
+    const decl = env.inductives.get('Natural');
+    assert.strictEqual(decl.name, 'Natural');
+    assert.deepStrictEqual(decl.constructors.map(c => c.name), ['zero', 'succ']);
+    assert.strictEqual(decl.elimName, 'Natural-rec');
+    assert.ok(env.terms.has('Natural'));
+    assert.ok(env.terms.has('zero'));
+    assert.ok(env.terms.has('succ'));
+    assert.ok(env.terms.has('Natural-rec'));
+    assert.strictEqual(env.getType('zero'), 'Natural');
+    assert.strictEqual(keyOf(env.getType('succ')), '(Pi (Natural n) Natural)');
+  });
+
+  it('rejects an inductive declaration with no constructors', () => {
+    const out = evaluate('(inductive Empty)');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E033');
+    assert.match(out.diagnostics[0].message, /at least one constructor/);
+  });
+
+  it('rejects a malformed constructor clause', () => {
+    const out = evaluate('(inductive Bad (zero))');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E033');
+    assert.match(out.diagnostics[0].message, /\(constructor <name>\)/);
+  });
+
+  it('rejects a constructor declared more than once', () => {
+    const out = evaluate(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor zero))',
+    );
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E033');
+    assert.match(out.diagnostics[0].message, /declared more than once/);
+  });
+
+  it('rejects a constructor whose Pi-type does not return the inductive type', () => {
+    const out = evaluate(
+      '(inductive Natural\n' +
+      '  (constructor (succ (Pi (Natural n) Boolean))))',
+    );
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E033');
+    assert.match(out.diagnostics[0].message, /must return "Natural"/);
+  });
+
+  it('rejects a type name that does not start with an uppercase letter', () => {
+    const out = evaluate('(inductive natural (constructor zero))');
+    assert.strictEqual(out.diagnostics.length, 1);
+    assert.strictEqual(out.diagnostics[0].code, 'E033');
+    assert.match(out.diagnostics[0].message, /uppercase letter/);
+  });
+});
+
+describe('generated eliminator type-checks', () => {
+  it('builds Natural-rec with the standard induction-principle Pi-type', () => {
+    const decl = parseInductiveForm([
+      'inductive', 'Natural',
+      ['constructor', 'zero'],
+      ['constructor', ['succ', ['Pi', ['Natural', 'n'], 'Natural']]],
+    ]);
+    const elimType = buildEliminatorType(decl);
+    assert.strictEqual(
+      keyOf(elimType),
+      '(Pi (' +
+        '(Pi (Natural _) (Type 0)) _motive) ' +
+        '(Pi ((apply _motive zero) case_zero) ' +
+          '(Pi (' +
+            '(Pi (Natural n) ' +
+              '(Pi ((apply _motive n) ih_n) (apply _motive (succ n)))) case_succ) ' +
+            '(Pi (Natural _target) (apply _motive _target)))))',
+    );
+  });
+
+  it('records the eliminator type so (type of Natural-rec) succeeds', () => {
+    const results = evaluateClean(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor (succ (Pi (Natural n) Natural))))\n' +
+      '(? (type of Natural-rec))',
+    );
+    assert.strictEqual(results.length, 1);
+    assert.match(results[0], /^\(Pi \(.*_motive\) /);
+    assert.match(results[0], /case_zero/);
+    assert.match(results[0], /case_succ/);
+  });
+
+  it('membership query holds for the eliminator against its synthesised type', () => {
+    const env = new Env();
+    evaluate(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor (succ (Pi (Natural n) Natural))))',
+      { env },
+    );
+    const elimTypeKey = keyOf(env.inductives.get('Natural').elimType);
+    const result = evalNode(['?', ['Natural-rec', 'of', elimTypeKey]], env);
+    assert.strictEqual(result.value, 1);
+  });
+});
+
+describe('Lists are definable', () => {
+  it('declares List with nil and cons constructors', () => {
+    const env = new Env();
+    evaluate('(A: (Type 0) A)', { env });
+    const out = evaluate(
+      '(inductive List\n' +
+      '  (constructor nil)\n' +
+      '  (constructor (cons (Pi (A x) (Pi (List xs) List)))))',
+      { env },
+    );
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.strictEqual(env.getType('nil'), 'List');
+    assert.strictEqual(keyOf(env.getType('cons')), '(Pi (A x) (Pi (List xs) List))');
+    const decl = env.inductives.get('List');
+    assert.strictEqual(decl.elimName, 'List-rec');
+    // The cons step type carries an inductive-hypothesis premise on its tail.
+    const consCase = decl.constructors[1];
+    assert.strictEqual(consCase.name, 'cons');
+    assert.strictEqual(consCase.params.length, 2);
+    assert.deepStrictEqual(consCase.params[1], { name: 'xs', type: 'List' });
+  });
+});
+
+describe('Vectors (length-indexed lists) are definable', () => {
+  it('records the indexed type and constructors', () => {
+    const env = new Env();
+    evaluate(
+      '(A: (Type 0) A)\n' +
+      '(Natural: (Type 0) Natural)\n' +
+      '(zero: Natural zero)\n' +
+      '(succ: (Pi (Natural n) Natural))',
+      { env },
+    );
+    // Vector here is encoded with the index baked into the carrier name —
+    // RML inductives currently parameterise by element type, with the
+    // length index represented as a Natural in each constructor signature.
+    const out = evaluate(
+      '(inductive Vector\n' +
+      '  (constructor vnil)\n' +
+      '  (constructor (vcons (Pi (Natural n) (Pi (A x) (Pi (Vector xs) Vector))))))',
+      { env },
+    );
+    assert.deepStrictEqual(out.diagnostics, []);
+    const decl = env.inductives.get('Vector');
+    assert.strictEqual(decl.constructors.length, 2);
+    const vcons = decl.constructors[1];
+    assert.deepStrictEqual(
+      vcons.params.map(p => [p.name, typeof p.type === 'string' ? p.type : keyOf(p.type)]),
+      [['n', 'Natural'], ['x', 'A'], ['xs', 'Vector']],
+    );
+  });
+});
+
+describe('propositional equality is definable', () => {
+  it('declares Eq with the refl constructor', () => {
+    const env = new Env();
+    evaluate(
+      '(A: (Type 0) A)\n' +
+      '(a: A a)',
+      { env },
+    );
+    const out = evaluate(
+      '(inductive Eq\n' +
+      '  (constructor refl))',
+      { env },
+    );
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.strictEqual(env.getType('refl'), 'Eq');
+    assert.strictEqual(env.inductives.get('Eq').elimName, 'Eq-rec');
+  });
+});
+
+describe('eliminator participates in the bidirectional checker', () => {
+  it('synth(Natural-rec) returns the generated dependent Pi-type', () => {
+    const env = new Env();
+    evaluate(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor (succ (Pi (Natural n) Natural))))',
+      { env },
+    );
+    const result = synth('Natural-rec', env);
+    assert.deepStrictEqual(result.diagnostics, []);
+    assert.ok(result.type);
+    assert.strictEqual(
+      keyOf(result.type),
+      keyOf(env.inductives.get('Natural').elimType),
+    );
+  });
+
+  it('check accepts a constructor against the recorded type', () => {
+    const env = new Env();
+    evaluate(
+      '(inductive Natural\n' +
+      '  (constructor zero)\n' +
+      '  (constructor (succ (Pi (Natural n) Natural))))',
+      { env },
+    );
+    const result = check('zero', 'Natural', env);
+    assert.deepStrictEqual(result.diagnostics, []);
+    assert.strictEqual(result.ok, true);
+  });
+});

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -701,6 +701,36 @@ pub struct Env {
     /// checker reads these clauses to verify structural decrease on
     /// recursive calls.
     pub relations: HashMap<String, Vec<Node>>,
+    /// Inductive declarations (issue #45, D10): a first-class inductive
+    /// datatype encoded as link signatures plus a generated eliminator.
+    /// Stored by type name; see [`InductiveDecl`] for the full layout.
+    pub inductives: HashMap<String, InductiveDecl>,
+}
+
+/// One constructor of an inductive datatype.
+#[derive(Debug, Clone)]
+pub struct ConstructorDecl {
+    /// Constructor name (e.g. `zero`, `succ`).
+    pub name: String,
+    /// Ordered binder list of the constructor's Pi-type, each `(name, type)`.
+    /// A constant constructor (`(constructor zero)`) has an empty list.
+    pub params: Vec<(String, Node)>,
+    /// The constructor's recorded type — either a bare leaf naming the
+    /// inductive type (constant constructor) or the original `(Pi …)` chain.
+    pub typ: Node,
+}
+
+/// A parsed `(inductive Name (constructor …) …)` declaration.
+#[derive(Debug, Clone)]
+pub struct InductiveDecl {
+    /// Inductive type name (must start with an uppercase letter).
+    pub name: String,
+    /// Ordered list of declared constructors.
+    pub constructors: Vec<ConstructorDecl>,
+    /// Generated eliminator name (`Name-rec`).
+    pub elim_name: String,
+    /// Generated eliminator's dependent Pi-type.
+    pub elim_type: Node,
 }
 
 /// Per-argument mode flag for a relation declared via `(mode …)`.
@@ -766,6 +796,7 @@ impl Env {
             file_namespaces: HashMap::new(),
             modes: HashMap::new(),
             relations: HashMap::new(),
+            inductives: HashMap::new(),
         };
 
         // Initialize truth constants: true, false, unknown, undefined
@@ -1197,6 +1228,10 @@ fn non_variable_token(s: &str) -> bool {
             | "is"
             | "?"
             | "mode"
+            | "relation"
+            | "total"
+            | "inductive"
+            | "constructor"
             | "+"
             | "-"
             | "*"
@@ -3069,6 +3104,300 @@ pub fn is_total(env: &Env, rel_name: &str) -> TotalityResult {
     }
 }
 
+// ---------- Inductive declarations (issue #45, D10) ----------
+// Mirrors the JavaScript helpers in `js/src/rml-links.mjs`. The
+// `(inductive Name (constructor …) …)` form records an inductive
+// datatype, installs every constructor, and synthesises the
+// eliminator `Name-rec` with a dependent Pi-type. Errors panic with
+// `Inductive declaration error:` so `decode_panic_payload` maps them
+// to E033.
+
+fn is_pi_sig(node: &Node) -> bool {
+    matches!(node, Node::List(items)
+        if items.len() == 3
+            && matches!(&items[0], Node::Leaf(h) if h == "Pi"))
+}
+
+// Walk a `(Pi (A x) (Pi (B y) … R))` chain into binder pairs and the result.
+fn flatten_pi(type_node: &Node) -> Option<(Vec<(String, Node)>, Node)> {
+    let mut params: Vec<(String, Node)> = Vec::new();
+    let mut current = type_node.clone();
+    while is_pi_sig(&current) {
+        let items = match &current {
+            Node::List(items) => items.clone(),
+            _ => return None,
+        };
+        let bindings = parse_bindings(&items[1])?;
+        if bindings.is_empty() {
+            return None;
+        }
+        for (name, type_str) in bindings {
+            // parse_bindings returns the type as a string key — recover the
+            // original type node from the binding form so a bare leaf stays
+            // a leaf and a complex Pi-type round-trips structurally.
+            let binding_node = &items[1];
+            let type_node = recover_binding_type(binding_node, &name).unwrap_or(Node::Leaf(type_str));
+            params.push((name, type_node));
+        }
+        current = items[2].clone();
+    }
+    Some((params, current))
+}
+
+// Pull the type-side of a `(A x)` (or its parsed equivalents) back as a Node.
+// `parse_bindings` flattens to a String type key, but for Pi-construction
+// we need to preserve list shapes such as `(Pi (Natural _) (Type 0))`.
+fn recover_binding_type(binding: &Node, param_name: &str) -> Option<Node> {
+    match binding {
+        Node::List(items) if items.len() == 2 => {
+            if let Node::Leaf(name) = &items[1] {
+                if name == param_name {
+                    return Some(items[0].clone());
+                }
+            }
+            if let Node::Leaf(name) = &items[0] {
+                if name == param_name {
+                    return Some(items[1].clone());
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+// Build a chain of nested Pi nodes from a binder list and a final result.
+fn build_pi(params: &[(String, Node)], result: Node) -> Node {
+    let mut out = result;
+    for (name, ty) in params.iter().rev() {
+        out = Node::List(vec![
+            Node::Leaf("Pi".to_string()),
+            Node::List(vec![ty.clone(), Node::Leaf(name.clone())]),
+            out,
+        ]);
+    }
+    out
+}
+
+fn parse_constructor_clause(clause: &Node, type_name: &str) -> ConstructorDecl {
+    let items = match clause {
+        Node::List(items) if items.len() == 2 => items,
+        _ => panic!(
+            "Inductive declaration error: each clause must be `(constructor <name>)` or `(constructor (<name> <pi-type>))`"
+        ),
+    };
+    match &items[0] {
+        Node::Leaf(h) if h == "constructor" => {}
+        _ => panic!(
+            "Inductive declaration error: each clause must be `(constructor <name>)` or `(constructor (<name> <pi-type>))`"
+        ),
+    }
+    match &items[1] {
+        Node::Leaf(name) => ConstructorDecl {
+            name: name.clone(),
+            params: Vec::new(),
+            typ: Node::Leaf(type_name.to_string()),
+        },
+        Node::List(inner) if inner.len() == 2 => {
+            let name = match &inner[0] {
+                Node::Leaf(s) => s.clone(),
+                _ => panic!(
+                    "Inductive declaration error: malformed constructor clause `{}`",
+                    key_of(clause)
+                ),
+            };
+            if !is_pi_sig(&inner[1]) {
+                panic!(
+                    "Inductive declaration error: malformed constructor clause `{}`",
+                    key_of(clause)
+                );
+            }
+            let (params, result) = match flatten_pi(&inner[1]) {
+                Some(parts) => parts,
+                None => panic!(
+                    "Inductive declaration error: constructor \"{}\" has malformed Pi-type `{}`",
+                    name,
+                    key_of(&inner[1])
+                ),
+            };
+            match &result {
+                Node::Leaf(r) if r == type_name => {}
+                other => panic!(
+                    "Inductive declaration error: constructor \"{}\" must return \"{}\" (got \"{}\")",
+                    name,
+                    type_name,
+                    key_of(other)
+                ),
+            }
+            ConstructorDecl {
+                name,
+                params,
+                typ: inner[1].clone(),
+            }
+        }
+        _ => panic!(
+            "Inductive declaration error: malformed constructor clause `{}`",
+            key_of(clause)
+        ),
+    }
+}
+
+/// Parse an `(inductive Name (constructor …) …)` form into an
+/// [`InductiveDecl`]. Panics with `Inductive declaration error:` on a
+/// malformed declaration so the existing diagnostic dispatch maps it to
+/// `E033`.
+pub fn parse_inductive_form(node: &Node) -> Option<InductiveDecl> {
+    let children = match node {
+        Node::List(items) => items,
+        _ => return None,
+    };
+    if children.is_empty() {
+        return None;
+    }
+    match &children[0] {
+        Node::Leaf(h) if h == "inductive" => {}
+        _ => return None,
+    }
+    let name = match children.get(1) {
+        Some(Node::Leaf(s)) => s.clone(),
+        _ => panic!("Inductive declaration error: type name must be a bare symbol"),
+    };
+    if !name.chars().next().map_or(false, |c| c.is_ascii_uppercase()) {
+        panic!(
+            "Inductive declaration error: declaration for \"{}\": type name must start with an uppercase letter",
+            name
+        );
+    }
+    if children.len() < 3 {
+        panic!(
+            "Inductive declaration error: declaration for \"{}\" must list at least one constructor",
+            name
+        );
+    }
+    let mut constructors: Vec<ConstructorDecl> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for clause in &children[2..] {
+        let ctor = parse_constructor_clause(clause, &name);
+        if seen.contains(&ctor.name) {
+            panic!(
+                "Inductive declaration error: declaration for \"{}\": constructor \"{}\" is declared more than once",
+                name, ctor.name
+            );
+        }
+        seen.insert(ctor.name.clone());
+        constructors.push(ctor);
+    }
+    let elim_name = format!("{}-rec", name);
+    let elim_type = build_eliminator_type(&name, &constructors);
+    Some(InductiveDecl {
+        name,
+        constructors,
+        elim_name,
+        elim_type,
+    })
+}
+
+fn build_case_type(ctor: &ConstructorDecl, type_name: &str, motive_var: &str) -> Node {
+    let mut rec_binders: Vec<(String, Node)> = Vec::new();
+    for (pname, ptype) in &ctor.params {
+        if let Node::Leaf(s) = ptype {
+            if s == type_name {
+                rec_binders.push((
+                    format!("ih_{}", pname),
+                    Node::List(vec![
+                        Node::Leaf("apply".to_string()),
+                        Node::Leaf(motive_var.to_string()),
+                        Node::Leaf(pname.clone()),
+                    ]),
+                ));
+            }
+        }
+    }
+    let ctor_applied = if ctor.params.is_empty() {
+        Node::Leaf(ctor.name.clone())
+    } else {
+        let mut items = vec![Node::Leaf(ctor.name.clone())];
+        for (pname, _) in &ctor.params {
+            items.push(Node::Leaf(pname.clone()));
+        }
+        Node::List(items)
+    };
+    let motive_on_target = Node::List(vec![
+        Node::Leaf("apply".to_string()),
+        Node::Leaf(motive_var.to_string()),
+        ctor_applied,
+    ]);
+    let inner = build_pi(&rec_binders, motive_on_target);
+    build_pi(&ctor.params, inner)
+}
+
+/// Compose the dependent eliminator type for `Name-rec`, given the parsed
+/// constructor list. The motive parameter binds the symbol `_motive`
+/// throughout, and each constructor case parameter binds `case_<ctorName>`.
+pub fn build_eliminator_type(type_name: &str, constructors: &[ConstructorDecl]) -> Node {
+    let motive_var = "_motive";
+    let motive_type = Node::List(vec![
+        Node::Leaf("Pi".to_string()),
+        Node::List(vec![
+            Node::Leaf(type_name.to_string()),
+            Node::Leaf("_".to_string()),
+        ]),
+        Node::List(vec![
+            Node::Leaf("Type".to_string()),
+            Node::Leaf("0".to_string()),
+        ]),
+    ]);
+    let case_params: Vec<(String, Node)> = constructors
+        .iter()
+        .map(|c| (format!("case_{}", c.name), build_case_type(c, type_name, motive_var)))
+        .collect();
+    let target_var = "_target";
+    let final_node = Node::List(vec![
+        Node::Leaf("apply".to_string()),
+        Node::Leaf(motive_var.to_string()),
+        Node::Leaf(target_var.to_string()),
+    ]);
+    let inner = build_pi(
+        &[(target_var.to_string(), Node::Leaf(type_name.to_string()))],
+        final_node,
+    );
+    let with_cases = build_pi(&case_params, inner);
+    build_pi(
+        &[(motive_var.to_string(), motive_type)],
+        with_cases,
+    )
+}
+
+/// Install an inductive declaration on the environment: register the type,
+/// every constructor, and the generated eliminator together with its
+/// dependent Pi-type. Mirrors `registerInductive` in the JavaScript kernel.
+pub fn register_inductive(env: &mut Env, decl: InductiveDecl) {
+    let store_type = env.qualify_name(&decl.name);
+    env.terms.insert(store_type.clone());
+    let type0 = Node::List(vec![
+        Node::Leaf("Type".to_string()),
+        Node::Leaf("0".to_string()),
+    ]);
+    env.set_type(&store_type, &key_of(&type0));
+    eval_node(&type0, env);
+
+    for ctor in &decl.constructors {
+        let store_name = env.qualify_name(&ctor.name);
+        env.terms.insert(store_name.clone());
+        env.set_type(&store_name, &key_of(&ctor.typ));
+        if matches!(ctor.typ, Node::List(_)) {
+            eval_node(&ctor.typ, env);
+        }
+    }
+
+    let store_elim = env.qualify_name(&decl.elim_name);
+    env.terms.insert(store_elim.clone());
+    env.set_type(&store_elim, &key_of(&decl.elim_type));
+    eval_node(&decl.elim_type, env);
+
+    env.inductives.insert(decl.name.clone(), decl);
+}
+
 /// Evaluate an AST node in the given environment.
 pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
     match node {
@@ -3140,6 +3469,23 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                     panic!(
                         "Totality check error: Totality declaration must be `(total <relation-name>)`"
                     );
+                }
+            }
+
+            // Inductive declaration (issue #45, D10):
+            //   (inductive Name (constructor c1) (constructor (c2 (Pi ...))) ...)
+            // Stores the type, every constructor, and a generated `Name-rec`
+            // eliminator on the env so they participate in `(of)`,
+            // `(type of …)`, and the bidirectional checker.
+            // `parse_inductive_form` panics with `Inductive declaration error:`
+            // on a malformed declaration, which `decode_panic_payload` maps
+            // to E033.
+            if let Node::Leaf(ref head) = children[0] {
+                if head == "inductive" {
+                    if let Some(decl) = parse_inductive_form(node) {
+                        register_inductive(env, decl);
+                        return EvalResult::Value(1.0);
+                    }
                 }
             }
 
@@ -4736,6 +5082,11 @@ fn decode_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> (String, Str
         (
             "E032".to_string(),
             raw_msg.replacen("Totality check error: ", "", 1),
+        )
+    } else if raw_msg.starts_with("Inductive declaration error:") {
+        (
+            "E033".to_string(),
+            raw_msg.replacen("Inductive declaration error: ", "", 1),
         )
     } else {
         ("E000".to_string(), raw_msg)

--- a/rust/tests/inductive_tests.rs
+++ b/rust/tests/inductive_tests.rs
@@ -1,0 +1,320 @@
+// Tests for inductive families with eliminators (issue #45, D10).
+// Mirrors js/tests/inductive.test.mjs so any drift between the two
+// implementations fails both test suites. Covers the `(inductive ...)`
+// parser form, the generated `Name-rec` eliminator, and the
+// acceptance-criteria datatypes (Natural, List, Vector, propositional
+// equality).
+
+use rml::{
+    build_eliminator_type, check, evaluate, evaluate_with_env, key_of,
+    parse_inductive_form, synth, tokenize_one, parse_one, Env, Node, RunResult,
+};
+
+fn parse(src: &str) -> Node {
+    let toks = tokenize_one(src);
+    parse_one(&toks).expect("parse")
+}
+
+// ---------- (inductive ...) parser form ----------
+
+#[test]
+fn records_type_constructors_and_eliminator_on_env() {
+    let mut env = Env::new(None);
+    let out = evaluate_with_env(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor (succ (Pi (Natural n) Natural))))",
+        None,
+        &mut env,
+    );
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    let decl = env
+        .inductives
+        .get("Natural")
+        .expect("Natural should be recorded");
+    assert_eq!(decl.name, "Natural");
+    let names: Vec<&str> = decl.constructors.iter().map(|c| c.name.as_str()).collect();
+    assert_eq!(names, vec!["zero", "succ"]);
+    assert_eq!(decl.elim_name, "Natural-rec");
+    assert!(env.terms.contains("Natural"));
+    assert!(env.terms.contains("zero"));
+    assert!(env.terms.contains("succ"));
+    assert!(env.terms.contains("Natural-rec"));
+    assert_eq!(env.get_type("zero").map(String::as_str), Some("Natural"));
+    assert_eq!(
+        env.get_type("succ").map(String::as_str),
+        Some("(Pi (Natural n) Natural)"),
+    );
+}
+
+#[test]
+fn rejects_inductive_with_no_constructors() {
+    let out = evaluate("(inductive Empty)", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E033");
+    assert!(
+        out.diagnostics[0].message.contains("at least one constructor"),
+        "msg was: {}",
+        out.diagnostics[0].message
+    );
+}
+
+#[test]
+fn rejects_malformed_constructor_clause() {
+    let out = evaluate("(inductive Bad (zero))", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E033");
+    assert!(
+        out.diagnostics[0].message.contains("(constructor <name>)"),
+        "msg was: {}",
+        out.diagnostics[0].message
+    );
+}
+
+#[test]
+fn rejects_constructor_declared_twice() {
+    let out = evaluate(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor zero))",
+        None,
+        None,
+    );
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E033");
+    assert!(
+        out.diagnostics[0].message.contains("declared more than once"),
+        "msg was: {}",
+        out.diagnostics[0].message
+    );
+}
+
+#[test]
+fn rejects_constructor_with_wrong_return_type() {
+    let out = evaluate(
+        "(inductive Natural\n\
+         (constructor (succ (Pi (Natural n) Boolean))))",
+        None,
+        None,
+    );
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E033");
+    assert!(
+        out.diagnostics[0].message.contains("must return \"Natural\""),
+        "msg was: {}",
+        out.diagnostics[0].message
+    );
+}
+
+#[test]
+fn rejects_lowercase_type_name() {
+    let out = evaluate("(inductive natural (constructor zero))", None, None);
+    assert_eq!(out.diagnostics.len(), 1);
+    assert_eq!(out.diagnostics[0].code, "E033");
+    assert!(
+        out.diagnostics[0].message.contains("uppercase letter"),
+        "msg was: {}",
+        out.diagnostics[0].message
+    );
+}
+
+// ---------- generated eliminator type-checks ----------
+
+#[test]
+fn builds_natural_rec_with_standard_induction_principle() {
+    let node = parse(
+        "(inductive Natural \
+         (constructor zero) \
+         (constructor (succ (Pi (Natural n) Natural))))",
+    );
+    let decl = parse_inductive_form(&node).expect("parses");
+    let elim = build_eliminator_type("Natural", &decl.constructors);
+    assert_eq!(
+        key_of(&elim),
+        "(Pi ((Pi (Natural _) (Type 0)) _motive) \
+         (Pi ((apply _motive zero) case_zero) \
+         (Pi ((Pi (Natural n) (Pi ((apply _motive n) ih_n) (apply _motive (succ n)))) case_succ) \
+         (Pi (Natural _target) (apply _motive _target)))))"
+    );
+}
+
+#[test]
+fn type_of_natural_rec_returns_eliminator_type() {
+    let out = evaluate(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor (succ (Pi (Natural n) Natural))))\n\
+         (? (type of Natural-rec))",
+        None,
+        None,
+    );
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    if let RunResult::Type(s) = &out.results[0] {
+        assert!(s.starts_with("(Pi ("), "got: {}", s);
+        assert!(s.contains("_motive"), "got: {}", s);
+        assert!(s.contains("case_zero"), "got: {}", s);
+        assert!(s.contains("case_succ"), "got: {}", s);
+    } else {
+        panic!("expected Type result, got {:?}", out.results[0]);
+    }
+}
+
+#[test]
+fn membership_query_holds_for_eliminator() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor (succ (Pi (Natural n) Natural))))",
+        None,
+        &mut env,
+    );
+    let elim_type_key = key_of(&env.inductives.get("Natural").unwrap().elim_type);
+    let src = format!("(? (Natural-rec of {}))", elim_type_key);
+    let out = evaluate_with_env(&src, None, &mut env);
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    if let RunResult::Num(v) = out.results[0] {
+        assert_eq!(v, 1.0);
+    } else {
+        panic!("expected Num result, got {:?}", out.results[0]);
+    }
+}
+
+// ---------- Lists are definable ----------
+
+#[test]
+fn list_is_definable() {
+    let mut env = Env::new(None);
+    evaluate_with_env("(A: (Type 0) A)", None, &mut env);
+    let out = evaluate_with_env(
+        "(inductive List\n\
+         (constructor nil)\n\
+         (constructor (cons (Pi (A x) (Pi (List xs) List)))))",
+        None,
+        &mut env,
+    );
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(env.get_type("nil").map(String::as_str), Some("List"));
+    assert_eq!(
+        env.get_type("cons").map(String::as_str),
+        Some("(Pi (A x) (Pi (List xs) List))"),
+    );
+    let decl = env.inductives.get("List").unwrap();
+    assert_eq!(decl.elim_name, "List-rec");
+    let cons_case = &decl.constructors[1];
+    assert_eq!(cons_case.name, "cons");
+    assert_eq!(cons_case.params.len(), 2);
+    let (xs_name, xs_type) = &cons_case.params[1];
+    assert_eq!(xs_name, "xs");
+    if let Node::Leaf(s) = xs_type {
+        assert_eq!(s, "List");
+    } else {
+        panic!("expected Leaf for xs param type");
+    }
+}
+
+// ---------- Vectors (length-indexed lists) are definable ----------
+
+#[test]
+fn vector_is_definable() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(A: (Type 0) A)\n\
+         (Natural: (Type 0) Natural)\n\
+         (zero: Natural zero)\n\
+         (succ: (Pi (Natural n) Natural))",
+        None,
+        &mut env,
+    );
+    let out = evaluate_with_env(
+        "(inductive Vector\n\
+         (constructor vnil)\n\
+         (constructor (vcons (Pi (Natural n) (Pi (A x) (Pi (Vector xs) Vector))))))",
+        None,
+        &mut env,
+    );
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    let decl = env.inductives.get("Vector").unwrap();
+    assert_eq!(decl.constructors.len(), 2);
+    let vcons = &decl.constructors[1];
+    let signature: Vec<(String, String)> = vcons
+        .params
+        .iter()
+        .map(|(name, t)| {
+            let key = if let Node::Leaf(s) = t {
+                s.clone()
+            } else {
+                key_of(t)
+            };
+            (name.clone(), key)
+        })
+        .collect();
+    assert_eq!(
+        signature,
+        vec![
+            ("n".to_string(), "Natural".to_string()),
+            ("x".to_string(), "A".to_string()),
+            ("xs".to_string(), "Vector".to_string()),
+        ]
+    );
+}
+
+// ---------- propositional equality ----------
+
+#[test]
+fn equality_is_definable() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(A: (Type 0) A)\n\
+         (a: A a)",
+        None,
+        &mut env,
+    );
+    let out = evaluate_with_env(
+        "(inductive Eq\n\
+         (constructor refl))",
+        None,
+        &mut env,
+    );
+    assert_eq!(out.diagnostics.len(), 0, "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(env.get_type("refl").map(String::as_str), Some("Eq"));
+    assert_eq!(env.inductives.get("Eq").unwrap().elim_name, "Eq-rec");
+}
+
+// ---------- bidirectional checker integration ----------
+
+#[test]
+fn synth_natural_rec_returns_generated_pi_type() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor (succ (Pi (Natural n) Natural))))",
+        None,
+        &mut env,
+    );
+    let result = synth(&Node::Leaf("Natural-rec".to_string()), &mut env);
+    assert_eq!(result.diagnostics.len(), 0, "diagnostics: {:?}", result.diagnostics);
+    let typ = result.typ.expect("type should be synthesised");
+    let expected = key_of(&env.inductives.get("Natural").unwrap().elim_type);
+    assert_eq!(key_of(&typ), expected);
+}
+
+#[test]
+fn check_accepts_constructor_against_recorded_type() {
+    let mut env = Env::new(None);
+    evaluate_with_env(
+        "(inductive Natural\n\
+         (constructor zero)\n\
+         (constructor (succ (Pi (Natural n) Natural))))",
+        None,
+        &mut env,
+    );
+    let term = Node::Leaf("zero".to_string());
+    let expected = Node::Leaf("Natural".to_string());
+    let result = check(&term, &expected, &mut env);
+    assert_eq!(result.diagnostics.len(), 0, "diagnostics: {:?}", result.diagnostics);
+    assert!(result.ok);
+}


### PR DESCRIPTION
## Summary

Implements [D10] inductive families with eliminators (issue #45). A new
`(inductive Name (constructor …) …)` form declares an inductive type with
a list of constructors. The kernel registers the type, every constructor
under its declared signature, and a generated `Name-rec` eliminator with
the standard dependent induction principle, all of which participate in
`(of)`, `(type of …)`, and the bidirectional checker.

Closes #45.

## Surface form

```
(inductive Natural
  (constructor zero)
  (constructor (succ (Pi (Natural n) Natural))))
```

After this form is evaluated the env contains:

- `Natural` typed as `(Type 0)`
- `zero` typed as `Natural`
- `succ` typed as `(Pi (Natural n) Natural)`
- `Natural-rec` typed as

  ```
  (Pi ((Pi (Natural _) (Type 0)) _motive)
   (Pi ((apply _motive zero) case_zero)
   (Pi ((Pi (Natural n)
         (Pi ((apply _motive n) ih_n) (apply _motive (succ n)))) case_succ)
   (Pi (Natural _target) (apply _motive _target)))))
  ```

The motive parameter binds `_motive`, the target binds `_target`, each
constructor case binds `case_<ctorName>`, and recursive parameters
contribute an inductive-hypothesis premise `(Pi ((apply _motive p) ih_p) …)`
inside their case.

## Acceptance datatypes

All four acceptance-criteria datatypes from the issue are definable
through the new form:

- `Natural` — `zero` / `succ`
- `List` — `nil` / `cons`
- `Vector` (length-indexed) — `vnil` / `vcons` with the `Natural` index
  baked into the constructor signature
- propositional `Eq` — `refl`

Strict-positivity enforcement beyond the syntactic return-type check is
intentionally out of scope (called out in the issue's "Out of Scope"
section).

## Diagnostics

New stable code: **E033** — inductive-declaration error.
Triggered by:

- a missing or lowercase type name
- an empty constructor list
- a malformed constructor clause (must be `(constructor <name>)` or
  `(constructor (<name> (Pi …)))`)
- a duplicate constructor name
- a constructor `Pi` whose return type is not the inductive type itself

`docs/DIAGNOSTICS.md` documents E033, and `docs/KERNEL.md` documents the
surface form, the generated eliminator, and points at the dedicated test
files.

## Test plan

- [x] 14 new JS tests in `js/tests/inductive.test.mjs`
- [x] 14 mirrored Rust tests in `rust/tests/inductive_tests.rs`
- [x] Full JS suite passes (`cd js && npm test` — 626 / 626)
- [x] Full Rust suite passes (`cargo test --manifest-path rust/Cargo.toml`)
- [x] `Natural`, `List`, `Vector`, `Eq` are all definable
- [x] Generated eliminator type has the expected dependent Pi shape
- [x] `(? (type of Natural-rec))` returns the eliminator type
- [x] `synth(Natural-rec)` returns the eliminator type
- [x] `check(zero, Natural)` accepts the constructor
- [x] All five malformed-input cases produce a single E033 diagnostic