### PR TITLE
[G2] Standard library: first-order logic (`lib/first-order/`)

### DIFF
--- a/.github/workflows/lint-english.yml
+++ b/.github/workflows/lint-english.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           node-version: '20'
       - name: Lint LiNo files for English readability
-        run: node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/classical/*.lino
+        run: node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/*/*.lino
       - name: Run lint unit tests
         run: node --test scripts/lint-english.test.mjs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
 # Updated: 2026-05-08T14:10:29.370Z
+# Updated: 2026-05-08T14:30:53.403Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
 # Updated: 2026-05-08T14:10:29.370Z
-# Updated: 2026-05-08T14:30:53.403Z

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ natural-deduction rule schemas from the `classical` namespace:
 (? (cl.excluded-middle p))
 ```
 
+The first-order library exports aliasable quantifier templates from the
+`first-order` namespace:
+
+```lino
+(import "lib/first-order/core.lino" as fo)
+(? (fo.forall (Term x) (predicate x)))
+(? ((fo.exists (Term x) (predicate x)) = (exists (Term x) (predicate x))))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/package.json
+++ b/js/package.json
@@ -14,7 +14,7 @@
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
     "check": "node src/rml-check.mjs",
     "meta": "node src/rml-meta.mjs",
-    "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino ../lib/classical/*.lino"
+    "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino ../lib/*/*.lino"
   },
   "keywords": [
     "logic",

--- a/js/tests/lib-first-order.test.mjs
+++ b/js/tests/lib-first-order.test.mjs
@@ -1,0 +1,61 @@
+// Tests for the first-order standard library (issue #69).
+// Mirrors rust/tests/lib_first_order_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-first-order-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/first-order/core.lino', () => {
+  it('exports forall as an alias-qualified template for Pi', () => {
+    const out = evaluateFromRoot(`
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.forall (Term x) (predicate x)) = (Pi (Term x) (predicate x))))
+(? (fo.forall (Term x) Term))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1]);
+  });
+
+  it('exports exists as an alias-qualified first-order link shape', () => {
+    const out = evaluateFromRoot(`
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.exists (Term x) (predicate x)) = (exists (Term x) (predicate x))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('expands nested quantified formulas before evaluation', () => {
+    const out = evaluateFromRoot(`
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.forall (Term x)
+       (fo.exists (Term y) ((pair x y) = (pair x y))))
+     =
+     (Pi (Term x)
+       (exists (Term y) ((pair x y) = (pair x y))))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+});

--- a/lib/first-order/core.lino
+++ b/lib/first-order/core.lino
@@ -1,0 +1,16 @@
+# First-order logic standard library.
+#
+# This file exports English-readable quantifier templates under the
+# `first-order` namespace. Import it with an alias such as:
+#
+#   (import "lib/first-order/core.lino" as fo)
+#   (? (fo.forall (Term x) (predicate x)))
+#   (? (fo.exists (Term x) (predicate x)))
+
+(namespace first-order)
+
+(template (forall binder body)
+  (forall binder body))
+
+(template (exists binder body)
+  (exists binder body))

--- a/rust/tests/lib_first_order_tests.rs
+++ b/rust/tests/lib_first_order_tests.rs
@@ -1,0 +1,69 @@
+// Tests for the first-order standard library (issue #69).
+// Mirrors js/tests/lib-first-order.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-first-order-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_forall_as_alias_qualified_template_for_pi() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.forall (Term x) (predicate x)) = (Pi (Term x) (predicate x))))
+(? (fo.forall (Term x) Term))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![RunResult::Num(1.0), RunResult::Num(1.0)]
+    );
+}
+
+#[test]
+fn exports_exists_as_alias_qualified_first_order_link_shape() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.exists (Term x) (predicate x)) = (exists (Term x) (predicate x))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+}
+
+#[test]
+fn expands_nested_quantified_formulas_before_evaluation() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/first-order/core.lino" as fo)
+(Term: (Type 0) Term)
+(? ((fo.forall (Term x)
+       (fo.exists (Term y) ((pair x y) = (pair x y))))
+     =
+     (Pi (Term x)
+       (exists (Term y) ((pair x y) = (pair x y))))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+}


### PR DESCRIPTION
## Summary
Fixes #69.

- Add `lib/first-order/core.lino` with the `first-order` namespace and alias-qualified `forall` / `exists` quantifier templates.
- Add JS and Rust parity tests for importing the library, expanding quantified formulas, and nested quantifier behavior.
- Link the library from the README and expand English lint coverage to all `lib/*/*.lino` standard-library files.

## Tests
- `node --test tests/lib-first-order.test.mjs`
- `cargo test --test lib_first_order_tests`
- `node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/*/*.lino`
- `node --test scripts/lint-english.test.mjs`
- `npm run lint:english`
- `npm test`
- `cargo test`
