### PR TITLE
[G8] Standard library: algebra (`lib/algebra/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-08T18:32:44.012Z for PR creation at branch issue-75-88705e0671d4 for issue https://github.com/link-foundation/relative-meta-logic/issues/75

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-08T18:32:44.012Z for PR creation at branch issue-75-88705e0671d4 for issue https://github.com/link-foundation/relative-meta-logic/issues/75

--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ namespace:
 (? (ar.decimal-sum-equals 0.1 0.2 0.3))
 ```
 
+The [algebra library](./lib/algebra/core.lino) exports operation laws and
+magma, semigroup, monoid, group, abelian-group, and unital-ring schemas from
+the `algebra` namespace:
+
+```lino
+(import "lib/algebra/core.lino" as al)
+(? (al.group (carrier G) (op times) (identity e) (inverse inv)))
+(? (al.ring R plus zero neg times one))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/lib-algebra.test.mjs
+++ b/js/tests/lib-algebra.test.mjs
@@ -1,0 +1,94 @@
+// Tests for the algebra standard library (issue #75).
+// Mirrors rust/tests/lib_algebra_tests.rs so the LiNo library surface stays
+// identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-algebra-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/algebra/core.lino', () => {
+  it('exports magma, monoid, and the issue-surface group through an import alias', () => {
+    const out = evaluateFromRoot(`
+(import "lib/algebra/core.lino" as al)
+(? (al.and true true))
+(? (al.and true false))
+(? (al.group (carrier G) (op times) (identity e) (inverse inv)))
+(? ((al.magma (carrier G) (op times)) =
+     (al.closed-under (carrier G) (op times))))
+(? ((al.monoid (carrier G) (op times) (identity e)) =
+     (algebra.and
+       (al.semigroup (carrier G) (op times))
+       (al.identity-element (carrier G) (op times) (identity e)))))
+(? ((al.group (carrier G) (op times) (identity e) (inverse inv)) =
+     (algebra.and
+       (al.monoid (carrier G) (op times) (identity e))
+       (al.inverse-operation (carrier G) (op times) (identity e) (inverse inv)))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 0, 1, 1, 1, 1]);
+  });
+
+  it('exports reusable operation-law schemas', () => {
+    const out = evaluateFromRoot(`
+(import "lib/algebra/core.lino" as al)
+(? ((al.closed-under G times) =
+     (forall (G left)
+       (forall (G right)
+         ((times left right) of G)))))
+(? ((al.associative G times) =
+     (forall (G left)
+       (forall (G middle)
+         (forall (G right)
+           (= (times (times left middle) right)
+              (times left (times middle right))))))))
+(? ((al.identity-element G times e) =
+     (algebra.and
+       (al.left-identity-law G times e)
+       (al.right-identity-law G times e))))
+(? ((al.inverse-operation G times e inv) =
+     (algebra.and
+       (al.left-inverse-law G times e inv)
+       (al.right-inverse-law G times e inv))))
+(? ((al.commutative G times) =
+     (forall (G left)
+       (forall (G right)
+         (= (times left right) (times right left))))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1]);
+  });
+
+  it('exports ring schemas from additive group and multiplicative monoid pieces', () => {
+    const out = evaluateFromRoot(`
+(import "lib/algebra/core.lino" as al)
+(? ((al.distributive R plus times) =
+     (algebra.and
+       (al.left-distributive R plus times)
+       (al.right-distributive R plus times))))
+(? ((al.ring R plus zero neg times one) =
+     (algebra.and
+       (al.abelian-group R plus zero neg)
+       (al.monoid R times one)
+       (al.distributive R plus times))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1]);
+  });
+});

--- a/lib/algebra/core.lino
+++ b/lib/algebra/core.lino
@@ -1,0 +1,112 @@
+# Algebra standard library.
+#
+# This file exports operation laws and algebraic structure schemas under the
+# `algebra` namespace. It covers magma, semigroup, monoid, group, abelian
+# group, and unital ring definitions. Import it with an alias such as:
+#
+#   (import "lib/algebra/core.lino" as al)
+#   (? (al.group (carrier G) (op times) (identity e) (inverse inv)))
+#   (? (al.ring R plus zero neg times one))
+
+(namespace algebra)
+
+(valence: 2)
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(template (closed-under carrier operation)
+  (forall (carrier left)
+    (forall (carrier right)
+      ((operation left right) of carrier))))
+
+(template (associative carrier operation)
+  (forall (carrier left)
+    (forall (carrier middle)
+      (forall (carrier right)
+        (= (operation (operation left middle) right)
+           (operation left (operation middle right)))))))
+
+(template (commutative carrier operation)
+  (forall (carrier left)
+    (forall (carrier right)
+      (= (operation left right) (operation right left)))))
+
+(template (left-identity-law carrier operation identity)
+  (forall (carrier element)
+    (= (operation identity element) element)))
+
+(template (right-identity-law carrier operation identity)
+  (forall (carrier element)
+    (= (operation element identity) element)))
+
+(template (identity-element carrier operation identity)
+  (algebra.and
+    (algebra.left-identity-law carrier operation identity)
+    (algebra.right-identity-law carrier operation identity)))
+
+(template (left-inverse-law carrier operation identity inverse)
+  (forall (carrier element)
+    (= (operation (inverse element) element) identity)))
+
+(template (right-inverse-law carrier operation identity inverse)
+  (forall (carrier element)
+    (= (operation element (inverse element)) identity)))
+
+(template (inverse-operation carrier operation identity inverse)
+  (algebra.and
+    (algebra.left-inverse-law carrier operation identity inverse)
+    (algebra.right-inverse-law carrier operation identity inverse)))
+
+(template (magma carrier operation)
+  (algebra.closed-under carrier operation))
+
+(template (semigroup carrier operation)
+  (algebra.and
+    (algebra.magma carrier operation)
+    (algebra.associative carrier operation)))
+
+(template (monoid carrier operation identity)
+  (algebra.and
+    (algebra.semigroup carrier operation)
+    (algebra.identity-element carrier operation identity)))
+
+(template (group carrier operation identity inverse)
+  (algebra.and
+    (algebra.monoid carrier operation identity)
+    (algebra.inverse-operation carrier operation identity inverse)))
+
+(template (abelian-group carrier operation identity inverse)
+  (algebra.and
+    (algebra.group carrier operation identity inverse)
+    (algebra.commutative carrier operation)))
+
+(template (left-distributive carrier addition multiplication)
+  (forall (carrier left)
+    (forall (carrier middle)
+      (forall (carrier right)
+        (= (multiplication left (addition middle right))
+           (addition
+             (multiplication left middle)
+             (multiplication left right)))))))
+
+(template (right-distributive carrier addition multiplication)
+  (forall (carrier left)
+    (forall (carrier middle)
+      (forall (carrier right)
+        (= (multiplication (addition left middle) right)
+           (addition
+             (multiplication left right)
+             (multiplication middle right)))))))
+
+(template (distributive carrier addition multiplication)
+  (algebra.and
+    (algebra.left-distributive carrier addition multiplication)
+    (algebra.right-distributive carrier addition multiplication)))
+
+(template (ring carrier addition zero negative multiplication one)
+  (algebra.and
+    (algebra.abelian-group carrier addition zero negative)
+    (algebra.monoid carrier multiplication one)
+    (algebra.distributive carrier addition multiplication)))

--- a/rust/tests/lib_algebra_tests.rs
+++ b/rust/tests/lib_algebra_tests.rs
@@ -1,0 +1,118 @@
+// Tests for the algebra standard library (issue #75).
+// Mirrors js/tests/lib-algebra.test.mjs so the LiNo library surface stays
+// identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-algebra-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_magma_monoid_and_issue_surface_group_through_import_alias() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/algebra/core.lino" as al)
+(? (al.and true true))
+(? (al.and true false))
+(? (al.group (carrier G) (op times) (identity e) (inverse inv)))
+(? ((al.magma (carrier G) (op times)) =
+     (al.closed-under (carrier G) (op times))))
+(? ((al.monoid (carrier G) (op times) (identity e)) =
+     (algebra.and
+       (al.semigroup (carrier G) (op times))
+       (al.identity-element (carrier G) (op times) (identity e)))))
+(? ((al.group (carrier G) (op times) (identity e) (inverse inv)) =
+     (algebra.and
+       (al.monoid (carrier G) (op times) (identity e))
+       (al.inverse-operation (carrier G) (op times) (identity e) (inverse inv)))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_reusable_operation_law_schemas() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/algebra/core.lino" as al)
+(? ((al.closed-under G times) =
+     (forall (G left)
+       (forall (G right)
+         ((times left right) of G)))))
+(? ((al.associative G times) =
+     (forall (G left)
+       (forall (G middle)
+         (forall (G right)
+           (= (times (times left middle) right)
+              (times left (times middle right))))))))
+(? ((al.identity-element G times e) =
+     (algebra.and
+       (al.left-identity-law G times e)
+       (al.right-identity-law G times e))))
+(? ((al.inverse-operation G times e inv) =
+     (algebra.and
+       (al.left-inverse-law G times e inv)
+       (al.right-inverse-law G times e inv))))
+(? ((al.commutative G times) =
+     (forall (G left)
+       (forall (G right)
+         (= (times left right) (times right left))))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_ring_schemas_from_additive_group_and_multiplicative_monoid_pieces() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/algebra/core.lino" as al)
+(? ((al.distributive R plus times) =
+     (algebra.and
+       (al.left-distributive R plus times)
+       (al.right-distributive R plus times))))
+(? ((al.ring R plus zero neg times one) =
+     (algebra.and
+       (al.abelian-group R plus zero neg)
+       (al.monoid R times one)
+       (al.distributive R plus times))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(1.0), RunResult::Num(1.0),]);
+}


### PR DESCRIPTION
Fixes #75

## Summary
- Add `lib/algebra/core.lino` with operation-law schemas and packaged magma, semigroup, monoid, group, abelian-group, and unital-ring definitions under the `algebra` namespace.
- Cover the issue-specified group surface: `(group (carrier G) (op times) (identity e) (inverse inv))`.
- Add mirrored JavaScript and Rust tests for alias imports, operation-law schemas, and ring composition.
- Link the algebra library from the README standard-library section.

## Reproduction
Before this change, importing the requested algebra library failed with `E007` because `lib/algebra/core.lino` did not exist:

```lino
(import "lib/algebra/core.lino" as al)
(? (al.group (carrier G) (op times) (identity e) (inverse inv)))
```

The new JS and Rust tests cover that import, the issue-specified group surface, reusable operation laws, and ring schemas.

## Tests
- `node --test js/tests/lib-algebra.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_algebra_tests`
- `npm run lint:english --prefix js`
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`
