### PR TITLE
[C3] Metatheorem checker over encoded systems

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
+# Updated: 2026-05-06T08:09:26.173Z

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 - [Configurability and operator redefinition](./docs/CONFIGURABILITY.md) - Why every operator, truth constant, range, and valence is redefinable at runtime, with the precedence rules and a comparison to Lean/Rocq fixed semantics.
 - [Typed kernel rules](./docs/KERNEL.md) - The implemented D1 rules for `Pi`, `lambda`, `apply`, `(expr of Type)`, and `(type of expr)`.
 - [Soundness statement](./docs/SOUNDNESS.md) - The trusted-kernel guarantee, proof-replay checker, trusted operator base, and aggregator-relative scope of soundness.
+- [Metatheorem checker](./docs/METATHEOREMS.md) - The C3 Twelf-style guarantee that composes D12 totality, D14 coverage, D15 modes, and D13 termination, plus the `rml-meta` CLI.
 
 ## Overview
 

--- a/docs/METATHEOREMS.md
+++ b/docs/METATHEOREMS.md
@@ -1,0 +1,170 @@
+# Metatheorems
+
+This document describes the **C3 metatheorem checker** introduced in
+issue #47. The checker is the Twelf-style guarantee that lets RML reason
+about user-defined formal systems: given a relation declared as a family
+of links plus a totality declaration (D12) and modes (D15), the checker
+verifies that the relation is a total function on its declared input
+domain.
+
+## Building blocks
+
+The checker composes four existing kernel facilities:
+
+| Phase | Form | API | Code |
+|-------|------|-----|------|
+| Mode declaration | `(mode plus +input +input -output)` | `env.modes` | E030/E031 |
+| Coverage check (D14) | `(coverage plus)` | `isCovered` / `is_covered` | E037 |
+| Totality check (D12) | `(total plus)` | `isTotal` / `is_total` | E032 |
+| Termination check (D13) | `(terminating plus)` | `isTerminating` / `is_terminating` | E035 |
+
+The metatheorem checker iterates every relation that has a `(mode ...)`
+declaration plus matching `(relation ...)` clauses and runs **both**
+totality and coverage on it. It also iterates every `(define ...)` in
+the program and runs termination on it. A relation passes only when
+every sub-check passes.
+
+## Surface
+
+A typical input file looks like the canonical Twelf `plus` example:
+
+```lino
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+(mode plus +input +input -output)
+(relation plus
+  (plus zero n n)
+  (plus (succ m) n (succ (plus m n))))
+```
+
+Equivalent surfaces verified end-to-end by the test suite:
+
+- `plus` on `Natural` (recursion on the first `+input`)
+- `le` (less-than-or-equal) on `Natural` (recursion shrinks both inputs)
+- `append` on `List` (recursion on the first list)
+
+## CLI usage
+
+The checker is shipped as a dedicated binary in both runtimes.
+
+JavaScript:
+
+```sh
+cd js
+node src/rml-meta.mjs ../experiments/metatheorem-plus.lino
+# or, when installed via npm
+rml-meta ../experiments/metatheorem-plus.lino
+```
+
+Rust:
+
+```sh
+cd rust
+cargo run --bin rml-meta -- ../experiments/metatheorem-plus.lino
+```
+
+The two CLIs are byte-compatible: each prints the same per-relation
+section and exits with status `0` only when every metatheorem holds.
+
+### Successful run
+
+```
+Relations:
+  OK: plus
+  - totality: pass
+  - coverage: pass
+All metatheorems hold.
+```
+
+Exit code: `0`.
+
+### Failure with counter-witness
+
+A relation that omits the `succ` case for `Natural`:
+
+```lino
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+(mode f +input -output)
+(relation f
+  (f zero zero))
+```
+
+produces:
+
+```
+Relations:
+  FAIL: f
+  - totality: pass
+  - coverage: fail
+      E037 Coverage check for "f": +input slot 1 (type "Natural") missing case for constructor (succ _)
+One or more metatheorems failed.
+```
+
+Exit code: `1`. The diagnostic carries the same stable error code as the
+underlying coverage checker, so editor integrations and CI scripts can
+match on it the same way they match on every other RML diagnostic
+(`docs/DIAGNOSTICS.md`).
+
+A relation that recurses without structural decrease produces:
+
+```
+Relations:
+  FAIL: loop
+  - totality: fail
+      E032 Totality check for "loop": clause 2 `(loop (succ n) (loop (succ n)))` — recursive call `(loop (succ n))` does not structurally decrease any `+input` slot of `(loop (succ n))`
+  - coverage: pass
+One or more metatheorems failed.
+```
+
+A relation can fail multiple sub-checks in a single run; each is
+reported independently so the user sees the full counter-witness set on
+one pass, not just the first failure.
+
+## Programmatic API
+
+JavaScript:
+
+```js
+import { checkMetatheorems, formatReport } from 'relative-meta-logic/src/rml-meta.mjs';
+
+const report = checkMetatheorems(text, { file: 'program.lino' });
+if (!report.ok) {
+  console.error(formatReport(report));
+  process.exit(1);
+}
+```
+
+Rust:
+
+```rust
+use rml::meta::{check_metatheorems, format_report};
+
+let report = check_metatheorems(text, Some("program.lino"));
+if !report.ok {
+    eprintln!("{}", format_report(&report));
+    std::process::exit(1);
+}
+```
+
+Both APIs return a structured report with the same shape:
+
+| Field | JS | Rust |
+|-------|----|------|
+| Overall outcome | `report.ok: bool` | `report.ok: bool` |
+| Evaluation diagnostics | `report.evaluation.diagnostics` | `report.evaluation_diagnostics` |
+| Per-relation results | `report.relations[i].checks[].kind/ok/diagnostics` | identical via `MetatheoremResult` |
+| Per-definition results | `report.definitions[i].checks[].kind/ok/diagnostics` | identical |
+
+## Out of scope
+
+- Proof of totality for **non-structurally-decreasing** definitions —
+  the `(define ...)` form already supports lexicographic measures via
+  D13 (issue #49). The metatheorem checker reuses that infrastructure
+  rather than introducing its own proof obligation.
+- Multi-relation mutual recursion. The current iteration verifies one
+  relation at a time; mutual termination is delegated to D13's
+  measure-based checker, which already accepts mutually-recursive
+  definitions when an explicit `(measure (lex ...))` is supplied.

--- a/experiments/metatheorem-bad.lino
+++ b/experiments/metatheorem-bad.lino
@@ -1,0 +1,6 @@
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+(mode bad +input -output)
+(relation bad
+  (bad zero zero))

--- a/experiments/metatheorem-plus.lino
+++ b/experiments/metatheorem-plus.lino
@@ -1,0 +1,9 @@
+; Sample program for the C3 metatheorem checker.
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+(mode plus +input +input -output)
+(relation plus
+  (plus zero n n)
+  (plus (succ m) n (succ (plus m n))))
+(total plus)

--- a/js/package.json
+++ b/js/package.json
@@ -1,17 +1,19 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",
   "bin": {
     "rml": "src/rml-links.mjs",
-    "rml-check": "src/rml-check.mjs"
+    "rml-check": "src/rml-check.mjs",
+    "rml-meta": "src/rml-meta.mjs"
   },
   "scripts": {
     "test": "node --test tests/ ../scripts/",
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
     "check": "node src/rml-check.mjs",
+    "meta": "node src/rml-meta.mjs",
     "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino"
   },
   "keywords": [

--- a/js/src/rml-meta.mjs
+++ b/js/src/rml-meta.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// rml-meta — metatheorem checker over encoded systems (issue #47, C3).
+//
+// Composes the existing D12 totality, D14 coverage, D15 modes, and D13
+// termination checkers into a single Twelf-style guarantee: a relation is
+// total on its declared input domain iff every input pattern is covered
+// and every recursive call structurally decreases on a `+input` slot.
+//
+// Used as a library from `checkMetatheorems(text, file)` and as a CLI via
+// `rml-meta program.lino`. Each declared relation that has a `(mode ...)`
+// declaration is treated as a metatheorem candidate; the checker runs
+// coverage (D14) and totality (D12) and reports each as `pass` or `fail`
+// with a counter-witness drawn from the underlying checkers.
+
+import fs from 'node:fs';
+import {
+  evaluate,
+  Env,
+  isTotal,
+  isCovered,
+  isTerminating,
+  formatDiagnostic,
+} from './rml-links.mjs';
+
+// Build a fresh `Env` and evaluate `text` so we can inspect declarations
+// after the fact. We pass our own `Env` because `evaluate()` does not
+// otherwise expose the post-run environment to library callers.
+function evaluateProgram(text, file) {
+  const env = new Env();
+  const out = evaluate(text, { env, file: file || null });
+  return { env, results: out.results, diagnostics: out.diagnostics };
+}
+
+// Run coverage (D14) and totality (D12) for a single relation. Returns a
+// structured `MetatheoremResult` with each sub-check's outcome and the
+// counter-witness messages collected from the underlying checkers.
+function checkRelation(env, name) {
+  const checks = [];
+  const totality = isTotal(env, name);
+  checks.push({
+    kind: 'totality',
+    ok: totality.ok,
+    diagnostics: totality.diagnostics,
+  });
+  // Coverage is only meaningful when an inductive type can be inferred
+  // for every `+input` slot. `isCovered` already handles the no-info case
+  // by returning `ok: true` with empty diagnostics.
+  const coverage = isCovered(env, name);
+  checks.push({
+    kind: 'coverage',
+    ok: coverage.ok,
+    diagnostics: coverage.diagnostics,
+  });
+  return {
+    name,
+    ok: checks.every(c => c.ok),
+    checks,
+  };
+}
+
+// Run termination (D13) for every definition that the program registered
+// via `(define ...)`. Definitions are independent of relations — they use
+// pattern arguments rather than mode flags — so they form a separate
+// section of the metatheorem report.
+function checkDefinition(env, name) {
+  const result = isTerminating(env, name);
+  return {
+    name,
+    ok: result.ok,
+    checks: [{
+      kind: 'termination',
+      ok: result.ok,
+      diagnostics: result.diagnostics,
+    }],
+  };
+}
+
+// Public API: evaluate the program, then enumerate every relation that has
+// a `(mode ...)` declaration and every definition that has a `(define ...)`
+// declaration. Each candidate becomes a metatheorem result.
+//
+// Returns `{ ok, evaluation, relations, definitions }`. `evaluation`
+// preserves the diagnostics emitted while parsing/running the program so
+// callers can surface them alongside the metatheorem outcomes.
+function checkMetatheorems(text, options = {}) {
+  const { env, results, diagnostics } = evaluateProgram(text, options.file);
+  const relationNames = Array.from(env.modes.keys()).sort();
+  const relations = [];
+  for (const name of relationNames) {
+    // A `(mode ...)` declaration without any matching `(relation ...)`
+    // clause means the relation has no body to verify; surface that as a
+    // failed metatheorem rather than silently treating it as total.
+    const clauses = env.relations.get(name);
+    if (!clauses || clauses.length === 0) continue;
+    relations.push(checkRelation(env, name));
+  }
+  const definitionNames = Array.from(env.definitions.keys()).sort();
+  const definitions = [];
+  for (const name of definitionNames) {
+    definitions.push(checkDefinition(env, name));
+  }
+  const ok =
+    diagnostics.length === 0 &&
+    relations.every(r => r.ok) &&
+    definitions.every(d => d.ok);
+  return { ok, evaluation: { results, diagnostics }, relations, definitions };
+}
+
+// Format a single check (totality / coverage / termination) for the CLI
+// output. Each diagnostic line starts with two spaces so it nests under
+// the relation/definition heading and remains greppable.
+function formatCheck(check) {
+  const status = check.ok ? 'pass' : 'fail';
+  const lines = [`  - ${check.kind}: ${status}`];
+  for (const diag of check.diagnostics) {
+    lines.push(`      ${diag.code || ''} ${diag.message}`.trimEnd());
+  }
+  return lines;
+}
+
+// Format the full report. The CLI uses this; library callers can either
+// consume the structured result directly or call this helper for parity.
+function formatReport(report) {
+  const lines = [];
+  for (const diag of report.evaluation.diagnostics) {
+    lines.push(formatDiagnostic(diag));
+  }
+  if (report.relations.length === 0 && report.definitions.length === 0) {
+    lines.push('No metatheorem candidates found (no `(mode ...)` or `(define ...)` declarations).');
+    return lines.join('\n');
+  }
+  if (report.relations.length > 0) {
+    lines.push('Relations:');
+    for (const rel of report.relations) {
+      const status = rel.ok ? 'OK' : 'FAIL';
+      lines.push(`  ${status}: ${rel.name}`);
+      for (const check of rel.checks) {
+        lines.push(...formatCheck(check));
+      }
+    }
+  }
+  if (report.definitions.length > 0) {
+    lines.push('Definitions:');
+    for (const def of report.definitions) {
+      const status = def.ok ? 'OK' : 'FAIL';
+      lines.push(`  ${status}: ${def.name}`);
+      for (const check of def.checks) {
+        lines.push(...formatCheck(check));
+      }
+    }
+  }
+  lines.push(report.ok
+    ? 'All metatheorems hold.'
+    : 'One or more metatheorems failed.');
+  return lines.join('\n');
+}
+
+function main(argv) {
+  const args = argv.slice(2);
+  if (args.length !== 1 || args[0] === '-h' || args[0] === '--help') {
+    process.stderr.write('Usage: rml-meta <program.lino>\n');
+    return args[0] === '-h' || args[0] === '--help' ? 0 : 2;
+  }
+  const file = args[0];
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (e) {
+    process.stderr.write(`Error reading ${file}: ${e.message}\n`);
+    return 1;
+  }
+  const report = checkMetatheorems(text, { file });
+  const formatted = formatReport(report);
+  if (report.ok) {
+    process.stdout.write(formatted + '\n');
+    return 0;
+  }
+  process.stderr.write(formatted + '\n');
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv));
+}
+
+export { checkMetatheorems, formatReport };

--- a/js/tests/metatheorems.test.mjs
+++ b/js/tests/metatheorems.test.mjs
@@ -1,0 +1,189 @@
+// Tests for the C3 metatheorem checker (issue #47).
+// The checker composes D12 totality, D14 coverage, D15 modes, and D13
+// termination into a single Twelf-style guarantee that a relation is
+// total on its declared input domain. The Rust suite mirrors these cases
+// in rust/tests/metatheorems_tests.rs so both runtimes report identical
+// pass/fail diagnostics.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { checkMetatheorems, formatReport } from '../src/rml-meta.mjs';
+
+const NATURAL_DECL =
+  '(inductive Natural\n' +
+  '  (constructor zero)\n' +
+  '  (constructor (succ (Pi (Natural n) Natural))))\n';
+
+const LIST_DECL =
+  '(A: (Type 0) A)\n' +
+  '(inductive List\n' +
+  '  (constructor nil)\n' +
+  '  (constructor (cons (Pi (A x) (Pi (List xs) List)))))\n';
+
+const BOOLEAN_DECL =
+  '(inductive Boolean\n' +
+  '  (constructor true)\n' +
+  '  (constructor false))\n';
+
+describe('checkMetatheorems passes Twelf-style sample relations', () => {
+  it('certifies `plus` on Natural as total and covered', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode plus +input +input -output)\n' +
+      '(relation plus\n' +
+      '  (plus zero n n)\n' +
+      '  (plus (succ m) n (succ (plus m n))))\n',
+    );
+    assert.strictEqual(report.ok, true, formatReport(report));
+    assert.strictEqual(report.relations.length, 1);
+    const plus = report.relations[0];
+    assert.strictEqual(plus.name, 'plus');
+    assert.strictEqual(plus.ok, true);
+    const kinds = plus.checks.map(c => c.kind).sort();
+    assert.deepStrictEqual(kinds, ['coverage', 'totality']);
+  });
+
+  it('certifies `le` (less-than-or-equal) on Natural', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      BOOLEAN_DECL +
+      '(mode le +input +input -output)\n' +
+      '(relation le\n' +
+      '  (le zero n true)\n' +
+      '  (le (succ m) zero false)\n' +
+      '  (le (succ m) (succ n) (le m n)))\n',
+    );
+    assert.strictEqual(report.ok, true, formatReport(report));
+    const le = report.relations.find(r => r.name === 'le');
+    assert.ok(le, 'expected `le` to be reported');
+    assert.strictEqual(le.ok, true);
+  });
+
+  it('certifies `append` on List', () => {
+    const report = checkMetatheorems(
+      LIST_DECL +
+      '(mode append +input +input -output)\n' +
+      '(relation append\n' +
+      '  (append nil ys ys)\n' +
+      '  (append (cons x xs) ys (cons x (append xs ys))))\n',
+    );
+    assert.strictEqual(report.ok, true, formatReport(report));
+    const append = report.relations.find(r => r.name === 'append');
+    assert.ok(append, 'expected `append` to be reported');
+    assert.strictEqual(append.ok, true);
+  });
+});
+
+describe('checkMetatheorems reports counter-witnesses on failure', () => {
+  it('flags a relation that omits a constructor case (coverage failure)', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode f +input -output)\n' +
+      '(relation f\n' +
+      '  (f zero zero))\n',
+    );
+    assert.strictEqual(report.ok, false);
+    const f = report.relations.find(r => r.name === 'f');
+    assert.ok(f);
+    assert.strictEqual(f.ok, false);
+    const coverage = f.checks.find(c => c.kind === 'coverage');
+    assert.ok(coverage);
+    assert.strictEqual(coverage.ok, false);
+    assert.match(coverage.diagnostics[0].message, /missing case/);
+    assert.match(coverage.diagnostics[0].message, /\(succ/);
+  });
+
+  it('flags a relation that recurses without structural decrease', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode loop +input -output)\n' +
+      '(relation loop\n' +
+      '  (loop zero zero)\n' +
+      '  (loop (succ n) (loop (succ n))))\n',
+    );
+    assert.strictEqual(report.ok, false);
+    const loop = report.relations.find(r => r.name === 'loop');
+    assert.ok(loop);
+    const totality = loop.checks.find(c => c.kind === 'totality');
+    assert.ok(totality);
+    assert.strictEqual(totality.ok, false);
+    assert.match(totality.diagnostics[0].message, /does not structurally decrease/);
+  });
+
+  it('reports both checks independently when a single relation fails both', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode bad +input -output)\n' +
+      '(relation bad\n' +
+      '  (bad (succ n) (bad (succ n))))\n',
+    );
+    assert.strictEqual(report.ok, false);
+    const bad = report.relations.find(r => r.name === 'bad');
+    assert.ok(bad);
+    const totality = bad.checks.find(c => c.kind === 'totality');
+    const coverage = bad.checks.find(c => c.kind === 'coverage');
+    assert.strictEqual(totality.ok, false);
+    assert.strictEqual(coverage.ok, false);
+  });
+});
+
+describe('checkMetatheorems also reports D13 termination for definitions', () => {
+  it('certifies `plus` declared via `(define ...)`', () => {
+    const report = checkMetatheorems(
+      '(define plus\n' +
+      '  (case (zero n) n)\n' +
+      '  (case ((succ m) n) (succ (plus m n))))\n',
+    );
+    assert.strictEqual(report.ok, true, formatReport(report));
+    const plus = report.definitions.find(d => d.name === 'plus');
+    assert.ok(plus);
+    assert.strictEqual(plus.ok, true);
+    assert.strictEqual(plus.checks[0].kind, 'termination');
+  });
+
+  it('reports a counter-witness for a non-terminating definition', () => {
+    const report = checkMetatheorems(
+      '(define loop\n' +
+      '  (case (zero) zero)\n' +
+      '  (case ((succ n)) (loop (succ n))))\n',
+    );
+    assert.strictEqual(report.ok, false);
+    const loop = report.definitions.find(d => d.name === 'loop');
+    assert.ok(loop);
+    assert.strictEqual(loop.ok, false);
+    assert.match(loop.checks[0].diagnostics[0].message, /does not structurally decrease/);
+  });
+});
+
+describe('formatReport summarizes structured results for the CLI', () => {
+  it('marks an all-passing run as `All metatheorems hold.`', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode plus +input +input -output)\n' +
+      '(relation plus\n' +
+      '  (plus zero n n)\n' +
+      '  (plus (succ m) n (succ (plus m n))))\n',
+    );
+    const text = formatReport(report);
+    assert.match(text, /OK: plus/);
+    assert.match(text, /All metatheorems hold\./);
+  });
+
+  it('marks a failing run as `One or more metatheorems failed.`', () => {
+    const report = checkMetatheorems(
+      NATURAL_DECL +
+      '(mode f +input -output)\n' +
+      '(relation f\n' +
+      '  (f zero zero))\n',
+    );
+    const text = formatReport(report);
+    assert.match(text, /FAIL: f/);
+    assert.match(text, /One or more metatheorems failed\./);
+  });
+
+  it('reports an empty program with a clear placeholder line', () => {
+    const report = checkMetatheorems('');
+    const text = formatReport(report);
+    assert.match(text, /No metatheorem candidates/);
+  });
+});

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"
@@ -12,6 +12,10 @@ path = "src/main.rs"
 [[bin]]
 name = "rml-check"
 path = "src/bin/rml-check.rs"
+
+[[bin]]
+name = "rml-meta"
+path = "src/bin/rml-meta.rs"
 
 [lib]
 name = "rml"

--- a/rust/src/bin/rml-meta.rs
+++ b/rust/src/bin/rml-meta.rs
@@ -1,0 +1,42 @@
+// rml-meta — metatheorem checker over encoded systems (issue #47, C3).
+//
+// CLI front-end for `rml::meta::check_metatheorems`. Reads a program file,
+// composes D12 totality, D14 coverage, D15 modes, and D13 termination, and
+// prints a per-relation / per-definition pass/fail report. Exits non-zero
+// when any metatheorem fails.
+
+use rml::meta::{check_metatheorems, format_report};
+use std::env;
+use std::fs;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 || args[1] == "-h" || args[1] == "--help" {
+        eprintln!("Usage: rml-meta <program.lino>");
+        return if args.get(1).map(|s| s.as_str()) == Some("-h")
+            || args.get(1).map(|s| s.as_str()) == Some("--help")
+        {
+            ExitCode::SUCCESS
+        } else {
+            ExitCode::from(2)
+        };
+    }
+    let file = &args[1];
+    let text = match fs::read_to_string(file) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error reading {}: {}", file, e);
+            return ExitCode::from(1);
+        }
+    };
+    let report = check_metatheorems(&text, Some(file));
+    let formatted = format_report(&report);
+    if report.ok {
+        println!("{}", formatted);
+        ExitCode::SUCCESS
+    } else {
+        eprintln!("{}", formatted);
+        ExitCode::from(1)
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -6365,3 +6365,4 @@ pub fn run(text: &str, options: Option<EnvOptions>) -> Vec<f64> {
 
 pub mod repl;
 pub mod check;
+pub mod meta;

--- a/rust/src/meta.rs
+++ b/rust/src/meta.rs
@@ -1,0 +1,233 @@
+// rml-meta — metatheorem checker over encoded systems (issue #47, C3).
+//
+// Composes the existing D12 totality, D14 coverage, D15 modes, and D13
+// termination checkers into a single Twelf-style guarantee: a relation is
+// total on its declared input domain iff every input pattern is covered
+// and every recursive call structurally decreases on a `+input` slot.
+//
+// Used as a library from `check_metatheorems(text, file)` and as a CLI via
+// the `rml-meta` binary in `src/bin/rml-meta.rs`.
+
+use crate::{
+    evaluate_with_env, format_diagnostic, is_covered, is_terminating, is_total,
+    CoverageDiagnostic, Diagnostic, Env, TerminationDiagnostic, TotalityDiagnostic,
+};
+
+/// Generic per-check diagnostic produced by the metatheorem checker. We
+/// flatten the per-checker diagnostic types ([`TotalityDiagnostic`] etc.)
+/// into a single shape so the report consumer does not have to know which
+/// underlying checker emitted the message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaDiagnostic {
+    pub code: String,
+    pub message: String,
+}
+
+impl From<TotalityDiagnostic> for MetaDiagnostic {
+    fn from(d: TotalityDiagnostic) -> Self {
+        MetaDiagnostic {
+            code: d.code,
+            message: d.message,
+        }
+    }
+}
+
+impl From<CoverageDiagnostic> for MetaDiagnostic {
+    fn from(d: CoverageDiagnostic) -> Self {
+        MetaDiagnostic {
+            code: d.code,
+            message: d.message,
+        }
+    }
+}
+
+impl From<TerminationDiagnostic> for MetaDiagnostic {
+    fn from(d: TerminationDiagnostic) -> Self {
+        MetaDiagnostic {
+            code: d.code,
+            message: d.message,
+        }
+    }
+}
+
+/// Which checker produced this entry. `Totality` and `Coverage` are
+/// reported per relation; `Termination` is reported per definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckKind {
+    Totality,
+    Coverage,
+    Termination,
+}
+
+impl CheckKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CheckKind::Totality => "totality",
+            CheckKind::Coverage => "coverage",
+            CheckKind::Termination => "termination",
+        }
+    }
+}
+
+/// One entry in a [`MetatheoremResult`]: which sub-check ran, whether it
+/// passed, and which diagnostics it emitted on failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetatheoremCheck {
+    pub kind: CheckKind,
+    pub ok: bool,
+    pub diagnostics: Vec<MetaDiagnostic>,
+}
+
+/// Per-relation (or per-definition) outcome — combines every sub-check
+/// run for that name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetatheoremResult {
+    pub name: String,
+    pub ok: bool,
+    pub checks: Vec<MetatheoremCheck>,
+}
+
+/// Top-level structured report returned by [`check_metatheorems`]. The
+/// CLI uses [`format_report`] to render it; library consumers can read
+/// the structured fields directly.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetatheoremReport {
+    pub ok: bool,
+    pub evaluation_diagnostics: Vec<Diagnostic>,
+    pub relations: Vec<MetatheoremResult>,
+    pub definitions: Vec<MetatheoremResult>,
+}
+
+fn check_relation(env: &Env, name: &str) -> MetatheoremResult {
+    let totality = is_total(env, name);
+    let coverage = is_covered(env, name);
+    let totality_check = MetatheoremCheck {
+        kind: CheckKind::Totality,
+        ok: totality.ok,
+        diagnostics: totality.diagnostics.into_iter().map(Into::into).collect(),
+    };
+    let coverage_check = MetatheoremCheck {
+        kind: CheckKind::Coverage,
+        ok: coverage.ok,
+        diagnostics: coverage.diagnostics.into_iter().map(Into::into).collect(),
+    };
+    let ok = totality_check.ok && coverage_check.ok;
+    MetatheoremResult {
+        name: name.to_string(),
+        ok,
+        checks: vec![totality_check, coverage_check],
+    }
+}
+
+fn check_definition(env: &Env, name: &str) -> MetatheoremResult {
+    let term = is_terminating(env, name);
+    let check = MetatheoremCheck {
+        kind: CheckKind::Termination,
+        ok: term.ok,
+        diagnostics: term.diagnostics.into_iter().map(Into::into).collect(),
+    };
+    let ok = check.ok;
+    MetatheoremResult {
+        name: name.to_string(),
+        ok,
+        checks: vec![check],
+    }
+}
+
+/// Public API: evaluate `text`, then enumerate every relation that has a
+/// `(mode ...)` declaration plus matching `(relation ...)` clauses, and
+/// every definition that has a `(define ...)` declaration. Each candidate
+/// becomes a metatheorem result.
+///
+/// `file` is the source path used in evaluation diagnostics; it is
+/// optional and only affects the rendered span.
+pub fn check_metatheorems(text: &str, file: Option<&str>) -> MetatheoremReport {
+    let mut env = Env::new(None);
+    let evaluation = evaluate_with_env(text, file, &mut env);
+
+    let mut relation_names: Vec<String> = env.modes.keys().cloned().collect();
+    relation_names.sort();
+    let mut relations: Vec<MetatheoremResult> = Vec::new();
+    for name in &relation_names {
+        let clauses = env.relations.get(name);
+        // A `(mode ...)` declaration with no matching `(relation ...)` body
+        // is not a metatheorem candidate — surface it through the existing
+        // E032 path rather than fabricating a result.
+        if clauses.map_or(true, |c| c.is_empty()) {
+            continue;
+        }
+        relations.push(check_relation(&env, name));
+    }
+
+    let mut definition_names: Vec<String> = env.definitions.keys().cloned().collect();
+    definition_names.sort();
+    let mut definitions: Vec<MetatheoremResult> = Vec::new();
+    for name in &definition_names {
+        definitions.push(check_definition(&env, name));
+    }
+
+    let ok = evaluation.diagnostics.is_empty()
+        && relations.iter().all(|r| r.ok)
+        && definitions.iter().all(|d| d.ok);
+    MetatheoremReport {
+        ok,
+        evaluation_diagnostics: evaluation.diagnostics,
+        relations,
+        definitions,
+    }
+}
+
+fn format_check(check: &MetatheoremCheck) -> Vec<String> {
+    let status = if check.ok { "pass" } else { "fail" };
+    let mut lines = vec![format!("  - {}: {}", check.kind.as_str(), status)];
+    for diag in &check.diagnostics {
+        lines.push(format!("      {} {}", diag.code, diag.message).trim_end().to_string());
+    }
+    lines
+}
+
+/// Render a [`MetatheoremReport`] as the same human-readable text the CLI
+/// prints. Useful in tests that want to assert on the rendered output as
+/// well as the structured shape.
+pub fn format_report(report: &MetatheoremReport) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for diag in &report.evaluation_diagnostics {
+        lines.push(format_diagnostic(diag, None));
+    }
+    if report.relations.is_empty() && report.definitions.is_empty() {
+        lines.push(
+            "No metatheorem candidates found (no `(mode ...)` or `(define ...)` declarations)."
+                .to_string(),
+        );
+        return lines.join("\n");
+    }
+    if !report.relations.is_empty() {
+        lines.push("Relations:".to_string());
+        for rel in &report.relations {
+            let status = if rel.ok { "OK" } else { "FAIL" };
+            lines.push(format!("  {}: {}", status, rel.name));
+            for check in &rel.checks {
+                lines.extend(format_check(check));
+            }
+        }
+    }
+    if !report.definitions.is_empty() {
+        lines.push("Definitions:".to_string());
+        for def in &report.definitions {
+            let status = if def.ok { "OK" } else { "FAIL" };
+            lines.push(format!("  {}: {}", status, def.name));
+            for check in &def.checks {
+                lines.extend(format_check(check));
+            }
+        }
+    }
+    lines.push(
+        if report.ok {
+            "All metatheorems hold."
+        } else {
+            "One or more metatheorems failed."
+        }
+        .to_string(),
+    );
+    lines.join("\n")
+}

--- a/rust/tests/metatheorems_tests.rs
+++ b/rust/tests/metatheorems_tests.rs
@@ -1,0 +1,256 @@
+// Tests for the C3 metatheorem checker (issue #47).
+// The checker composes D12 totality, D14 coverage, D15 modes, and D13
+// termination into a single Twelf-style guarantee that a relation is
+// total on its declared input domain. These cases mirror the JS suite in
+// js/tests/metatheorems.test.mjs to keep the two runtimes in lock-step.
+
+use rml::meta::{check_metatheorems, format_report, CheckKind};
+
+const NATURAL_DECL: &str = "(inductive Natural\n\
+                            (constructor zero)\n\
+                            (constructor (succ (Pi (Natural n) Natural))))\n";
+
+const LIST_DECL: &str = "(A: (Type 0) A)\n\
+                         (inductive List\n\
+                         (constructor nil)\n\
+                         (constructor (cons (Pi (A x) (Pi (List xs) List)))))\n";
+
+const BOOLEAN_DECL: &str = "(inductive Boolean\n\
+                            (constructor true)\n\
+                            (constructor false))\n";
+
+#[test]
+fn certifies_plus_on_natural_as_total_and_covered() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode plus +input +input -output)\n\
+         (relation plus\n\
+           (plus zero n n)\n\
+           (plus (succ m) n (succ (plus m n))))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(report.ok, "report should pass: {}", format_report(&report));
+    assert_eq!(report.relations.len(), 1);
+    let plus = &report.relations[0];
+    assert_eq!(plus.name, "plus");
+    assert!(plus.ok);
+    let mut kinds: Vec<&str> = plus.checks.iter().map(|c| c.kind.as_str()).collect();
+    kinds.sort();
+    assert_eq!(kinds, vec!["coverage", "totality"]);
+}
+
+#[test]
+fn certifies_le_on_natural() {
+    let program = format!(
+        "{}{}{}",
+        NATURAL_DECL,
+        BOOLEAN_DECL,
+        "(mode le +input +input -output)\n\
+         (relation le\n\
+           (le zero n true)\n\
+           (le (succ m) zero false)\n\
+           (le (succ m) (succ n) (le m n)))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(report.ok, "report should pass: {}", format_report(&report));
+    let le = report
+        .relations
+        .iter()
+        .find(|r| r.name == "le")
+        .expect("le should be reported");
+    assert!(le.ok);
+}
+
+#[test]
+fn certifies_append_on_list() {
+    let program = format!(
+        "{}{}",
+        LIST_DECL,
+        "(mode append +input +input -output)\n\
+         (relation append\n\
+           (append nil ys ys)\n\
+           (append (cons x xs) ys (cons x (append xs ys))))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(report.ok, "report should pass: {}", format_report(&report));
+    let append = report
+        .relations
+        .iter()
+        .find(|r| r.name == "append")
+        .expect("append should be reported");
+    assert!(append.ok);
+}
+
+#[test]
+fn flags_relation_missing_constructor_case() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode f +input -output)\n\
+         (relation f\n\
+           (f zero zero))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(!report.ok);
+    let f = report
+        .relations
+        .iter()
+        .find(|r| r.name == "f")
+        .expect("f should be reported");
+    assert!(!f.ok);
+    let coverage = f
+        .checks
+        .iter()
+        .find(|c| c.kind == CheckKind::Coverage)
+        .expect("coverage check");
+    assert!(!coverage.ok);
+    assert!(coverage.diagnostics[0].message.contains("missing case"));
+    assert!(coverage.diagnostics[0].message.contains("(succ"));
+}
+
+#[test]
+fn flags_relation_without_structural_decrease() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode loop +input -output)\n\
+         (relation loop\n\
+           (loop zero zero)\n\
+           (loop (succ n) (loop (succ n))))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(!report.ok);
+    let loop_rel = report
+        .relations
+        .iter()
+        .find(|r| r.name == "loop")
+        .expect("loop should be reported");
+    let totality = loop_rel
+        .checks
+        .iter()
+        .find(|c| c.kind == CheckKind::Totality)
+        .expect("totality check");
+    assert!(!totality.ok);
+    assert!(totality.diagnostics[0]
+        .message
+        .contains("does not structurally decrease"));
+}
+
+#[test]
+fn reports_both_checks_when_relation_fails_both() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode bad +input -output)\n\
+         (relation bad\n\
+           (bad (succ n) (bad (succ n))))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    assert!(!report.ok);
+    let bad = report
+        .relations
+        .iter()
+        .find(|r| r.name == "bad")
+        .expect("bad should be reported");
+    let totality = bad
+        .checks
+        .iter()
+        .find(|c| c.kind == CheckKind::Totality)
+        .unwrap();
+    let coverage = bad
+        .checks
+        .iter()
+        .find(|c| c.kind == CheckKind::Coverage)
+        .unwrap();
+    assert!(!totality.ok);
+    assert!(!coverage.ok);
+}
+
+#[test]
+fn certifies_termination_for_definition_form() {
+    let report = check_metatheorems(
+        "(define plus\n\
+           (case (zero n) n)\n\
+           (case ((succ m) n) (succ (plus m n))))\n",
+        None,
+    );
+    assert!(report.ok, "report should pass: {}", format_report(&report));
+    let plus = report
+        .definitions
+        .iter()
+        .find(|d| d.name == "plus")
+        .expect("plus definition");
+    assert!(plus.ok);
+    assert_eq!(plus.checks[0].kind, CheckKind::Termination);
+}
+
+#[test]
+fn reports_counter_witness_for_non_terminating_definition() {
+    let report = check_metatheorems(
+        "(define loop\n\
+           (case (zero) zero)\n\
+           (case ((succ n)) (loop (succ n))))\n",
+        None,
+    );
+    assert!(!report.ok);
+    let loop_def = report
+        .definitions
+        .iter()
+        .find(|d| d.name == "loop")
+        .expect("loop definition");
+    assert!(!loop_def.ok);
+    assert!(loop_def.checks[0].diagnostics[0]
+        .message
+        .contains("does not structurally decrease"));
+}
+
+#[test]
+fn format_report_marks_passing_run() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode plus +input +input -output)\n\
+         (relation plus\n\
+           (plus zero n n)\n\
+           (plus (succ m) n (succ (plus m n))))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    let text = format_report(&report);
+    assert!(text.contains("OK: plus"), "expected OK line, got:\n{}", text);
+    assert!(
+        text.contains("All metatheorems hold."),
+        "expected pass marker, got:\n{}",
+        text,
+    );
+}
+
+#[test]
+fn format_report_marks_failing_run() {
+    let program = format!(
+        "{}{}",
+        NATURAL_DECL,
+        "(mode f +input -output)\n\
+         (relation f\n\
+           (f zero zero))\n",
+    );
+    let report = check_metatheorems(&program, None);
+    let text = format_report(&report);
+    assert!(text.contains("FAIL: f"), "expected FAIL line, got:\n{}", text);
+    assert!(
+        text.contains("One or more metatheorems failed."),
+        "expected fail marker, got:\n{}",
+        text,
+    );
+}
+
+#[test]
+fn format_report_handles_empty_program() {
+    let report = check_metatheorems("", None);
+    let text = format_report(&report);
+    assert!(
+        text.contains("No metatheorem candidates"),
+        "expected placeholder line, got:\n{}",
+        text,
+    );
+}


### PR DESCRIPTION
## Summary

Closes #47.

Adds a Twelf-style metatheorem checker that, given a relation declared as a family of links plus `(mode ...)` and totality, certifies the relation is a total function on its declared input domain. The checker composes four already-merged kernel facilities — D12 totality (E032), D14 coverage (E037), D15 modes (E030/E031), and D13 termination (E035) — into one driver that emits per-relation pass/fail with a counter-witness diagnostic on failure.

A relation passes only when every sub-check passes. Failures keep the underlying checker's stable error codes so editor integrations and CI scripts match on them the same way they already match every other RML diagnostic (`docs/DIAGNOSTICS.md`).

### Surface

The canonical Twelf `plus` example works end-to-end:

```lino
(inductive Natural
  (constructor zero)
  (constructor (succ (Pi (Natural n) Natural))))
(mode plus +input +input -output)
(relation plus
  (plus zero n n)
  (plus (succ m) n (succ (plus m n))))
```

### CLIs (byte-compatible)

```sh
# JS
node js/src/rml-meta.mjs experiments/metatheorem-plus.lino
# Rust
cd rust && cargo run --bin rml-meta -- ../experiments/metatheorem-plus.lino
```

Successful output:

```
Relations:
  OK: plus
  - totality: pass
  - coverage: pass
All metatheorems hold.
```

Exit code: `0`. On failure exit code is `1` and the report goes to stderr.

### Programmatic API

```js
import { checkMetatheorems, formatReport } from 'relative-meta-logic/src/rml-meta.mjs';
const report = checkMetatheorems(text, { file: 'program.lino' });
if (!report.ok) console.error(formatReport(report));
```

```rust
use rml::meta::{check_metatheorems, format_report};
let report = check_metatheorems(text, Some("program.lino"));
if !report.ok { eprintln!("{}", format_report(&report)); }
```

### Acceptance criteria covered

- [x] `plus` on `Natural` certified — recursion on the first `+input`.
- [x] `le` (less-than-or-equal) on `Natural` certified — recursion shrinks both inputs.
- [x] `append` on `List` certified — recursion on the first list.
- [x] Pass/fail diagnostic with counter-witness on failure (missing case → E037, no structural decrease → E032, multi-failure relation reports both).
- [x] Documented in `docs/METATHEOREMS.md` (linked from main `README.md`).

### Implementation

| Phase | Form | API | Code |
|-------|------|-----|------|
| Mode declaration | `(mode plus +input +input -output)` | `env.modes` | E030/E031 |
| Coverage check (D14) | `(coverage plus)` | `isCovered` / `is_covered` | E037 |
| Totality check (D12) | `(total plus)` | `isTotal` / `is_total` | E032 |
| Termination check (D13) | `(terminating plus)` | `isTerminating` / `is_terminating` | E035 |

Iteration is two-phase: every relation that has both a `(mode ...)` and matching `(relation ...)` clauses runs totality + coverage; every `(define ...)` runs termination. A `(mode ...)` with no matching body is not a metatheorem candidate and is left to the existing E032 path rather than fabricating a result.

Mirrored across both runtimes:
- JS: `js/src/rml-meta.mjs` exports `checkMetatheorems` and `formatReport`. CLI registered as `rml-meta` in `js/package.json` (also `npm run meta`).
- Rust: `rust/src/meta.rs` exposes `check_metatheorems` and `format_report`. New `rml-meta` binary in `rust/src/bin/rml-meta.rs` declared in `rust/Cargo.toml`. `MetaDiagnostic` flattens the per-checker diagnostic shapes via `From` impls so the report consumer does not have to know which checker emitted the message.

### Out of scope (deliberate)

- Proof of totality for non-structurally-decreasing definitions — D13 already accepts an explicit `(measure (lex ...))`, and the metatheorem checker reuses that infrastructure rather than introducing its own proof obligation.
- Multi-relation mutual recursion — the iteration verifies one relation at a time; mutual termination is delegated to D13's measure-based checker.

### Version bump

Bumps both `js/package.json` and `rust/Cargo.toml` from 0.15.0 → 0.16.0 to mark the C3 milestone (consistent with #53 bumping for D11 and prior milestone PRs).

## Test plan

- [x] `cd js && npm test` — 715 / 715 (704 baseline + 11 new for the metatheorem checker)
- [x] `cd rust && cargo test` — every suite green, 11 new tests in `rust/tests/metatheorems_tests.rs` mirroring the JS suite case-by-case
- [x] Manual CLI run on `experiments/metatheorem-plus.lino` and `experiments/metatheorem-bad.lino` for both runtimes; outputs are byte-identical
- [x] Counter-witness verified for missing-constructor (`f` with no `succ` case), no-structural-decrease (`loop`), both-failures (`bad`)
- [x] Termination for `(define ...)` form verified end-to-end (passes for `plus`, fails for `loop`)
- [x] `cargo build --release` clean