### PR TITLE
[G4] Standard library: modal logic (`lib/modal/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-05T11:51:47.888Z for PR creation at branch issue-42-64d5c4edef5f for issue https://github.com/link-foundation/relative-meta-logic/issues/42
 # Updated: 2026-05-05T12:10:25.688Z
 # Updated: 2026-05-08T14:10:29.370Z
+# Updated: 2026-05-08T15:10:24.296Z

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ from the `higher-order` namespace:
      ((P zero) implies (ho.forall (Natural n) (P (succ n))))))
 ```
 
+The modal library exports normal modal operators, K/T/S4/S5 axiom schemas,
+and Kripke-frame interpretation templates from the `modal` namespace:
+
+```lino
+(import "lib/modal/core.lino" as ml)
+(? (ml.axiom-k p q))
+(? (ml.necessarily-at current p))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/lib-modal.test.mjs
+++ b/js/tests/lib-modal.test.mjs
@@ -1,0 +1,110 @@
+// Tests for the modal standard library (issue #71).
+// Mirrors rust/tests/lib_modal_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-modal-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/modal/core.lino', () => {
+  it('exports modal operators through an import alias', () => {
+    const out = evaluateFromRoot(`
+(import "lib/modal/core.lino" as ml)
+(? ((ml.necessarily p) = (necessarily p)))
+(? ((ml.possibly p) = (possibly p)))
+(? (ml.implies true false))
+(? (ml.implies false false))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 0, 1]);
+  });
+
+  it('exports K, T, S4, and S5 axiom schemas as reusable templates', () => {
+    const out = evaluateFromRoot(`
+(import "lib/modal/core.lino" as ml)
+(? ((ml.axiom-k p q) =
+     (ml.implies
+       (ml.necessarily (ml.implies p q))
+       (ml.implies (ml.necessarily p) (ml.necessarily q)))))
+(? ((ml.axiom-t p) =
+     (ml.implies (ml.necessarily p) p)))
+(? ((ml.axiom-s4 p) =
+     (ml.implies (ml.necessarily p)
+       (ml.necessarily (ml.necessarily p)))))
+(? ((ml.axiom-s5 p) =
+     (ml.implies (ml.possibly p)
+       (ml.necessarily (ml.possibly p)))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1]);
+  });
+
+  it('exports Kripke-frame interpretation templates', () => {
+    const out = evaluateFromRoot(`
+(import "lib/modal/core.lino" as ml)
+(? ((ml.holds current p) = (holds current p)))
+(? ((ml.accessible current next) = (accessible current next)))
+(? ((ml.necessarily-at current p) =
+     (forall (World accessible-world)
+       (ml.implies
+         (ml.accessible current accessible-world)
+         (ml.holds accessible-world p)))))
+(? ((ml.possibly-at current p) =
+     (exists (World accessible-world)
+       (modal.and
+         (ml.accessible current accessible-world)
+         (ml.holds accessible-world p)))))
+(? ((ml.valid p) =
+     (forall (World possible-world) (ml.holds possible-world p))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1]);
+  });
+
+  it('exports Kripke frame conditions for modal systems', () => {
+    const out = evaluateFromRoot(`
+(import "lib/modal/core.lino" as ml)
+(? ((ml.frame-k modal.accessible) = true))
+(? ((ml.frame-t modal.accessible) = (ml.reflexive-frame modal.accessible)))
+(? ((ml.frame-s4 modal.accessible) =
+     (modal.and
+       (ml.reflexive-frame modal.accessible)
+       (ml.transitive-frame modal.accessible))))
+(? ((ml.frame-s5 modal.accessible) =
+     (modal.and
+       (ml.reflexive-frame modal.accessible)
+       (modal.and
+         (ml.symmetric-frame modal.accessible)
+         (ml.transitive-frame modal.accessible)))))
+(? ((ml.euclidean-frame modal.accessible) =
+     (forall (World source)
+       (forall (World left)
+         (forall (World right)
+           (ml.implies
+             (modal.and
+               (ml.accessible source left)
+               (ml.accessible source right))
+             (ml.accessible left right)))))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1]);
+  });
+});

--- a/lib/modal/core.lino
+++ b/lib/modal/core.lino
@@ -1,0 +1,117 @@
+# Modal logic standard library.
+#
+# This file configures Boolean connectives for normal modal logic and exports
+# modal operators, K/T/S4/S5 axiom schemas, and Kripke-frame interpretation
+# templates under the `modal` namespace. Import it with an alias such as:
+#
+#   (import "lib/modal/core.lino" as ml)
+#   (? (ml.axiom-k p q))
+#   (? (ml.necessarily-at current p))
+
+(namespace modal)
+
+(valence: 2)
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(template (implies antecedent consequent)
+  (modal.or (modal.not antecedent) consequent))
+
+(template (necessarily proposition)
+  (necessarily proposition))
+
+(template (possibly proposition)
+  (possibly proposition))
+
+(template (axiom-k antecedent consequent)
+  (modal.implies
+    (modal.necessarily (modal.implies antecedent consequent))
+    (modal.implies
+      (modal.necessarily antecedent)
+      (modal.necessarily consequent))))
+
+(template (axiom-t proposition)
+  (modal.implies (modal.necessarily proposition) proposition))
+
+(template (axiom-s4 proposition)
+  (modal.implies
+    (modal.necessarily proposition)
+    (modal.necessarily (modal.necessarily proposition))))
+
+(template (axiom-s5 proposition)
+  (modal.implies
+    (modal.possibly proposition)
+    (modal.necessarily (modal.possibly proposition))))
+
+(template (holds possible-world proposition)
+  (holds possible-world proposition))
+
+(template (accessible source target)
+  (accessible source target))
+
+(template (valid proposition)
+  (forall (World possible-world)
+    (modal.holds possible-world proposition)))
+
+(template (necessarily-at current-world proposition)
+  (forall (World accessible-world)
+    (modal.implies
+      (modal.accessible current-world accessible-world)
+      (modal.holds accessible-world proposition))))
+
+(template (possibly-at current-world proposition)
+  (exists (World accessible-world)
+    (modal.and
+      (modal.accessible current-world accessible-world)
+      (modal.holds accessible-world proposition))))
+
+(template (reflexive-frame accessibility)
+  (forall (World possible-world)
+    (accessibility possible-world possible-world)))
+
+(template (transitive-frame accessibility)
+  (forall (World source)
+    (forall (World middle)
+      (forall (World target)
+        (modal.implies
+          (modal.and
+            (accessibility source middle)
+            (accessibility middle target))
+          (accessibility source target))))))
+
+(template (symmetric-frame accessibility)
+  (forall (World source)
+    (forall (World target)
+      (modal.implies
+        (accessibility source target)
+        (accessibility target source)))))
+
+(template (euclidean-frame accessibility)
+  (forall (World source)
+    (forall (World left)
+      (forall (World right)
+        (modal.implies
+          (modal.and
+            (accessibility source left)
+            (accessibility source right))
+          (accessibility left right))))))
+
+(template (frame-k accessibility)
+  true)
+
+(template (frame-t accessibility)
+  (modal.reflexive-frame accessibility))
+
+(template (frame-s4 accessibility)
+  (modal.and
+    (modal.reflexive-frame accessibility)
+    (modal.transitive-frame accessibility)))
+
+(template (frame-s5 accessibility)
+  (modal.and
+    (modal.reflexive-frame accessibility)
+    (modal.and
+      (modal.symmetric-frame accessibility)
+      (modal.transitive-frame accessibility))))

--- a/rust/tests/lib_modal_tests.rs
+++ b/rust/tests/lib_modal_tests.rs
@@ -1,0 +1,152 @@
+// Tests for the modal standard library (issue #71).
+// Mirrors js/tests/lib-modal.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-modal-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_modal_operators_through_import_alias() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/modal/core.lino" as ml)
+(? ((ml.necessarily p) = (necessarily p)))
+(? ((ml.possibly p) = (possibly p)))
+(? (ml.implies true false))
+(? (ml.implies false false))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_k_t_s4_and_s5_axiom_schemas_as_reusable_templates() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/modal/core.lino" as ml)
+(? ((ml.axiom-k p q) =
+     (ml.implies
+       (ml.necessarily (ml.implies p q))
+       (ml.implies (ml.necessarily p) (ml.necessarily q)))))
+(? ((ml.axiom-t p) =
+     (ml.implies (ml.necessarily p) p)))
+(? ((ml.axiom-s4 p) =
+     (ml.implies (ml.necessarily p)
+       (ml.necessarily (ml.necessarily p)))))
+(? ((ml.axiom-s5 p) =
+     (ml.implies (ml.possibly p)
+       (ml.necessarily (ml.possibly p)))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_kripke_frame_interpretation_templates() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/modal/core.lino" as ml)
+(? ((ml.holds current p) = (holds current p)))
+(? ((ml.accessible current next) = (accessible current next)))
+(? ((ml.necessarily-at current p) =
+     (forall (World accessible-world)
+       (ml.implies
+         (ml.accessible current accessible-world)
+         (ml.holds accessible-world p)))))
+(? ((ml.possibly-at current p) =
+     (exists (World accessible-world)
+       (modal.and
+         (ml.accessible current accessible-world)
+         (ml.holds accessible-world p)))))
+(? ((ml.valid p) =
+     (forall (World possible-world) (ml.holds possible-world p))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_kripke_frame_conditions_for_modal_systems() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/modal/core.lino" as ml)
+(? ((ml.frame-k modal.accessible) = true))
+(? ((ml.frame-t modal.accessible) = (ml.reflexive-frame modal.accessible)))
+(? ((ml.frame-s4 modal.accessible) =
+     (modal.and
+       (ml.reflexive-frame modal.accessible)
+       (ml.transitive-frame modal.accessible))))
+(? ((ml.frame-s5 modal.accessible) =
+     (modal.and
+       (ml.reflexive-frame modal.accessible)
+       (modal.and
+         (ml.symmetric-frame modal.accessible)
+         (ml.transitive-frame modal.accessible)))))
+(? ((ml.euclidean-frame modal.accessible) =
+     (forall (World source)
+       (forall (World left)
+         (forall (World right)
+           (ml.implies
+             (modal.and
+               (ml.accessible source left)
+               (ml.accessible source right))
+             (ml.accessible left right)))))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}


### PR DESCRIPTION
Fixes #71

## Summary
- Add `lib/modal/core.lino` with the `modal` namespace, Boolean modal connectives, `necessarily` / `possibly`, and K/T/S4/S5 axiom schemas.
- Add Kripke-frame interpretation templates for `holds`, `accessible`, validity, necessity/possibility at a world, and frame conditions for K, T, S4, and S5.
- Add JS and Rust parity tests covering imports, axiom-schema expansion, Kripke interpretation templates, and frame conditions.
- Link the modal standard library from the README standard libraries section.

## Reproduction
Before this change, the requested import failed with `E007` because `lib/modal/core.lino` did not exist:

```lino
(import "lib/modal/core.lino" as ml)
(? (ml.axiom-k p q))
(? (ml.necessarily-at current p))
```

The new JS and Rust tests cover that import and the issue-specified `(necessarily p)` / `(possibly p)` surface directly.

## Tests
- `node --test js/tests/lib-modal.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_modal_tests`
- `npm run lint:english --prefix js`
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
