### PR TITLE
[E3] Bounded proof search

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
+# Updated: 2026-05-07T20:50:34.944Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
-# Updated: 2026-05-05T12:10:25.688Z
-# Updated: 2026-05-07T20:50:34.944Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+# .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
+# Updated: 2026-05-05T12:10:25.688Z

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,11 +124,12 @@ The tactic engine keeps proof steps as links:
 | JavaScript | Rust | Purpose |
 |------------|------|---------|
 | `runTactics(state, tactics)` | `run_tactics(state, tactics)` | Apply link tactics to a proof state and return the updated state plus diagnostics. |
+| `search(goal, depth, lemmas)` | `search(goal, depth, lemmas)` | Run bounded backwards search and return a derivation-tree link on success. |
 | Goal state | `ProofState` / `ProofGoal` | Open goals, local context, and successful tactic links. |
 
 Built-in tactics are `reflexivity`, `symmetry`, `transitivity`, `induction`,
-`suppose`, `introduce`, `by`, `rewrite`, and `exact`. A failed tactic emits
-`E039` and includes the current goal in the diagnostic message.
+`suppose`, `introduce`, `by`, `rewrite`, `exact`, and `search`. A failed
+tactic emits `E039` and includes the current goal in the diagnostic message.
 
 For consumers that start from a selected natural-language interpretation rather than a complete `.lino` file, the library also exposes a meta-expression adapter:
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ and successful tactic history is stored as links in the proof state:
 (introduce n)
 (rewrite (a = b) in goal)
 (exact (p = q))
+(by search depth 2)
 (induction n
   (case zero (by reflexivity))
   (case (succ m) (by reflexivity)))
@@ -432,9 +433,11 @@ Programmatic APIs:
 
 - JavaScript: `runTactics(state, tactics)` returns `{ state, diagnostics }`.
 - Rust: `run_tactics(state, tactics)` returns `TacticRunResult`.
+- JavaScript/Rust: `search(goal, depth, lemmas)` returns a derivation tree
+  link, or `null` / `None` when bounded search cannot close the goal.
 
 The built-in tactic set is `reflexivity`, `symmetry`, `transitivity`,
-`induction`, `suppose`, `introduce`, `by`, `rewrite`, and `exact`.
+`induction`, `suppose`, `introduce`, `by`, `rewrite`, `exact`, and `search`.
 Failed tactics emit `E039` diagnostics that include the current goal.
 
 #### Type Queries
@@ -730,7 +733,7 @@ The test suites cover:
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic (`+`, `-`, `*`, `/`) and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, definitional equality, type queries, prefix type notation
-- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact
+- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact, bounded search
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types, coexistence with universe hierarchy
 - Bayesian inference: Bayes' theorem, law of total probability, conditional probability, complement rule
 - Bayesian networks: joint probability (product), probabilistic sum (probabilistic_sum), multi-node networks, chain rule decomposition

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -470,7 +470,9 @@ The tactic engine is a library layer over proof states rather than a new
 kernel form. A proof state contains open goals, each goal's local context,
 and a history of successful tactic links. The public APIs are
 `runTactics(state, tactics)` in JavaScript and `run_tactics(state, tactics)`
-in Rust.
+in Rust. Both runtimes also expose `search(goal, depth, lemmas)`, which
+returns a derivation-tree link or `null` / `None` when the bounded search
+cannot close the goal.
 
 Built-in tactics:
 
@@ -484,11 +486,22 @@ Built-in tactics:
 | `(introduce x)` | Opens a `Pi` goal and records `(x of A)` in context. |
 | `(rewrite (L = R) in goal)` | Rewrites occurrences of `L` to `R` in the current goal. |
 | `(exact term)` | Closes the goal when `term` or its context ascription proves it. |
+| `(by search depth N)` | Runs depth-bounded backwards search using the current goal context as lemmas. |
 | `(induction x (case p tactics...) ...)` | Creates one substituted case goal per case and runs its tactic links. |
 
 Failed tactics return `E039` diagnostics with the current goal printed in the
 message. Successful tactic history remains a list of links, preserving the
 "everything is a link" invariant.
+
+Search closes reflexive equality and exact lemma matches at depth `0`.
+Applying a `Pi` lemma consumes one depth unit and recursively searches for
+the lemma premises. Lemmas may be raw propositions, typed links such as
+`(h of P)`, or named declarations such as `(h: P)`. A successful search
+records a concrete derivation tree, for example:
+
+```lino
+(by apply trans (by exact ab) (by exact bc))
+```
 
 ## Bidirectional Type Checker
 

--- a/js/README.md
+++ b/js/README.md
@@ -65,6 +65,7 @@ import {
   Env,
   evalNode,
   runTactics,
+  search,
   quantize,
   decRound,
   keyOf,
@@ -102,6 +103,18 @@ const tacticResult = runTactics(
 );
 // -> { state: { goals: [], proof: [['by', 'reflexivity']] }, diagnostics: [] }
 
+// Run bounded backwards search over available lemmas
+const searchProof = search(
+  parseOne(tokenizeOne('(a = c)')),
+  1,
+  [
+    parseOne(tokenizeOne('(ab of (a = b))')),
+    parseOne(tokenizeOne('(bc of (b = c))')),
+    parseOne(tokenizeOne('(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))')),
+  ],
+);
+// -> (by apply trans (by exact ab) (by exact bc))
+
 // Quantize a value to N discrete levels
 const q = quantize(0.4, 3, 0, 1); // -> 0.5 (nearest ternary level)
 
@@ -134,7 +147,7 @@ The test suite covers:
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, definitional equality, capture-avoiding substitution, freshness, type queries
-- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact
+- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact, bounded search
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Dependencies

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relative-meta-logic",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "Unlicense",
       "dependencies": {
         "links-notation": "^0.13.0"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relative-meta-logic",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A prototype for logic framework that can reason about anything relative to given probability of input statements",
   "type": "module",
   "main": "src/rml-links.mjs",

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -1160,6 +1160,110 @@ function _exactClosesGoal(arg, goal) {
   });
 }
 
+function _searchLemma(lemma) {
+  const ascription = _typeAscription(lemma);
+  if (ascription) {
+    return {
+      term: cloneTerm(ascription.term),
+      statement: cloneTerm(ascription.type),
+    };
+  }
+  if (
+    Array.isArray(lemma) &&
+    lemma.length === 2 &&
+    typeof lemma[0] === 'string' &&
+    lemma[0].endsWith(':')
+  ) {
+    return {
+      term: lemma[0].slice(0, -1),
+      statement: cloneTerm(lemma[1]),
+    };
+  }
+  return {
+    term: cloneTerm(lemma),
+    statement: cloneTerm(lemma),
+  };
+}
+
+function _piPremisesAndConclusion(statement) {
+  const premises = [];
+  let current = statement;
+  while (Array.isArray(current) && current.length === 3 && current[0] === 'Pi') {
+    const binding = parseBinding(current[1]);
+    if (!binding) return null;
+    premises.push(cloneTerm(binding.paramType));
+    current = current[2];
+  }
+  return {
+    premises,
+    conclusion: cloneTerm(current),
+  };
+}
+
+function _reflexivityProof(goal) {
+  const eq = _asEquality(goal);
+  if (eq && isStructurallySame(eq.left, eq.right)) {
+    return _wrap('reflexivity');
+  }
+  return null;
+}
+
+function _searchWithLemmas(goal, depth, lemmas) {
+  const reflexive = _reflexivityProof(goal);
+  if (reflexive) return reflexive;
+
+  for (const lemma of lemmas) {
+    if (isStructurallySame(lemma.statement, goal)) {
+      return _wrap('exact', lemma.term);
+    }
+  }
+
+  if (depth <= 0) return null;
+
+  for (const lemma of lemmas) {
+    const rule = _piPremisesAndConclusion(lemma.statement);
+    if (!rule || rule.premises.length === 0 || !isStructurallySame(rule.conclusion, goal)) {
+      continue;
+    }
+    const subProofs = [];
+    let solved = true;
+    for (const premise of rule.premises) {
+      const subProof = _searchWithLemmas(premise, depth - 1, lemmas);
+      if (!subProof) {
+        solved = false;
+        break;
+      }
+      subProofs.push(subProof);
+    }
+    if (solved) return _wrap('apply', lemma.term, ...subProofs);
+  }
+
+  return null;
+}
+
+function _parseSearchDepth(value) {
+  if (Number.isInteger(value) && value >= 0) return value;
+  if (typeof value === 'string' && /^\d+$/.test(value)) return Number(value);
+  return null;
+}
+
+function _recordSearchProof(recordTactic, proof) {
+  const recorded = cloneTerm(recordTactic);
+  if (Array.isArray(recorded)) return [...recorded, cloneTerm(proof)];
+  return [recorded, cloneTerm(proof)];
+}
+
+function search(goal, depth, lemmas = []) {
+  const parsedDepth = _parseSearchDepth(depth);
+  if (parsedDepth === null) return null;
+  const lemmaList = Array.isArray(lemmas) ? lemmas : [lemmas];
+  return _searchWithLemmas(
+    cloneTerm(goal),
+    parsedDepth,
+    lemmaList.map(_searchLemma),
+  );
+}
+
 function _applyTactic(state, tactic, recordTactic = tactic) {
   const name = _tacticName(tactic);
   const args = _tacticArgs(tactic);
@@ -1180,6 +1284,36 @@ function _applyTactic(state, tactic, recordTactic = tactic) {
       ok: false,
       state,
       diagnostic: _tacticDiagnostic(recordTactic, null, 'no open goals'),
+    };
+  }
+
+  if (name === 'search') {
+    if (args.length !== 2 || args[0] !== 'depth') {
+      return {
+        ok: false,
+        state,
+        diagnostic: _tacticDiagnostic(recordTactic, current, 'search expects `(search depth N)`'),
+      };
+    }
+    const depth = _parseSearchDepth(args[1]);
+    if (depth === null) {
+      return {
+        ok: false,
+        state,
+        diagnostic: _tacticDiagnostic(recordTactic, current, 'search depth must be a non-negative integer'),
+      };
+    }
+    const proof = search(current.goal, depth, current.context);
+    if (!proof) {
+      return {
+        ok: false,
+        state,
+        diagnostic: _tacticDiagnostic(recordTactic, current, `search found no derivation within depth ${depth}`),
+      };
+    }
+    return {
+      ok: true,
+      state: _replaceCurrentGoal(state, [], _recordSearchProof(recordTactic, proof)),
     };
   }
 
@@ -4612,6 +4746,7 @@ export {
   evalNode,
   buildProof,
   runTactics,
+  search,
   quantize,
   decRound,
   keyOf,

--- a/js/tests/tactics.test.mjs
+++ b/js/tests/tactics.test.mjs
@@ -8,6 +8,7 @@ import {
   keyOf,
   parseOne,
   runTactics,
+  search,
   tokenizeOne,
 } from '../src/rml-links.mjs';
 
@@ -17,6 +18,15 @@ function link(src) {
 
 function state(...goals) {
   return { goals: goals.map(goal => link(goal)) };
+}
+
+function stateWithContext(goal, ...context) {
+  return {
+    goals: [{
+      goal: link(goal),
+      context: context.map(link),
+    }],
+  };
 }
 
 function goalKeys(proofState) {
@@ -124,5 +134,39 @@ describe('runTactics applies link tactics to proof states', () => {
     assert.strictEqual(out.diagnostics[0].code, 'E039');
     assert.match(out.diagnostics[0].message, /current goal: \(a = b\)/);
     assert.deepStrictEqual(goalKeys(out.state), ['(a = b)']);
+  });
+
+  it('search returns a bounded derivation tree from available lemmas', () => {
+    const lemmas = [
+      link('(ab of (a = b))'),
+      link('(bc of (b = c))'),
+      link('(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))'),
+    ];
+
+    assert.strictEqual(search(link('(a = c)'), 0, lemmas), null);
+
+    const proof = search(link('(a = c)'), 1, lemmas);
+    assert.strictEqual(
+      keyOf(proof),
+      '(by apply trans (by exact ab) (by exact bc))',
+    );
+  });
+
+  it('closes a goal with (by search depth N)', () => {
+    const out = runTactics(
+      stateWithContext(
+        '(a = c)',
+        '(ab of (a = b))',
+        '(bc of (b = c))',
+        '(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))',
+      ),
+      [link('(by search depth 1)')],
+    );
+
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.state.goals, []);
+    assert.deepStrictEqual(out.state.proof.map(keyOf), [
+      '(by search depth 1 (by apply trans (by exact ab) (by exact bc)))',
+    ]);
   });
 });

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "relative-meta-logic"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "links-notation",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "relative-meta-logic"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "A prototype for logic framework that can reason about anything relative to given probability of input statements"
 license = "Unlicense"

--- a/rust/README.md
+++ b/rust/README.md
@@ -56,7 +56,7 @@ Or after building:
 use rml::{
     run, evaluate, format_diagnostic, Diagnostic, EvaluateResult, RunResult, Span,
     tokenize_one, parse_one, Env, EnvOptions, eval_node, quantize, dec_round, subst,
-    run_tactics, ProofState,
+    run_tactics, search, ProofState,
     formalize_selected_interpretation, evaluate_formalization,
     FormalizationRequest, Interpretation,
 };
@@ -85,6 +85,16 @@ let tactic = parse_one(&tokenize_one("(by reflexivity)")).unwrap();
 let goal = parse_one(&tokenize_one("(a = a)")).unwrap();
 let tactic_result = run_tactics(ProofState::from_goals(vec![goal]), &[tactic]);
 // -> tactic_result.state.goals is empty, diagnostics is empty
+
+// Run bounded backwards search over available lemmas
+let search_goal = parse_one(&tokenize_one("(a = c)")).unwrap();
+let lemmas = vec![
+    parse_one(&tokenize_one("(ab of (a = b))")).unwrap(),
+    parse_one(&tokenize_one("(bc of (b = c))")).unwrap(),
+    parse_one(&tokenize_one("(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))")).unwrap(),
+];
+let search_proof = search(&search_goal, 1, &lemmas).unwrap();
+// -> (by apply trans (by exact ab) (by exact bc))
 
 // Quantize a value to N discrete levels
 let q = quantize(0.4, 3, 0.0, 1.0); // -> 0.5 (nearest ternary level)
@@ -116,7 +126,7 @@ The test suite covers:
 - Liar paradox resolution across logic types
 - Decimal-precision arithmetic and numeric equality
 - Dependent type system: universes, Pi-types, lambdas, application, definitional equality, capture-avoiding substitution, freshness, type queries
-- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact
+- Link-based tactic engine: reflexivity, symmetry, transitivity, induction, suppose, introduce, by, rewrite, exact, bounded search
 - Self-referential types: `(Type: Type Type)`, paradox resolution alongside types
 
 ## Implementation Notes

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3549,6 +3549,133 @@ fn exact_closes_goal(arg: &Node, goal: &ProofGoal) -> bool {
     })
 }
 
+#[derive(Clone)]
+struct SearchLemma {
+    term: Node,
+    statement: Node,
+}
+
+fn search_lemma(lemma: &Node) -> SearchLemma {
+    if let Some((term, typ)) = type_ascription(lemma) {
+        return SearchLemma {
+            term: term.clone(),
+            statement: typ.clone(),
+        };
+    }
+    if let Node::List(children) = lemma {
+        if children.len() == 2 {
+            if let Node::Leaf(name) = &children[0] {
+                if name.ends_with(':') {
+                    return SearchLemma {
+                        term: Node::Leaf(name[..name.len() - 1].to_string()),
+                        statement: children[1].clone(),
+                    };
+                }
+            }
+        }
+    }
+    SearchLemma {
+        term: lemma.clone(),
+        statement: lemma.clone(),
+    }
+}
+
+fn pi_premises_and_conclusion(statement: &Node) -> Option<(Vec<Node>, Node)> {
+    let mut premises = Vec::new();
+    let mut current = statement.clone();
+    loop {
+        let Node::List(children) = &current else {
+            return Some((premises, current));
+        };
+        if children.len() != 3 || !matches!(&children[0], Node::Leaf(head) if head == "Pi") {
+            return Some((premises, current));
+        }
+        let (_, param_type_key) = parse_binding(&children[1])?;
+        premises.push(type_key_to_node(&param_type_key));
+        current = children[2].clone();
+    }
+}
+
+fn reflexivity_proof(goal: &Node) -> Option<Node> {
+    let (left, right) = as_equality(goal)?;
+    if is_structurally_same(left, right) {
+        return Some(wrap_proof("reflexivity", Vec::new()));
+    }
+    None
+}
+
+fn search_with_lemmas(goal: &Node, depth: usize, lemmas: &[SearchLemma]) -> Option<Node> {
+    if let Some(proof) = reflexivity_proof(goal) {
+        return Some(proof);
+    }
+
+    for lemma in lemmas {
+        if is_structurally_same(&lemma.statement, goal) {
+            return Some(wrap_proof("exact", vec![lemma.term.clone()]));
+        }
+    }
+
+    if depth == 0 {
+        return None;
+    }
+
+    for lemma in lemmas {
+        let Some((premises, conclusion)) = pi_premises_and_conclusion(&lemma.statement) else {
+            continue;
+        };
+        if premises.is_empty() || !is_structurally_same(&conclusion, goal) {
+            continue;
+        }
+        let mut subproofs = Vec::new();
+        let mut solved = true;
+        for premise in premises {
+            if let Some(subproof) = search_with_lemmas(&premise, depth - 1, lemmas) {
+                subproofs.push(subproof);
+            } else {
+                solved = false;
+                break;
+            }
+        }
+        if solved {
+            let mut subs = vec![lemma.term.clone()];
+            subs.extend(subproofs);
+            return Some(wrap_proof("apply", subs));
+        }
+    }
+
+    None
+}
+
+/// Depth-bounded backwards search over a goal and the available lemma links.
+///
+/// Direct lemmas and reflexive equality close at depth 0. Applying a `Pi`
+/// lemma consumes one unit of depth and recursively solves its premises.
+pub fn search(goal: &Node, depth: usize, lemmas: &[Node]) -> Option<Node> {
+    let search_lemmas: Vec<SearchLemma> = lemmas.iter().map(search_lemma).collect();
+    search_with_lemmas(goal, depth, &search_lemmas)
+}
+
+fn parse_search_depth(args: &[Node]) -> Option<usize> {
+    if args.len() != 2 || !matches!(&args[0], Node::Leaf(s) if s == "depth") {
+        return None;
+    }
+    let Node::Leaf(depth) = &args[1] else {
+        return None;
+    };
+    depth.parse::<usize>().ok()
+}
+
+fn record_search_proof(record_tactic: &Node, proof: &Node) -> Node {
+    match record_tactic {
+        Node::List(children) => {
+            let mut recorded = children.clone();
+            recorded.push(proof.clone());
+            Node::List(recorded)
+        }
+        _ => Node::List(vec![record_tactic.clone(), proof.clone()]),
+    }
+}
+
 fn apply_tactic(
     state: &ProofState,
     tactic: &Node,
@@ -3576,6 +3703,27 @@ fn apply_tactic(
     };
 
     match name {
+        Some("search") => {
+            let Some(depth) = parse_search_depth(args) else {
+                return Err(tactic_diagnostic(
+                    record_tactic,
+                    Some(current),
+                    "search expects `(search depth N)`",
+                ));
+            };
+            let Some(proof) = search(&current.goal, depth, &current.context) else {
+                return Err(tactic_diagnostic(
+                    record_tactic,
+                    Some(current),
+                    format!("search found no derivation within depth {}", depth),
+                ));
+            };
+            Ok(replace_current_goal(
+                state,
+                Vec::new(),
+                &record_search_proof(record_tactic, &proof),
+            ))
+        }
         Some("reflexivity") => {
             let Some((left, right)) = as_equality(&current.goal) else {
                 return Err(tactic_diagnostic(

--- a/rust/tests/tactics_tests.rs
+++ b/rust/tests/tactics_tests.rs
@@ -2,7 +2,8 @@
 // Mirrors js/tests/tactics.test.mjs so drift between runtimes fails CI.
 
 use rml::{
-    key_of, parse_one, parse_tactic_links, run_tactics, tokenize_one, Node, ProofGoal, ProofState,
+    key_of, parse_one, parse_tactic_links, run_tactics, search, tokenize_one, Node, ProofGoal,
+    ProofState,
 };
 
 fn link(src: &str) -> Node {
@@ -18,6 +19,16 @@ fn state(goals: &[&str]) -> ProofState {
                 context: Vec::new(),
             })
             .collect(),
+        proof: Vec::new(),
+    }
+}
+
+fn state_with_context(goal: &str, context: &[&str]) -> ProofState {
+    ProofState {
+        goals: vec![ProofGoal {
+            goal: link(goal),
+            context: context.iter().map(|lemma| link(lemma)).collect(),
+        }],
         proof: Vec::new(),
     }
 }
@@ -153,4 +164,43 @@ fn failed_tactic_reports_current_goal() {
     assert_eq!(out.diagnostics[0].code, "E039");
     assert!(out.diagnostics[0].message.contains("current goal: (a = b)"));
     assert_eq!(goal_keys(&out.state), vec!["(a = b)"]);
+}
+
+#[test]
+fn search_returns_bounded_derivation_tree_from_available_lemmas() {
+    let lemmas = vec![
+        link("(ab of (a = b))"),
+        link("(bc of (b = c))"),
+        link("(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))"),
+    ];
+
+    assert!(search(&link("(a = c)"), 0, &lemmas).is_none());
+
+    let proof = search(&link("(a = c)"), 1, &lemmas).expect("search proof missing");
+    assert_eq!(
+        key_of(&proof),
+        "(by apply trans (by exact ab) (by exact bc))"
+    );
+}
+
+#[test]
+fn closes_goal_with_by_search_depth() {
+    let out = run_tactics(
+        state_with_context(
+            "(a = c)",
+            &[
+                "(ab of (a = b))",
+                "(bc of (b = c))",
+                "(trans of (Pi ((a = b) ab) (Pi ((b = c) bc) (a = c))))",
+            ],
+        ),
+        &[link("(by search depth 1)")],
+    );
+
+    assert!(out.diagnostics.is_empty());
+    assert!(out.state.goals.is_empty());
+    assert_eq!(
+        out.state.proof.iter().map(key_of).collect::<Vec<_>>(),
+        vec!["(by search depth 1 (by apply trans (by exact ab) (by exact bc)))"]
+    );
 }


### PR DESCRIPTION
## Summary

Implements bounded backwards proof search for issue #57 in both reference runtimes.

- Adds `search(goal, depth, lemmas)` in JavaScript and Rust, returning a LiNo derivation tree or `null` / `None` when no bounded derivation is found.
- Adds `(by search depth N)` to the tactic engine, using the current goal context as available lemmas and recording the generated derivation tree in tactic history.
- Supports direct lemma matches, reflexive equality at depth 0, and `Pi` lemma application where each application consumes one depth unit.
- Documents the API/tactic surface and bumps JS/Rust package metadata to `0.19.0`.
- Removes the placeholder `.gitkeep` commit artifact.

## Reproduction and Tests

The regression tests build a goal `(a = c)` with context lemmas `ab`, `bc`, and a `trans` Pi lemma. Search at depth `0` fails, while depth `1` returns:

```lino
(by apply trans (by exact ab) (by exact bc))
```

Local verification:

- `node --test js/tests/tactics.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test tactics_tests`
- `cd js && npm test`
- `cargo test --manifest-path rust/Cargo.toml`
- `cd js && npm run lint:english`
- `git diff --check`

Note: `cargo fmt --manifest-path rust/Cargo.toml --check` still reports broad preexisting rustfmt drift in unrelated files/sections, so this PR avoids repo-wide formatting churn.

Fixes #57
