### PR TITLE
[G10] Standard library: probabilistic / Belnap (`lib/probabilistic/`)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T02:57:23.606Z for PR creation at branch issue-77-e3532d226a57 for issue https://github.com/link-foundation/relative-meta-logic/issues/77

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T02:57:23.606Z for PR creation at branch issue-77-e3532d226a57 for issue https://github.com/link-foundation/relative-meta-logic/issues/77

--- a/README.md
+++ b/README.md
@@ -174,6 +174,27 @@ typing and small-step schemas, and type-safety theorem forms from the
 (? (pl.theorem preservation (pl.preservation term next T)))
 ```
 
+The [probabilistic library](./lib/probabilistic/) packages Bayesian-network,
+fuzzy-control, Belnap-bilattice, and paradox-catalogue helpers as standard
+LiNo imports:
+
+```lino
+(import "lib/probabilistic/bayesian.lino" as bn)
+(import "lib/probabilistic/fuzzy.lino" as fz)
+(import "lib/probabilistic/belnap.lino" as bl)
+(import "lib/probabilistic/paradoxes.lino" as px)
+(bn.network sprinkler-network (nodes cloudy rain) (edges (bn.edge cloudy rain)))
+(bn.prior rain 0.5)
+(fz.membership temperature hot 0.8)
+(fz.membership humidity wet 0.6)
+(s: s is s)
+(px.midpoint (px.liar s))
+(? (bn.joint (rain = true) (rain = true)))
+(? (fz.rule (fz.degree temperature hot) (fz.degree humidity wet)))
+(? (bl.contradiction true false))
+(? (px.fixed-point (px.liar s)))
+```
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/lib-probabilistic.test.mjs
+++ b/js/tests/lib-probabilistic.test.mjs
@@ -1,0 +1,138 @@
+// Tests for the probabilistic and Belnap standard libraries (issue #77).
+// Mirrors rust/tests/lib_probabilistic_tests.rs so the LiNo library surface
+// stays identical across both implementations.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { evaluate } from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const virtualRootFile = join(repoRoot, 'inline-probabilistic-test.lino');
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+describe('lib/probabilistic/*.lino', () => {
+  it('exports Bayesian-network helpers through the issue import surface', () => {
+    const out = evaluateFromRoot(`
+(import "lib/probabilistic/bayesian.lino" as bn)
+(bn.prior rain 0.3)
+(bn.prior sprinkler 0.6)
+(? (rain = true))
+(? (bn.joint (rain = true) (sprinkler = true)))
+(? (bn.union (rain = true) (sprinkler = true)))
+(? (bn.complement (rain = true)))
+(? (bn.bayes 0.95 0.01 0.059))
+(? ((bn.edge cloudy rain) =
+     (bayesian.directed-edge cloudy rain)))
+(? ((bn.network sprinkler-network
+       (nodes cloudy rain sprinkler)
+       (edges (bn.edge cloudy rain) (bn.edge cloudy sprinkler))) =
+     (bayesian.network-description sprinkler-network
+       (nodes cloudy rain sprinkler)
+       (edges
+         (bayesian.directed-edge cloudy rain)
+         (bayesian.directed-edge cloudy sprinkler)))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [
+      0.3,
+      0.18,
+      0.72,
+      0.7,
+      0.161016949153,
+      1,
+      1,
+    ]);
+  });
+
+  it('exports fuzzy membership and fuzzy-control helpers', () => {
+    const out = evaluateFromRoot(`
+(import "lib/probabilistic/fuzzy.lino" as fz)
+(fz.membership temperature hot 0.8)
+(fz.membership humidity wet 0.6)
+(? (fz.degree temperature hot))
+(? (fz.all (fz.degree temperature hot) (fz.degree humidity wet)))
+(? (fz.any 0.2 (fz.degree humidity wet)))
+(? (fz.complement (fz.degree temperature hot)))
+(? (fz.weighted-output 0.6 0.8))
+(? (fz.centroid2 0.6 0.8 0.4 0.3))
+(? ((fz.control-action fan-fast (fz.degree temperature hot) 0.8) =
+     (fuzzy.control-action-description fan-fast (temperature = hot) 0.8)))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [
+      0.8,
+      0.6,
+      0.6,
+      0.19999999999999996,
+      0.48,
+      0.6,
+      1,
+    ]);
+  });
+
+  it('exports Belnap bilattice helpers for truth and knowledge orders', () => {
+    const out = evaluateFromRoot(`
+(import "lib/probabilistic/belnap.lino" as bl)
+(? (bl.truth-meet true false))
+(? (bl.truth-join true false))
+(? (bl.contradiction true false))
+(? (bl.gap true false))
+(? (bl.knowledge-join true false))
+(? (bl.knowledge-meet true false))
+(? ((bl.bilattice-value contradiction
+       (truth-evidence true)
+       (false-evidence true)) =
+     (belnap.value contradiction
+       (truth-evidence true)
+       (false-evidence true))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [0, 1, 0.5, 0, 0.5, 0, 1]);
+  });
+
+  it('exports a paradox catalogue with midpoint fixed-point helpers', () => {
+    const out = evaluateFromRoot(`
+(import "lib/probabilistic/paradoxes.lino" as px)
+(s: s is s)
+(px.midpoint (px.liar s))
+(? (px.liar s))
+(? (px.fixed-point (px.liar s)))
+(? ((px.russell member-of R) =
+     (= (member-of R R)
+        (paradoxes.not (member-of R R)))))
+(? ((px.barber shaves barber alice) =
+     (= (shaves barber alice)
+        (paradoxes.not (shaves alice alice)))))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [0.5, 0.5, 1, 1]);
+  });
+
+  it('exports balanced-range paradox midpoint helpers', () => {
+    const out = evaluateFromRoot(`
+(range: -1 1)
+(import "lib/probabilistic/paradoxes.lino" as px)
+(s: s is s)
+(px.balanced-midpoint (px.liar s))
+(? (px.liar s))
+(? (px.fixed-point (px.liar s)))
+`);
+
+    assertClean(out);
+    assert.deepStrictEqual(out.results, [0, 0]);
+  });
+});

--- a/lib/probabilistic/bayesian.lino
+++ b/lib/probabilistic/bayesian.lino
@@ -1,0 +1,58 @@
+# Bayesian probabilistic standard library.
+#
+# This file exports Bayesian-network description helpers, prior and
+# conditional-probability assignment templates, and common probability
+# calculations under the `bayesian` namespace. Import it with an alias such as:
+#
+#   (import "lib/probabilistic/bayesian.lino" as bn)
+#   (bn.network sprinkler-network (nodes cloudy rain) (edges (bn.edge cloudy rain)))
+#   (? (bn.bayes 0.95 0.01 0.059))
+
+(namespace bayesian)
+
+(and: product)
+(or: probabilistic_sum)
+(not: not)
+(!=: not =)
+
+(template (event name)
+  (bayesian.event-node name))
+
+(template (edge cause effect)
+  (bayesian.directed-edge cause effect))
+
+(template (network name nodes edges)
+  (bayesian.network-description name nodes edges))
+
+(template (prior event probability-value)
+  ((event = true) has probability probability-value))
+
+(template (conditional event given probability-value)
+  ((bayesian.conditional event given) has probability probability-value))
+
+(template (joint left right)
+  (bayesian.and left right))
+
+(template (joint-three first second third)
+  (bayesian.and first second third))
+
+(template (union left right)
+  (bayesian.or left right))
+
+(template (union-three first second third)
+  (bayesian.or first second third))
+
+(template (complement event)
+  (bayesian.not event))
+
+(template (conditional-probability joint-probability evidence-probability)
+  (joint-probability / evidence-probability))
+
+(template (total-probability true-likelihood true-prior false-likelihood false-prior)
+  ((true-likelihood * true-prior) + (false-likelihood * false-prior)))
+
+(template (bayes likelihood prior evidence)
+  ((likelihood * prior) / evidence))
+
+(template (posterior likelihood prior evidence)
+  (bayesian.bayes likelihood prior evidence))

--- a/lib/probabilistic/belnap.lino
+++ b/lib/probabilistic/belnap.lino
@@ -1,0 +1,48 @@
+# Belnap bilattice standard library.
+#
+# This file exports truth-order and knowledge-order helpers for RML's
+# Belnap-style `both` and `neither` operators under the `belnap` namespace.
+# Import it with an alias such as:
+#
+#   (import "lib/probabilistic/belnap.lino" as bl)
+#   (? (bl.contradiction true false))
+#   (? (bl.knowledge-meet true false))
+
+(namespace belnap)
+
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+(both: avg)
+(neither: product)
+
+(template (truth-meet left right)
+  (belnap.and left right))
+
+(template (truth-join left right)
+  (belnap.or left right))
+
+(template (contradiction left right)
+  (belnap.both left right))
+
+(template (gap left right)
+  (belnap.neither left right))
+
+(template (knowledge-join left right)
+  (belnap.contradiction left right))
+
+(template (knowledge-meet left right)
+  (belnap.gap left right))
+
+(template (consistent proposition)
+  (belnap.not
+    (belnap.contradiction proposition
+      (belnap.not proposition))))
+
+(template (complete proposition)
+  (belnap.truth-join proposition
+    (belnap.not proposition)))
+
+(template (bilattice-value name truth-evidence false-evidence)
+  (belnap.value name truth-evidence false-evidence))

--- a/lib/probabilistic/fuzzy.lino
+++ b/lib/probabilistic/fuzzy.lino
@@ -1,0 +1,47 @@
+# Fuzzy logic and control standard library.
+#
+# This file exports Zadeh-style membership helpers and small fuzzy-control
+# calculation templates under the `fuzzy` namespace. Import it with an alias
+# such as:
+#
+#   (import "lib/probabilistic/fuzzy.lino" as fz)
+#   (fz.membership temperature hot 0.8)
+#   (? (fz.two-point-centroid 0.6 0.8 0.4 0.3))
+
+(namespace fuzzy)
+
+(and: min)
+(or: max)
+(not: not)
+(!=: not =)
+
+(template (membership subject predicate degree)
+  ((subject = predicate) has probability degree))
+
+(template (degree subject predicate)
+  (subject = predicate))
+
+(template (all left right)
+  (fuzzy.and left right))
+
+(template (any left right)
+  (fuzzy.or left right))
+
+(template (complement value)
+  (fuzzy.not value))
+
+(template (rule antecedent consequent)
+  (fuzzy.and antecedent consequent))
+
+(template (weighted-output activation output)
+  (activation * output))
+
+(template (two-point-centroid activation-a output-a activation-b output-b)
+  (((activation-a * output-a) + (activation-b * output-b)) /
+   (activation-a + activation-b)))
+
+(template (centroid2 activation-a output-a activation-b output-b)
+  (fuzzy.two-point-centroid activation-a output-a activation-b output-b))
+
+(template (control-action name condition output)
+  (fuzzy.control-action-description name condition output))

--- a/lib/probabilistic/paradoxes.lino
+++ b/lib/probabilistic/paradoxes.lino
@@ -1,0 +1,58 @@
+# Paradox catalogue standard library.
+#
+# This file exports reusable paradox schemas plus midpoint assignment helpers
+# for `[0, 1]` and balanced `[-1, 1]` ranges under the `paradoxes` namespace.
+# The schemas are intentionally lightweight: they package common self-reference
+# shapes while letting a caller choose the propositions, predicates, and range.
+# Import it with an alias such as:
+#
+#   (import "lib/probabilistic/paradoxes.lino" as px)
+#   (px.midpoint (px.liar s))
+#   (? (px.fixed-point (px.liar s)))
+
+(namespace paradoxes)
+
+(and: avg)
+(or: max)
+(not: not)
+(!=: not =)
+(both: avg)
+(neither: product)
+
+(template (implies antecedent consequent)
+  (paradoxes.or (paradoxes.not antecedent) consequent))
+
+(template (liar sentence)
+  (sentence = false))
+
+(template (truth-teller sentence)
+  (sentence = true))
+
+(template (midpoint proposition)
+  (proposition has probability 0.5))
+
+(template (balanced-midpoint proposition)
+  (proposition has probability 0))
+
+(template (fixed-point proposition)
+  (paradoxes.both proposition
+    (paradoxes.not proposition)))
+
+(template (russell member collection)
+  (= (member collection collection)
+     (paradoxes.not (member collection collection))))
+
+(template (barber shaves barber person)
+  (= (shaves barber person)
+     (paradoxes.not (shaves person person))))
+
+(template (curry sentence consequent)
+  (paradoxes.implies sentence consequent))
+
+(template (gap proposition)
+  (paradoxes.neither proposition
+    (paradoxes.not proposition)))
+
+(template (contradiction proposition)
+  (paradoxes.both proposition
+    (paradoxes.not proposition)))

--- a/rust/tests/lib_probabilistic_tests.rs
+++ b/rust/tests/lib_probabilistic_tests.rs
@@ -1,0 +1,174 @@
+// Tests for the probabilistic and Belnap standard libraries (issue #77).
+// Mirrors js/tests/lib-probabilistic.test.mjs so the LiNo library surface
+// stays identical across both implementations.
+
+use rml::{evaluate, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-probabilistic-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn exports_bayesian_network_helpers_through_the_issue_import_surface() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/probabilistic/bayesian.lino" as bn)
+(bn.prior rain 0.3)
+(bn.prior sprinkler 0.6)
+(? (rain = true))
+(? (bn.joint (rain = true) (sprinkler = true)))
+(? (bn.union (rain = true) (sprinkler = true)))
+(? (bn.complement (rain = true)))
+(? (bn.bayes 0.95 0.01 0.059))
+(? ((bn.edge cloudy rain) =
+     (bayesian.directed-edge cloudy rain)))
+(? ((bn.network sprinkler-network
+       (nodes cloudy rain sprinkler)
+       (edges (bn.edge cloudy rain) (bn.edge cloudy sprinkler))) =
+     (bayesian.network-description sprinkler-network
+       (nodes cloudy rain sprinkler)
+       (edges
+         (bayesian.directed-edge cloudy rain)
+         (bayesian.directed-edge cloudy sprinkler)))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.3),
+            RunResult::Num(0.18),
+            RunResult::Num(0.72),
+            RunResult::Num(0.7),
+            RunResult::Num(0.161016949153),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_fuzzy_membership_and_fuzzy_control_helpers() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/probabilistic/fuzzy.lino" as fz)
+(fz.membership temperature hot 0.8)
+(fz.membership humidity wet 0.6)
+(? (fz.degree temperature hot))
+(? (fz.all (fz.degree temperature hot) (fz.degree humidity wet)))
+(? (fz.any 0.2 (fz.degree humidity wet)))
+(? (fz.complement (fz.degree temperature hot)))
+(? (fz.weighted-output 0.6 0.8))
+(? (fz.centroid2 0.6 0.8 0.4 0.3))
+(? ((fz.control-action fan-fast (fz.degree temperature hot) 0.8) =
+     (fuzzy.control-action-description fan-fast (temperature = hot) 0.8)))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.8),
+            RunResult::Num(0.6),
+            RunResult::Num(0.6),
+            RunResult::Num(0.19999999999999996),
+            RunResult::Num(0.48),
+            RunResult::Num(0.6),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_belnap_bilattice_helpers_for_truth_and_knowledge_orders() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/probabilistic/belnap.lino" as bl)
+(? (bl.truth-meet true false))
+(? (bl.truth-join true false))
+(? (bl.contradiction true false))
+(? (bl.gap true false))
+(? (bl.knowledge-join true false))
+(? (bl.knowledge-meet true false))
+(? ((bl.bilattice-value contradiction
+       (truth-evidence true)
+       (false-evidence true)) =
+     (belnap.value contradiction
+       (truth-evidence true)
+       (false-evidence true))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+            RunResult::Num(0.5),
+            RunResult::Num(0.0),
+            RunResult::Num(0.5),
+            RunResult::Num(0.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_a_paradox_catalogue_with_midpoint_fixed_point_helpers() {
+    let out = evaluate_from_root(
+        r#"
+(import "lib/probabilistic/paradoxes.lino" as px)
+(s: s is s)
+(px.midpoint (px.liar s))
+(? (px.liar s))
+(? (px.fixed-point (px.liar s)))
+(? ((px.russell member-of R) =
+     (= (member-of R R)
+        (paradoxes.not (member-of R R)))))
+(? ((px.barber shaves barber alice) =
+     (= (shaves barber alice)
+        (paradoxes.not (shaves alice alice)))))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(
+        out.results,
+        vec![
+            RunResult::Num(0.5),
+            RunResult::Num(0.5),
+            RunResult::Num(1.0),
+            RunResult::Num(1.0),
+        ]
+    );
+}
+
+#[test]
+fn exports_balanced_range_paradox_midpoint_helpers() {
+    let out = evaluate_from_root(
+        r#"
+(range: -1 1)
+(import "lib/probabilistic/paradoxes.lino" as px)
+(s: s is s)
+(px.balanced-midpoint (px.liar s))
+(? (px.liar s))
+(? (px.fixed-point (px.liar s)))
+"#,
+    );
+
+    assert_clean(&out);
+    assert_eq!(out.results, vec![RunResult::Num(0.0), RunResult::Num(0.0)]);
+}


### PR DESCRIPTION
Fixes #77

## Summary
- Add `lib/probabilistic/bayesian.lino`, `fuzzy.lino`, `belnap.lino`, and `paradoxes.lino` with header summaries and namespaced templates for Bayesian-network helpers, fuzzy-control calculations, Belnap bilattice operations, and paradox schemas.
- Cover the issue-specified Bayesian import surface plus fuzzy, Belnap, and paradox aliases across both implementations.
- Add mirrored JavaScript and Rust tests for probability calculations, fuzzy control, Belnap truth/knowledge helpers, and paradox midpoint helpers in `[0, 1]` and `[-1, 1]`.
- Link the probabilistic library from the README standard-library section.

## Reproduction
Before this change, importing the requested probabilistic library failed with `E007` because `lib/probabilistic/bayesian.lino` and the related `.lino` modules did not exist:

```lino
(import "lib/probabilistic/bayesian.lino" as bn)
(bn.network sprinkler-network (nodes cloudy rain) (edges (bn.edge cloudy rain)))
```

The new JS and Rust tests cover that import, the issue-specified network surface, fuzzy-control helpers, Belnap bilattice helpers, and paradox catalogue helpers.

## Tests
- `node --test js/tests/lib-probabilistic.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test lib_probabilistic_tests`
- `npm run lint:english` from `js/`
- `npm test` from `js/`
- `cargo test --manifest-path rust/Cargo.toml`
- `rustfmt --check rust/tests/lib_probabilistic_tests.rs`
- `git diff --check`
