### PR TITLE
[G1] Standard library: classical logic (`lib/classical/`)

### DIFF
--- a/.github/workflows/lint-english.yml
+++ b/.github/workflows/lint-english.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Lint examples for English readability
-        run: node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino
+      - name: Lint LiNo files for English readability
+        run: node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/classical/*.lino
       - name: Run lint unit tests
         run: node --test scripts/lint-english.test.mjs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
+# Updated: 2026-05-08T14:10:29.370Z

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ Examples are language-agnostic and live in [`/examples/`](./examples/). Both
 implementations execute the same files and are required to produce identical
 output (enforced by `examples/expected.lino` and the shared-examples tests).
 
+### Standard libraries
+
+Reusable LiNo libraries live under [`/lib/`](./lib/). The classical Boolean
+library configures two-valued truth values and exports connectives, laws, and
+natural-deduction rule schemas from the `classical` namespace:
+
+```lino
+(import "lib/classical/core.lino" as cl)
+(? (cl.or p (cl.not p)))
+(? (cl.excluded-middle p))
+```
+
 ### Isabelle export
 
 ```bash
@@ -564,6 +576,10 @@ See `examples/classical-logic.lino` — the most familiar logic system where eve
 (? ((p = true) or (not (p = true))))    # -> 1 (law of excluded middle)
 (? ((p = true) and (not (p = true))))   # -> 0 (law of non-contradiction)
 ```
+
+For reusable imports, see `lib/classical/core.lino`, which packages these
+Boolean connectives plus excluded middle, double negation, De Morgan laws, and
+natural-deduction rule schemas under the `classical` namespace.
 
 ### Propositional Logic (Probabilistic)
 

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,7 @@
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
     "check": "node src/rml-check.mjs",
     "meta": "node src/rml-meta.mjs",
-    "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino"
+    "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino ../lib/classical/*.lino"
   },
   "keywords": [
     "logic",

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -4173,6 +4173,15 @@ function defineForm(head, rhs, env){
 
   // Operator redefinitions
   if (['=','!=','and','or','not','is','?:','both','neither'].includes(head) || /[=!]/.test(head)) {
+    // Operator alias: `(not: not)` inside a namespace exports the existing
+    // operator under the qualified name, e.g. `classical.not`.
+    if (rhs.length === 1 && typeof rhs[0] === 'string' && env.hasOp(rhs[0])) {
+      const target = rhs[0];
+      const op = env.getOp(target);
+      env.defineOp(storeName, (...xs) => op(...xs));
+      env.trace('resolve', `(${storeName}: ${target})`);
+      return 1;
+    }
 
     // Composition like: (!=: not =)   or  (=: =) (no-op)
     if (rhs.length === 2 && typeof rhs[0]==='string' && typeof rhs[1]==='string') {

--- a/js/tests/lib-classical.test.mjs
+++ b/js/tests/lib-classical.test.mjs
@@ -1,0 +1,69 @@
+// Tests for the classical standard library (issue #67).
+// Mirrors rust/tests/lib_classical_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-classical-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/classical/core.lino', () => {
+  it('exports Boolean operators through an import alias', () => {
+    const out = evaluateFromRoot(`
+(import "lib/classical/core.lino" as cl)
+(? (cl.and true false))
+(? (cl.or true false))
+(? (cl.not true))
+(? (cl.not false))
+(? (cl.or p (cl.not p)))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [0, 1, 0, 1, 1]);
+  });
+
+  it('exports classical laws as reusable templates', () => {
+    const out = evaluateFromRoot(`
+(import "lib/classical/core.lino" as cl)
+(? (cl.excluded-middle true))
+(? (cl.excluded-middle false))
+(? (cl.double-negation true))
+(? (cl.double-negation false))
+(? (cl.de-morgan-not-and true false))
+(? (cl.de-morgan-not-or true false))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1, 1]);
+  });
+
+  it('exports natural-deduction rule schemas as tautology templates', () => {
+    const out = evaluateFromRoot(`
+(import "lib/classical/core.lino" as cl)
+(? (cl.implies true false))
+(? (cl.implies false false))
+(? (cl.and-introduction true false))
+(? (cl.and-elimination-left true false))
+(? (cl.and-elimination-right true false))
+(? (cl.or-introduction-left false true))
+(? (cl.or-introduction-right true false))
+(? (cl.modus-ponens true false))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [0, 1, 1, 1, 1, 1, 1, 1]);
+  });
+});

--- a/lib/classical/core.lino
+++ b/lib/classical/core.lino
@@ -1,0 +1,64 @@
+# Classical logic standard library.
+#
+# This file installs Boolean truth values and exports classical connective
+# templates under the `classical` namespace. Import it with an alias such as:
+#
+#   (import "lib/classical/core.lino" as cl)
+#   (? (cl.excluded-middle p))
+
+(namespace classical)
+
+(valence: 2)
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(template (implies antecedent consequent)
+  (classical.or (classical.not antecedent) consequent))
+
+(template (excluded-middle proposition)
+  (classical.or proposition (classical.not proposition)))
+
+(template (non-contradiction proposition)
+  (classical.not (classical.and proposition (classical.not proposition))))
+
+(template (double-negation proposition)
+  (= (classical.not (classical.not proposition)) proposition))
+
+(template (de-morgan-not-and left right)
+  (= (classical.not (classical.and left right))
+     (classical.or (classical.not left) (classical.not right))))
+
+(template (de-morgan-not-or left right)
+  (= (classical.not (classical.or left right))
+     (classical.and (classical.not left) (classical.not right))))
+
+(template (and-introduction left right)
+  (classical.implies left
+    (classical.implies right (classical.and left right))))
+
+(template (and-elimination-left left right)
+  (classical.implies (classical.and left right) left))
+
+(template (and-elimination-right left right)
+  (classical.implies (classical.and left right) right))
+
+(template (or-introduction-left left right)
+  (classical.implies left (classical.or left right)))
+
+(template (or-introduction-right left right)
+  (classical.implies right (classical.or left right)))
+
+(template (or-elimination left right conclusion)
+  (classical.implies
+    (classical.implies left conclusion)
+    (classical.implies
+      (classical.implies right conclusion)
+      (classical.implies (classical.or left right) conclusion))))
+
+(template (modus-ponens antecedent consequent)
+  (classical.implies antecedent
+    (classical.implies
+      (classical.implies antecedent consequent)
+      consequent)))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7498,6 +7498,18 @@ fn define_form(head: &str, rhs: &[Node], env: &mut Env) -> EvalResult {
         || head.contains('!');
 
     if is_op_name {
+        // Operator alias: `(not: not)` inside a namespace exports the existing
+        // operator under the qualified name, e.g. `classical.not`.
+        if rhs.len() == 1 {
+            if let Node::Leaf(ref target) = rhs[0] {
+                if let Some(op) = env.get_op(target.as_str()).cloned() {
+                    env.define_op(&store_name, op);
+                    env.trace("resolve", format!("({}: {})", store_name, target));
+                    return EvalResult::Value(1.0);
+                }
+            }
+        }
+
         // Composition like: (!=: not =) or (=: =) (no-op)
         if rhs.len() == 2 {
             if let (Node::Leaf(ref outer), Node::Leaf(ref inner)) = (&rhs[0], &rhs[1]) {

--- a/rust/tests/lib_classical_tests.rs
+++ b/rust/tests/lib_classical_tests.rs
@@ -1,0 +1,105 @@
+// Tests for the classical standard library (issue #67).
+// Mirrors js/tests/lib-classical.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-classical-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_boolean_operators_through_import_alias() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/classical/core.lino" as cl)
+(? (cl.and true false))
+(? (cl.or true false))
+(? (cl.not true))
+(? (cl.not false))
+(? (cl.or p (cl.not p)))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_classical_laws_as_reusable_templates() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/classical/core.lino" as cl)
+(? (cl.excluded-middle true))
+(? (cl.excluded-middle false))
+(? (cl.double-negation true))
+(? (cl.double-negation false))
+(? (cl.de-morgan-not-and true false))
+(? (cl.de-morgan-not-or true false))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_natural_deduction_rule_schemas_as_tautology_templates() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/classical/core.lino" as cl)
+(? (cl.implies true false))
+(? (cl.implies false false))
+(? (cl.and-introduction true false))
+(? (cl.and-elimination-left true false))
+(? (cl.and-elimination-right true false))
+(? (cl.or-introduction-left false true))
+(? (cl.or-introduction-right true false))
+(? (cl.modus-ponens true false))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}

--- a/scripts/lint-english.test.mjs
+++ b/scripts/lint-english.test.mjs
@@ -234,11 +234,14 @@ describe('loadAllowlist()', () => {
 });
 
 describe('CLI', () => {
-  it('exits 0 when all bundled examples are clean', () => {
+  it('exits 0 when all bundled examples and libraries are clean', () => {
     const examples = fs.readdirSync(path.join(REPO_ROOT, 'examples'))
       .filter(f => f.endsWith('.lino'))
       .map(f => path.join(REPO_ROOT, 'examples', f));
-    const r = spawnSync(process.execPath, [SCRIPT, ...examples], { encoding: 'utf8' });
+    const libraries = fs.readdirSync(path.join(REPO_ROOT, 'lib', 'classical'))
+      .filter(f => f.endsWith('.lino'))
+      .map(f => path.join(REPO_ROOT, 'lib', 'classical', f));
+    const r = spawnSync(process.execPath, [SCRIPT, ...examples, ...libraries], { encoding: 'utf8' });
     assert.strictEqual(r.status, 0,
       `expected clean lint, got status ${r.status}\n${r.stdout}\n${r.stderr}`);
   });


### PR DESCRIPTION
Fixes #67

## Summary
- Add `lib/classical/core.lino` with Boolean connectives, excluded middle, non-contradiction, double negation, De Morgan laws, and natural-deduction rule schemas under `(namespace classical)`.
- Add JS and Rust tests for importing the library as `cl`, including the issue's literal `(? (cl.or p (cl.not p)))` surface.
- Add operator alias support so namespaced `.lino` libraries can export aliases like `classical.not`.
- Reference the standard library from the README and include it in English lint coverage.

## Reproduction
Before this change, the requested import failed because `lib/classical/core.lino` did not exist:

```lino
(import "lib/classical/core.lino" as cl)
(? (cl.or p (cl.not p)))
```

The new JS and Rust tests cover that import and query directly.

## Tests
- `npm run lint:english`
- `node --test tests/lib-classical.test.mjs`
- `cargo test --test lib_classical_tests`
- `npm test`
- `cargo test`
