### PR TITLE
[G7] Standard library: arithmetic (`lib/arithmetic/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-08T17:48:00.545Z for PR creation at branch issue-74-fc365a776853 for issue https://github.com/link-foundation/relative-meta-logic/issues/74

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-08T17:48:00.545Z for PR creation at branch issue-74-fc365a776853 for issue https://github.com/link-foundation/relative-meta-logic/issues/74

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ ZF-style axiom schemas from the `set-theory` namespace:
 (? (st.axiom-extensionality a b))
 ```
 
+The [arithmetic library](./lib/arithmetic/core.lino) exports Peano naturals,
+addition/order templates, and decimal-precision lemmas from the `arithmetic`
+namespace:
+
+```lino
+(import "lib/arithmetic/core.lino" as ar)
+(? ((plus zero zero) = zero))
+(? (ar.less-than zero (succ zero)))
+(? (ar.decimal-sum-equals 0.1 0.2 0.3))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -318,6 +318,8 @@ class Env {
     this.defineOp('-', (a,b)=> decRound(a - b));
     this.defineOp('*', (a,b)=> decRound(a * b));
     this.defineOp('/', (a,b)=> b === 0 ? 0 : decRound(a / b));
+    this.defineOp('<', (a,b)=> a < b ? this.hi : this.lo);
+    this.defineOp('<=', (a,b)=> a <= b ? this.hi : this.lo);
 
     // Initialize truth constants: true, false, unknown, undefined
     // These are predefined symbol probabilities based on the current range.
@@ -392,7 +394,10 @@ class Env {
   }
   getType(exprNode){
     const key = typeof exprNode === 'string' ? exprNode : keyOf(exprNode);
-    return this.types.get(key) || null;
+    if (this.types.has(key)) return this.types.get(key);
+    const resolved = this._resolveQualified(key);
+    if (resolved !== key && this.types.has(resolved)) return this.types.get(resolved);
+    return null;
   }
   setLambda(name, param, paramType, body){
     this.lambdas.set(name, { param, paramType, body });
@@ -447,6 +452,7 @@ class Env {
         this.ops.has(qualified) ||
         this.symbolProb.has(qualified) ||
         this.terms.has(qualified) ||
+        this.types.has(qualified) ||
         this.lambdas.has(qualified) ||
         this.templates.has(qualified)
       ) {
@@ -561,7 +567,7 @@ const NON_VARIABLE_TOKENS = new Set([
   'define', 'case', 'measure', 'lex', 'terminating',
   'whnf', 'nf', 'normal-form',
   'template',
-  '+', '-', '*', '/', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
+  '+', '-', '*', '/', '<', '<=', '=', '!=', 'and', 'or', 'not', 'both', 'neither', 'nor',
 ]);
 
 function cloneTerm(node) {
@@ -3888,6 +3894,14 @@ function evalNode(node, env){
     return op(L,R);
   }
 
+  // Numeric comparisons: (A < B), (A <= B)
+  if (node.length === 3 && typeof node[1] === 'string' && ['<','<='].includes(node[1])) {
+    const op = env.getOp(node[1]);
+    const L = evalArith(node[0], env);
+    const R = evalArith(node[2], env);
+    return env.clamp(op(L,R));
+  }
+
   // Infix AND/OR/BOTH/NEITHER: ((A) and (B))  /  ((A) or (B))  /  ((A) both (B))  /  ((A) neither (B))
   if (node.length === 3 && typeof node[1] === 'string' && (node[1]==='and' || node[1]==='or' || node[1]==='both' || node[1]==='neither')) {
     const op = env.getOp(node[1]);
@@ -4093,6 +4107,8 @@ function _reinitOps(env) {
   env.ops.set('-', (a,b) => decRound(a - b));
   env.ops.set('*', (a,b) => decRound(a * b));
   env.ops.set('/', (a,b) => b === 0 ? 0 : decRound(a / b));
+  env.ops.set('<', (a,b) => a < b ? env.hi : env.lo);
+  env.ops.set('<=', (a,b) => a <= b ? env.hi : env.lo);
   // Re-initialize truth constants for new range
   env._initTruthConstants();
 }

--- a/js/tests/lib-arithmetic.test.mjs
+++ b/js/tests/lib-arithmetic.test.mjs
@@ -1,0 +1,78 @@
+// Tests for the arithmetic standard library (issue #74).
+// Mirrors rust/tests/lib_arithmetic_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-arithmetic-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/arithmetic/core.lino', () => {
+  it('exports Peano naturals and issue-surface arithmetic through an import alias', () => {
+    const out = evaluateFromRoot(`
+(import "lib/arithmetic/core.lino" as ar)
+(? (zero of Natural))
+(? (type of ar.succ))
+(? ((plus zero zero) = zero))
+(? (less-than zero (succ zero)))
+(? (less-than-or-equal zero zero))
+(? (ar.less-than zero (succ zero)))
+(? (ar.less-than-or-equal zero zero))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [
+      1,
+      '(Pi (Natural n) Natural)',
+      1,
+      1,
+      1,
+      1,
+      1,
+    ]);
+  });
+
+  it('exports Peano axiom schemas as reusable templates', () => {
+    const out = evaluateFromRoot(`
+(import "lib/arithmetic/core.lino" as ar)
+(? (ar.peano-zero-is-natural zero))
+(? (ar.peano-successor-is-natural zero))
+(? (ar.plus-zero-left zero))
+(? (ar.plus-zero-right zero))
+(? (ar.plus-successor-left zero zero))
+(? (ar.less-than-successor zero))
+(? (ar.less-than-or-equal-reflexive zero))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1, 1, 1]);
+  });
+
+  it('exports decimal-precision lemmas for built-in arithmetic', () => {
+    const out = evaluateFromRoot(`
+(import "lib/arithmetic/core.lino" as ar)
+(? (ar.decimal-sum-equals 0.1 0.2 0.3))
+(? (ar.decimal-difference-equals 0.3 0.1 0.2))
+(? (ar.decimal-product-equals 0.1 0.2 0.02))
+(? (ar.decimal-quotient-equals 1 3 0.333333333333))
+(? (ar.less-than 0.1 0.2))
+(? (ar.less-than-or-equal 0.3 (0.1 + 0.2)))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1, 1]);
+  });
+});

--- a/lib/arithmetic/core.lino
+++ b/lib/arithmetic/core.lino
@@ -1,0 +1,161 @@
+# Arithmetic standard library.
+#
+# This file declares Peano naturals, validates total symbolic relations for
+# addition and order, and exports Peano and decimal arithmetic templates under
+# the `arithmetic` namespace. Import it with an alias such as:
+#
+#   (import "lib/arithmetic/core.lino" as ar)
+#   (? ((plus zero zero) = zero))
+#   (? (ar.less-than zero (succ zero)))
+#   (? (ar.decimal-sum-equals 0.1 0.2 0.3))
+
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+
+(zero: 0)
+
+(mode plus-relation +input +input -output)
+(relation plus-relation
+  (plus-relation zero n n)
+  (plus-relation (succ m) n (succ (plus-relation m n))))
+(total plus-relation)
+(coverage plus-relation)
+
+(mode less-than-relation +input +input -output)
+(relation less-than-relation
+  (less-than-relation zero zero false)
+  (less-than-relation zero (succ n) true)
+  (less-than-relation (succ m) zero false)
+  (less-than-relation (succ m) (succ n) (less-than-relation m n)))
+(total less-than-relation)
+(coverage less-than-relation)
+
+(mode less-than-or-equal-relation +input +input -output)
+(relation less-than-or-equal-relation
+  (less-than-or-equal-relation zero n true)
+  (less-than-or-equal-relation (succ m) zero false)
+  (less-than-or-equal-relation (succ m) (succ n) (less-than-or-equal-relation m n)))
+(total less-than-or-equal-relation)
+(coverage less-than-or-equal-relation)
+
+(define plus-recursive
+  (case (zero n) n)
+  (case ((succ m) n) (succ (plus-recursive m n))))
+(terminating plus-recursive)
+
+(define less-than-recursive
+  (case (zero zero) false)
+  (case (zero (succ n)) true)
+  (case ((succ m) zero) false)
+  (case ((succ m) (succ n)) (less-than-recursive m n)))
+(terminating less-than-recursive)
+
+(define less-than-or-equal-recursive
+  (case (zero n) true)
+  (case ((succ m) zero) false)
+  (case ((succ m) (succ n)) (less-than-or-equal-recursive m n)))
+(terminating less-than-or-equal-recursive)
+
+(template (succ n)
+  (n + 1))
+
+(template (plus left right)
+  (left + right))
+
+(template (less-than left right)
+  (left < right))
+
+(template (less-than-or-equal left right)
+  (left <= right))
+
+(namespace arithmetic)
+
+(valence: 2)
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(Natural: (Type 0) Natural)
+(zero: Natural zero)
+(zero: 0)
+(succ: (Pi (Natural n) Natural))
+
+(template (succ n)
+  (n + 1))
+
+(template (successor n)
+  (succ n))
+
+(template (plus left right)
+  (left + right))
+
+(template (less-than left right)
+  (left < right))
+
+(template (less-than-or-equal left right)
+  (left <= right))
+
+(template (implies antecedent consequent)
+  (arithmetic.or (arithmetic.not antecedent) consequent))
+
+(template (iff left right)
+  (arithmetic.and
+    (arithmetic.implies left right)
+    (arithmetic.implies right left)))
+
+(template (peano-zero-is-natural witness)
+  (zero of Natural))
+
+(template (peano-successor-is-natural n)
+  (n of Natural))
+
+(template (plus-zero-left n)
+  (= (plus zero n) n))
+
+(template (plus-zero-right n)
+  (= (plus n zero) n))
+
+(template (plus-successor-left left right)
+  (= (plus (succ left) right)
+     (succ (plus left right))))
+
+(template (plus-successor-right left right)
+  (= (plus left (succ right))
+     (succ (plus left right))))
+
+(template (less-than-successor n)
+  (less-than n (succ n)))
+
+(template (less-than-or-equal-reflexive n)
+  (less-than-or-equal n n))
+
+(template (less-than-implies-less-than-or-equal left right)
+  (arithmetic.implies
+    (less-than left right)
+    (less-than-or-equal left right)))
+
+(template (decimal-sum left right)
+  (left + right))
+
+(template (decimal-difference left right)
+  (left - right))
+
+(template (decimal-product left right)
+  (left * right))
+
+(template (decimal-quotient left right)
+  (left / right))
+
+(template (decimal-sum-equals left right expected-sum)
+  (= (left + right) expected-sum))
+
+(template (decimal-difference-equals left right difference)
+  (= (left - right) difference))
+
+(template (decimal-product-equals left right product)
+  (= (left * right) product))
+
+(template (decimal-quotient-equals left right quotient)
+  (= (left / right) quotient))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -660,6 +660,9 @@ pub enum Op {
     Sub,
     Mul,
     Div,
+    /// Numeric comparisons: <, <=
+    Less,
+    LessOrEqual,
 }
 
 // ========== Environment ==========
@@ -915,6 +918,8 @@ impl Env {
         ops.insert("-".to_string(), Op::Sub);
         ops.insert("*".to_string(), Op::Mul);
         ops.insert("/".to_string(), Op::Div);
+        ops.insert("<".to_string(), Op::Less);
+        ops.insert("<=".to_string(), Op::LessOrEqual);
 
         let mut env = Self {
             terms: HashSet::new(),
@@ -1057,6 +1062,7 @@ impl Env {
             if self.ops.contains_key(&qualified)
                 || self.symbol_prob.contains_key(&qualified)
                 || self.terms.contains(&qualified)
+                || self.types.contains_key(&qualified)
                 || self.lambdas.contains_key(&qualified)
                 || self.templates.contains_key(&qualified)
             {
@@ -1107,7 +1113,14 @@ impl Env {
     }
 
     pub fn get_type(&self, expr: &str) -> Option<&String> {
-        self.types.get(expr)
+        if let Some(recorded) = self.types.get(expr) {
+            return Some(recorded);
+        }
+        let resolved = self.resolve_qualified(expr);
+        if resolved != expr {
+            return self.types.get(&resolved);
+        }
+        None
     }
 
     pub fn set_lambda(&mut self, name: &str, lambda: Lambda) {
@@ -1186,6 +1199,20 @@ impl Env {
                     0.0
                 }
             }
+            Op::Less => {
+                if vals.len() >= 2 && vals[0] < vals[1] {
+                    self.hi
+                } else {
+                    self.lo
+                }
+            }
+            Op::LessOrEqual => {
+                if vals.len() >= 2 && vals[0] <= vals[1] {
+                    self.hi
+                } else {
+                    self.lo
+                }
+            }
         }
     }
 
@@ -1222,6 +1249,8 @@ impl Env {
         self.ops.insert("-".to_string(), Op::Sub);
         self.ops.insert("*".to_string(), Op::Mul);
         self.ops.insert("/".to_string(), Op::Div);
+        self.ops.insert("<".to_string(), Op::Less);
+        self.ops.insert("<=".to_string(), Op::LessOrEqual);
         // Re-initialize truth constants for new range
         self.init_truth_constants();
     }
@@ -1413,6 +1442,8 @@ fn non_variable_token(s: &str) -> bool {
             | "-"
             | "*"
             | "/"
+            | "<"
+            | "<="
             | "="
             | "!="
             | "and"
@@ -7099,6 +7130,17 @@ pub fn eval_node(node: &Node, env: &mut Env) -> EvalResult {
                         let l = eval_arith(&children[0], env);
                         let r = eval_arith(&children[2], env);
                         return EvalResult::Value(env.apply_op(op_name, &[l, r]));
+                    }
+                }
+            }
+
+            // Infix numeric comparisons: (A < B), (A <= B)
+            if children.len() == 3 {
+                if let Node::Leaf(ref op_name) = children[1] {
+                    if op_name == "<" || op_name == "<=" {
+                        let l = eval_arith(&children[0], env);
+                        let r = eval_arith(&children[2], env);
+                        return EvalResult::Value(env.clamp(env.apply_op(op_name, &[l, r])));
                     }
                 }
             }

--- a/rust/tests/lib_arithmetic_tests.rs
+++ b/rust/tests/lib_arithmetic_tests.rs
@@ -1,0 +1,107 @@
+// Tests for the arithmetic standard library (issue #74).
+// Mirrors js/tests/lib-arithmetic.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-arithmetic-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_peano_naturals_and_issue_surface_arithmetic_through_import_alias() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/arithmetic/core.lino" as ar)
+(? (zero of Natural))
+(? (type of ar.succ))
+(? ((plus zero zero) = zero))
+(? (less-than zero (succ zero)))
+(? (less-than-or-equal zero zero))
+(? (ar.less-than zero (succ zero)))
+(? (ar.less-than-or-equal zero zero))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Type("(Pi (Natural n) Natural)".to_string()),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_peano_axiom_schemas_as_reusable_templates() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/arithmetic/core.lino" as ar)
+(? (ar.peano-zero-is-natural zero))
+(? (ar.peano-successor-is-natural zero))
+(? (ar.plus-zero-left zero))
+(? (ar.plus-zero-right zero))
+(? (ar.plus-successor-left zero zero))
+(? (ar.less-than-successor zero))
+(? (ar.less-than-or-equal-reflexive zero))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_decimal_precision_lemmas_for_built_in_arithmetic() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/arithmetic/core.lino" as ar)
+(? (ar.decimal-sum-equals 0.1 0.2 0.3))
+(? (ar.decimal-difference-equals 0.3 0.1 0.2))
+(? (ar.decimal-product-equals 0.1 0.2 0.02))
+(? (ar.decimal-quotient-equals 1 3 0.333333333333))
+(? (ar.less-than 0.1 0.2))
+(? (ar.less-than-or-equal 0.3 (0.1 + 0.2)))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}


### PR DESCRIPTION
Fixes #74

## Summary
- Add `lib/arithmetic/core.lino` with Peano `Natural`, `zero`, `succ`, addition/order relations, and totality/coverage checks.
- Export the `arithmetic` namespace with Peano axiom schemas, `plus`, `less-than`, `less-than-or-equal`, and decimal-precision lemma templates.
- Add JS/Rust support for `<` and `<=` numeric comparisons plus alias-aware type lookup for imported typed symbols such as `ar.succ`.
- Add mirrored JS and Rust tests for the issue-specified surface and link the library from the README standard-library section.

## Reproduction
Before this change, importing the requested arithmetic library failed with `E007` because `lib/arithmetic/core.lino` did not exist:

```lino
(import "lib/arithmetic/core.lino" as ar)
(? ((plus zero zero) = zero))
(? (less-than zero (succ zero)))
```

The new JS and Rust tests cover that import, the issue-specified LiNo surface, Peano schemas, and decimal arithmetic lemmas.

## Tests
- `node --test js/tests/lib-arithmetic.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_arithmetic_tests`
- `npm run lint:english --prefix js`
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`
