### PR TITLE
[G3] Standard library: higher-order logic (`lib/higher-order/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
 # Updated: 2026-05-08T14:10:29.370Z
-# Updated: 2026-05-08T14:51:07.007Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
 # Updated: 2026-05-08T14:10:29.370Z
+# Updated: 2026-05-08T14:51:07.007Z

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ The first-order library exports aliasable quantifier templates from the
 (? ((fo.exists (Term x) (predicate x)) = (exists (Term x) (predicate x))))
 ```
 
+The higher-order library exports quantifier templates for predicate binders
+from the `higher-order` namespace:
+
+```lino
+(import "lib/higher-order/core.lino" as ho)
+(? (ho.forall ((Pi (Natural n) Boolean) P)
+     ((P zero) implies (ho.forall (Natural n) (P (succ n))))))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/lib-higher-order.test.mjs
+++ b/js/tests/lib-higher-order.test.mjs
@@ -1,0 +1,54 @@
+// Tests for the higher-order standard library (issue #70).
+// Mirrors rust/tests/lib_higher_order_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-higher-order-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/higher-order/core.lino', () => {
+  it('exports forall as an alias-qualified template for predicate binders', () => {
+    const out = evaluateFromRoot(`
+(import "lib/higher-order/core.lino" as ho)
+(Natural: (Type 0) Natural)
+(zero: Natural)
+(succ: (Pi (Natural n) Natural))
+(? ((ho.forall ((Pi (Natural n) Boolean) P)
+       ((P zero) implies (ho.forall (Natural n) (P (succ n)))))
+     =
+     (Pi ((Pi (Natural n) Boolean) P)
+       ((P zero) implies (Pi (Natural n) (P (succ n)))))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('exports exists as an alias-qualified template for predicate binders', () => {
+    const out = evaluateFromRoot(`
+(import "lib/higher-order/core.lino" as ho)
+(Natural: (Type 0) Natural)
+(zero: Natural)
+(? ((ho.exists ((Pi (Natural n) Boolean) P) (P zero))
+    =
+    (exists ((Pi (Natural n) Boolean) P) (P zero))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+});

--- a/lib/higher-order/core.lino
+++ b/lib/higher-order/core.lino
@@ -1,0 +1,15 @@
+# Higher-order logic standard library.
+#
+# This file exports quantifier templates that accept higher-order binders under
+# the `higher-order` namespace. Import it with an alias such as:
+#
+#   (import "lib/higher-order/core.lino" as ho)
+#   (? (ho.forall ((Pi (Natural n) Boolean) P) (P zero)))
+
+(namespace higher-order)
+
+(template (forall binder body)
+  (forall binder body))
+
+(template (exists binder body)
+  (exists binder body))

--- a/rust/tests/lib_higher_order_tests.rs
+++ b/rust/tests/lib_higher_order_tests.rs
@@ -1,0 +1,56 @@
+// Tests for the higher-order standard library (issue #70).
+// Mirrors js/tests/lib-higher-order.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-higher-order-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_forall_as_alias_qualified_template_for_predicate_binders() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/higher-order/core.lino" as ho)
+(Natural: (Type 0) Natural)
+(zero: Natural)
+(succ: (Pi (Natural n) Natural))
+(? ((ho.forall ((Pi (Natural n) Boolean) P)
+       ((P zero) implies (ho.forall (Natural n) (P (succ n)))))
+     =
+     (Pi ((Pi (Natural n) Boolean) P)
+       ((P zero) implies (Pi (Natural n) (P (succ n)))))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+}
+
+#[test]
+fn exports_exists_as_alias_qualified_template_for_predicate_binders() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/higher-order/core.lino" as ho)
+(Natural: (Type 0) Natural)
+(zero: Natural)
+(? ((ho.exists ((Pi (Natural n) Boolean) P) (P zero))
+    =
+    (exists ((Pi (Natural n) Boolean) P) (P zero))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(1.0)]);
+}


### PR DESCRIPTION
## Summary
Fixes #70.

- Add `lib/higher-order/core.lino` with the `higher-order` namespace and alias-qualified `forall` / `exists` quantifier templates for higher-order predicate binders.
- Add JS and Rust parity tests covering the issue-specified predicate quantification shape and existential predicate binders.
- Link the new library from the README standard libraries section.

## Reproduction
Before this change, importing `lib/higher-order/core.lino` failed with `E007` because the standard library file did not exist.

## Tests
- `node --test js/tests/lib-higher-order.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_higher_order_tests`
- `node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/*/*.lino`
- `node --test scripts/lint-english.test.mjs`
- `npm run lint:english --prefix js`
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
