### PR TITLE
[G9] Standard library: programming-language theory (`lib/programming-language/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-08T19:25:08.718Z for PR creation at branch issue-76-2e70749b52ea for issue https://github.com/link-foundation/relative-meta-logic/issues/76

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-08T19:25:08.718Z for PR creation at branch issue-76-2e70749b52ea for issue https://github.com/link-foundation/relative-meta-logic/issues/76

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ the `algebra` namespace:
 (? (al.ring R plus zero neg times one))
 ```
 
+The [programming-language theory library](./lib/programming-language/core.lino)
+exports untyped lambda-calculus constructors, simply typed lambda calculus
+typing and small-step schemas, and type-safety theorem forms from the
+`programming-language` namespace:
+
+```lino
+(import "lib/programming-language/core.lino" as pl)
+(? (pl.theorem progress (pl.progress term T)))
+(? (pl.theorem preservation (pl.preservation term next T)))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/lib-programming-language.test.mjs
+++ b/js/tests/lib-programming-language.test.mjs
@@ -1,0 +1,91 @@
+// Tests for the programming-language theory standard library (issue #76).
+// Mirrors rust/tests/lib_programming_language_tests.rs so the LiNo library
+// surface stays identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-programming-language-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/programming-language/core.lino', () => {
+  it('exports untyped lambda-calculus syntax and beta-step schemas', () => {
+    const out = evaluateFromRoot(`
+(import "lib/programming-language/core.lino" as pl)
+(? ((pl.variable x) = (programming-language.object-variable x)))
+(? ((pl.abstraction x (pl.variable x)) =
+     (programming-language.object-lambda x
+       (programming-language.object-variable x))))
+(? ((pl.application (pl.abstraction x (pl.variable x)) y) =
+     (programming-language.object-apply
+       (programming-language.object-lambda x
+         (programming-language.object-variable x))
+       y)))
+(? ((pl.beta-reduction x (pl.variable x) y) =
+     (programming-language.small-step
+       (programming-language.object-apply
+         (programming-language.object-lambda x
+           (programming-language.object-variable x))
+         y)
+       (programming-language.object-substitution
+         (programming-language.object-variable x) x y))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1]);
+  });
+
+  it('exports STLC typing rules as reusable schemas', () => {
+    const out = evaluateFromRoot(`
+(import "lib/programming-language/core.lino" as pl)
+(? ((pl.function-type A B) =
+     (programming-language.simple-function-type A B)))
+(? ((pl.typing-abstraction gamma x A body B) =
+     (programming-language.implies
+       (pl.has-type (pl.extend-context gamma x A) body B)
+       (pl.has-type gamma
+         (pl.abstraction x body)
+         (pl.function-type A B)))))
+(? ((pl.typing-application gamma fn arg A B) =
+     (programming-language.implies
+       (programming-language.and
+         (pl.has-type gamma fn (pl.function-type A B))
+         (pl.has-type gamma arg A))
+       (pl.has-type gamma (pl.application fn arg) B))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1]);
+  });
+
+  it('exports theorem progress and preservation through the issue surface', () => {
+    const out = evaluateFromRoot(`
+(import "lib/programming-language/core.lino" as pl)
+(? (pl.theorem progress (pl.progress term T)))
+(? (pl.theorem preservation (pl.preservation term next T)))
+(? ((pl.progress term T) =
+     (pl.progress-in programming-language.empty-context term T)))
+(? ((pl.preservation term next T) =
+     (pl.preservation-in programming-language.empty-context term next T)))
+(? ((pl.type-safety term next T) =
+     (programming-language.and
+       (pl.progress term T)
+       (pl.preservation term next T))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1]);
+  });
+});

--- a/lib/programming-language/core.lino
+++ b/lib/programming-language/core.lino
@@ -1,0 +1,176 @@
+# Programming-language theory standard library.
+#
+# This file exports untyped lambda-calculus constructors, simply typed lambda
+# calculus typing and small-step schemas, and type-safety theorem forms under
+# the `programming-language` namespace. Import it with an alias such as:
+#
+#   (import "lib/programming-language/core.lino" as pl)
+#   (? (pl.theorem progress (pl.progress term T)))
+#   (? (pl.theorem preservation (pl.preservation term next T)))
+
+(namespace programming-language)
+
+(valence: 2)
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(Expression: (Type 0) Expression)
+(Context: (Type 0) Context)
+(Judgment: (Type 0) Judgment)
+(empty-context: Context empty-context)
+
+(template (implies antecedent consequent)
+  (programming-language.or (programming-language.not antecedent) consequent))
+
+(template (iff left right)
+  (programming-language.and
+    (programming-language.implies left right)
+    (programming-language.implies right left)))
+
+(template (theorem name statement)
+  statement)
+
+(template (extend-context context variable typ)
+  (programming-language.context-extend context variable typ))
+
+(template (lookup context variable typ)
+  (programming-language.context-lookup context variable typ))
+
+(template (variable name)
+  (programming-language.object-variable name))
+
+(template (abstraction variable body)
+  (programming-language.object-lambda variable body))
+
+(template (application function argument)
+  (programming-language.object-apply function argument))
+
+(template (substitution body variable replacement)
+  (programming-language.object-substitution body variable replacement))
+
+(template (beta-redex variable body argument)
+  (programming-language.application
+    (programming-language.abstraction variable body)
+    argument))
+
+(template (steps-to expression next)
+  (programming-language.small-step expression next))
+
+(template (multi-step expression result)
+  (programming-language.multi-step expression result))
+
+(template (beta-reduction variable body argument)
+  (programming-language.steps-to
+    (programming-language.beta-redex variable body argument)
+    (programming-language.substitution body variable argument)))
+
+(template (step-application-function function next-function argument)
+  (programming-language.implies
+    (programming-language.steps-to function next-function)
+    (programming-language.steps-to
+      (programming-language.application function argument)
+      (programming-language.application next-function argument))))
+
+(template (step-application-argument function argument next-argument)
+  (programming-language.implies
+    (programming-language.and
+      (programming-language.value function)
+      (programming-language.steps-to argument next-argument))
+    (programming-language.steps-to
+      (programming-language.application function argument)
+      (programming-language.application function next-argument))))
+
+(template (value expression)
+  (programming-language.term-value expression))
+
+(template (lambda-value variable body)
+  (programming-language.value
+    (programming-language.abstraction variable body)))
+
+(template (base-type name)
+  (programming-language.simple-base-type name))
+
+(template (function-type domain codomain)
+  (programming-language.simple-function-type domain codomain))
+
+(template (has-type context expression typ)
+  (programming-language.typing-judgment context expression typ))
+
+(template (well-typed expression typ)
+  (programming-language.has-type
+    programming-language.empty-context
+    expression
+    typ))
+
+(template (typing-variable context variable typ)
+  (programming-language.implies
+    (programming-language.lookup context variable typ)
+    (programming-language.has-type
+      context
+      (programming-language.variable variable)
+      typ)))
+
+(template (typing-abstraction context variable domain body codomain)
+  (programming-language.implies
+    (programming-language.has-type
+      (programming-language.extend-context context variable domain)
+      body
+      codomain)
+    (programming-language.has-type
+      context
+      (programming-language.abstraction variable body)
+      (programming-language.function-type domain codomain))))
+
+(template (typing-application context function argument domain codomain)
+  (programming-language.implies
+    (programming-language.and
+      (programming-language.has-type
+        context
+        function
+        (programming-language.function-type domain codomain))
+      (programming-language.has-type context argument domain))
+    (programming-language.has-type
+      context
+      (programming-language.application function argument)
+      codomain)))
+
+(template (canonical-function expression)
+  (exists (programming-language.Expression variable)
+    (exists (programming-language.Expression body)
+      (= expression
+         (programming-language.abstraction variable body)))))
+
+(template (progress-in context expression typ)
+  (programming-language.implies
+    (programming-language.has-type context expression typ)
+    (programming-language.or
+      (programming-language.value expression)
+      (exists (programming-language.Expression next)
+        (programming-language.steps-to expression next)))))
+
+(template (progress expression typ)
+  (programming-language.progress-in
+    programming-language.empty-context
+    expression
+    typ))
+
+(template (preservation-in context expression next typ)
+  (programming-language.implies
+    (programming-language.and
+      (programming-language.has-type context expression typ)
+      (programming-language.steps-to expression next))
+    (programming-language.has-type context next typ)))
+
+(template (preservation expression next typ)
+  (programming-language.preservation-in
+    programming-language.empty-context
+    expression
+    next
+    typ))
+
+(template (type-safety expression next typ)
+  (programming-language.and
+    (programming-language.progress expression typ)
+    (programming-language.preservation expression next typ)))

--- a/rust/tests/lib_programming_language_tests.rs
+++ b/rust/tests/lib_programming_language_tests.rs
@@ -1,0 +1,116 @@
+// Tests for the programming-language theory standard library (issue #76).
+// Mirrors js/tests/lib-programming-language.test.mjs so the LiNo library
+// surface stays identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-programming-language-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_untyped_lambda_calculus_syntax_and_beta_step_schemas() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/programming-language/core.lino" as pl)
+(? ((pl.variable x) = (programming-language.object-variable x)))
+(? ((pl.abstraction x (pl.variable x)) =
+     (programming-language.object-lambda x
+       (programming-language.object-variable x))))
+(? ((pl.application (pl.abstraction x (pl.variable x)) y) =
+     (programming-language.object-apply
+       (programming-language.object-lambda x
+         (programming-language.object-variable x))
+       y)))
+(? ((pl.beta-reduction x (pl.variable x) y) =
+     (programming-language.small-step
+       (programming-language.object-apply
+         (programming-language.object-lambda x
+           (programming-language.object-variable x))
+         y)
+       (programming-language.object-substitution
+         (programming-language.object-variable x) x y))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_stlc_typing_rules_as_reusable_schemas() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/programming-language/core.lino" as pl)
+(? ((pl.function-type A B) =
+     (programming-language.simple-function-type A B)))
+(? ((pl.typing-abstraction gamma x A body B) =
+     (programming-language.implies
+       (pl.has-type (pl.extend-context gamma x A) body B)
+       (pl.has-type gamma
+         (pl.abstraction x body)
+         (pl.function-type A B)))))
+(? ((pl.typing-application gamma fn arg A B) =
+     (programming-language.implies
+       (programming-language.and
+         (pl.has-type gamma fn (pl.function-type A B))
+         (pl.has-type gamma arg A))
+       (pl.has-type gamma (pl.application fn arg) B))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![RunResult::Num(1.0), RunResult::Num(1.0), RunResult::Num(1.0),]
+    );
+}
+
+#[test]
+fn exports_theorem_progress_and_preservation_through_the_issue_surface() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/programming-language/core.lino" as pl)
+(? (pl.theorem progress (pl.progress term T)))
+(? (pl.theorem preservation (pl.preservation term next T)))
+(? ((pl.progress term T) =
+     (pl.progress-in programming-language.empty-context term T)))
+(? ((pl.preservation term next T) =
+     (pl.preservation-in programming-language.empty-context term next T)))
+(? ((pl.type-safety term next T) =
+     (programming-language.and
+       (pl.progress term T)
+       (pl.preservation term next T))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}


### PR DESCRIPTION
Fixes #76

## Summary
- Add `lib/programming-language/core.lino` with untyped lambda-calculus constructors, small-step schemas, simply typed lambda calculus typing schemas, and type-safety theorem forms under the `programming-language` namespace.
- Cover the issue-specified theorem surface with `(pl.theorem progress (pl.progress ...))` and `(pl.theorem preservation (pl.preservation ...))`.
- Add mirrored JavaScript and Rust tests for alias imports, lambda-calculus schemas, STLC typing schemas, and progress/preservation/type-safety forms.
- Link the programming-language theory library from the README standard-library section.

## Reproduction
Before this change, importing the requested programming-language library failed with `E007` because `lib/programming-language/core.lino` did not exist:

```lino
(import "lib/programming-language/core.lino" as pl)
(? (pl.theorem progress (pl.progress term T)))
(? (pl.theorem preservation (pl.preservation term next T)))
```

The new JS and Rust tests cover that import, the issue-specified theorem surface, reusable untyped lambda-calculus schemas, STLC typing schemas, and the composed type-safety schema.

## Tests
- `node --test js/tests/lib-programming-language.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_programming_language_tests`
- `npm run lint:english --prefix js`
- `npm test --prefix js`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`
