### PR TITLE
[H1] Language Server Protocol implementation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T03:50:39.316Z for PR creation at branch issue-78-9983c491f4e6 for issue https://github.com/link-foundation/relative-meta-logic/issues/78

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For implementation details, see [ARCHITECTURE.md](./ARCHITECTURE.md).
 - [Metatheorem checker](./docs/METATHEOREMS.md) - The C3 Twelf-style guarantee that composes D12 totality, D14 coverage, D15 modes, and D13 termination, plus the `rml-meta` CLI.
 - [Lean 4 export](./docs/LEAN_EXPORT.md) - The `rml export lean` bridge for typed, non-probabilistic RML fragments.
 - [Rocq export](./docs/ROCQ-EXPORT.md) - The supported typed LiNo subset for `rml export rocq <file.lino> -o <file.v>`.
+- [Language Server](./docs/LANGUAGE_SERVER.md) - Stdio LSP setup for diagnostics, hover, go-to-definition, and completion in Neovim and Helix.
 
 ## Overview
 
@@ -71,6 +72,10 @@ npm install
 node src/rml-links.mjs ../examples/demo.lino
 node src/rml-links.mjs export lean ../examples/lean-export-basic.lino -o out.lean
 ```
+
+Editor integration is available through the stdio language server; see
+[`docs/LANGUAGE_SERVER.md`](./docs/LANGUAGE_SERVER.md) for Neovim and Helix
+setup.
 
 ### Rust
 

--- a/docs/LANGUAGE_SERVER.md
+++ b/docs/LANGUAGE_SERVER.md
@@ -1,0 +1,94 @@
+# RML Language Server
+
+`rml-lsp` is a stdio Language Server Protocol server for `.lino` files. It
+uses the JavaScript evaluator for diagnostics and provides editor features
+that are useful while writing RML:
+
+- Diagnostics from `evaluate()` as LSP `textDocument/publishDiagnostics`
+- Hover text for local definitions and core RML keywords
+- Go-to-definition for definitions declared in the current document
+- Completion for keywords, operators, terms, templates, relations, and local
+  definitions
+
+## Install
+
+From the repository checkout:
+
+```sh
+cd js
+npm install
+npm run lsp
+```
+
+When the package is installed globally or linked, the binary name is:
+
+```sh
+rml-lsp
+```
+
+The server speaks only LSP over stdin/stdout. Do not run it directly in a
+terminal unless an editor or test harness is managing the JSON-RPC stream.
+
+## Neovim
+
+For Neovim's built-in LSP client, add this to your Lua config:
+
+```lua
+vim.filetype.add({
+  extension = {
+    lino = "lino",
+  },
+})
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "lino",
+  callback = function(args)
+    vim.lsp.start({
+      name = "rml-lsp",
+      cmd = { "rml-lsp" },
+      root_dir = vim.fs.root(args.buf, { "js/package.json", ".git" }) or vim.fn.getcwd(),
+    })
+  end,
+})
+```
+
+If you are using the repository checkout without linking the package, replace
+`cmd` with an absolute path:
+
+```lua
+cmd = { "node", "/path/to/relative-meta-logic/js/src/rml-lsp.mjs" }
+```
+
+## Helix
+
+Add a language entry to `~/.config/helix/languages.toml`:
+
+```toml
+[[language]]
+name = "lino"
+scope = "source.lino"
+file-types = ["lino"]
+comment-token = "#"
+language-servers = ["rml-lsp"]
+
+[language-server.rml-lsp]
+command = "rml-lsp"
+```
+
+For a repository checkout without a linked binary, use:
+
+```toml
+[language-server.rml-lsp]
+command = "node"
+args = ["/path/to/relative-meta-logic/js/src/rml-lsp.mjs"]
+```
+
+## Smoke Test
+
+The protocol smoke test starts the server through stdio framing and verifies
+initialize, diagnostics, hover, definition, completion, shutdown, and exit:
+
+```sh
+cd js
+node --test tests/lsp.test.mjs
+```

--- a/js/README.md
+++ b/js/README.md
@@ -61,6 +61,17 @@ node src/rml-links.mjs export rocq ../examples/dependent-types.lino -o dependent
 See [`../docs/ROCQ-EXPORT.md`](../docs/ROCQ-EXPORT.md) for the supported
 typed subset.
 
+### Language Server Protocol
+
+```bash
+node src/rml-lsp.mjs
+```
+
+The LSP server is stdio-based and is normally launched by an editor. It
+publishes evaluator diagnostics and supports hover, go-to-definition, and
+completion for `.lino` files. Neovim and Helix setup examples are documented
+in [`../docs/LANGUAGE_SERVER.md`](../docs/LANGUAGE_SERVER.md).
+
 ### Example
 
 ```lino

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -14,6 +14,7 @@
       "bin": {
         "rml": "src/rml-links.mjs",
         "rml-check": "src/rml-check.mjs",
+        "rml-lsp": "src/rml-lsp.mjs",
         "rml-meta": "src/rml-meta.mjs"
       },
       "devDependencies": {},

--- a/js/package.json
+++ b/js/package.json
@@ -7,13 +7,15 @@
   "bin": {
     "rml": "src/rml-links.mjs",
     "rml-check": "src/rml-check.mjs",
-    "rml-meta": "src/rml-meta.mjs"
+    "rml-meta": "src/rml-meta.mjs",
+    "rml-lsp": "src/rml-lsp.mjs"
   },
   "scripts": {
     "test": "node --test tests/ ../scripts/",
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
     "check": "node src/rml-check.mjs",
     "meta": "node src/rml-meta.mjs",
+    "lsp": "node src/rml-lsp.mjs",
     "lint:english": "node ../scripts/lint-english.mjs --allowlist ../scripts/lint-english.allowlist.json ../examples/*.lino ../lib/*/*.lino"
   },
   "keywords": [

--- a/js/src/rml-lsp.mjs
+++ b/js/src/rml-lsp.mjs
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+// rml-lsp - stdio Language Server Protocol bridge for LiNo/RML files.
+//
+// The server intentionally keeps the protocol surface small and dependency
+// free. It reuses the structured evaluator for diagnostics, then layers
+// lightweight document analysis on top for hover, go-to-definition, and
+// completion.
+
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import {
+  Env,
+  evaluate,
+  computeFormSpans,
+  parseLino,
+  tokenizeOne,
+  parseOne,
+} from './rml-links.mjs';
+import { envCompletionCandidates } from './rml-repl.mjs';
+
+const TextDocumentSyncKind = {
+  Full: 1,
+};
+
+const DiagnosticSeverity = {
+  Error: 1,
+  Warning: 2,
+};
+
+const CompletionItemKind = {
+  Text: 1,
+  Function: 3,
+  Variable: 6,
+  Keyword: 14,
+};
+
+const BUILTIN_DOCS = new Map([
+  ['?', 'Query the truth value or type of an RML expression.'],
+  ['has', 'Part of a probability assignment: `((expr) has probability p)`.'],
+  ['probability', 'Assigns or reads an expression truth value in the active range.'],
+  ['range', 'Configures the evaluator truth-value range, for example `(range: -1 1)`.'],
+  ['valence', 'Configures discrete truth-value levels, for example `(valence: 2)`.'],
+  ['and', 'Default conjunction operator. It can be redefined with `(and: ...)`.'],
+  ['or', 'Default disjunction operator. It can be redefined with `(or: ...)`.'],
+  ['not', 'Default negation operator. It can be redefined with `(not: ...)`.'],
+  ['both', 'Belnap-style contradiction-aware conjunction operator.'],
+  ['neither', 'Belnap-style gap-aware conjunction operator.'],
+  ['lambda', 'Introduces a typed lambda term.'],
+  ['apply', 'Applies a lambda term to an argument.'],
+  ['Pi', 'Forms a dependent function type.'],
+  ['Type', 'Universe type constructor.'],
+  ['Prop', 'Proposition universe.'],
+  ['type', 'Used in `(type of expr)` queries.'],
+  ['of', 'Used in type queries and type ascriptions.'],
+  ['fresh', 'Introduces a fresh variable for a scoped body.'],
+  ['template', 'Declares a reusable link template.'],
+  ['namespace', 'Sets the active namespace for subsequent declarations.'],
+  ['import', 'Imports another `.lino` file into the current environment.'],
+  ['relation', 'Declares relation clauses used by totality and coverage checks.'],
+  ['define', 'Declares recursive definitions used by termination checks.'],
+  ['inductive', 'Declares an inductive datatype and generated eliminator.'],
+  ['coinductive', 'Declares a coinductive datatype and generated corecursor.'],
+]);
+
+function uriToFilePath(uri) {
+  if (typeof uri !== 'string') return null;
+  if (!uri.startsWith('file://')) return uri;
+  try {
+    return fileURLToPath(uri);
+  } catch (_) {
+    return null;
+  }
+}
+
+function lspRange(line, character, length = 1) {
+  const start = {
+    line: Math.max(0, line),
+    character: Math.max(0, character),
+  };
+  return {
+    start,
+    end: {
+      line: start.line,
+      character: start.character + Math.max(1, length),
+    },
+  };
+}
+
+function spanToRange(span) {
+  const line = Math.max(0, (span?.line || 1) - 1);
+  const character = Math.max(0, (span?.col || 1) - 1);
+  return lspRange(line, character, span?.length || 1);
+}
+
+function toLspDiagnostic(diag) {
+  return {
+    range: spanToRange(diag.span),
+    severity: diag.code === 'E008' ? DiagnosticSeverity.Warning : DiagnosticSeverity.Error,
+    code: diag.code,
+    source: 'rml',
+    message: diag.message,
+  };
+}
+
+function parseFormsWithSpans(text, file) {
+  const spans = computeFormSpans(text, file);
+  let links;
+  try {
+    links = parseLino(text);
+  } catch (_) {
+    return [];
+  }
+
+  const out = [];
+  let spanIndex = 0;
+  for (const link of links) {
+    const source = String(link).trim();
+    const span = spans[spanIndex++] || { file, line: 1, col: 1, length: 1 };
+    if (/^\(#\s/.test(source)) continue;
+    try {
+      let node = parseOne(tokenizeOne(source));
+      while (Array.isArray(node) && node.length === 1 && Array.isArray(node[0])) {
+        node = node[0];
+      }
+      out.push({ node, span, source });
+    } catch (_) {
+      // The evaluator reports parse diagnostics; document features just skip
+      // malformed forms so a partial file remains usable while editing.
+    }
+  }
+  return out;
+}
+
+function tokenBoundary(ch) {
+  return ch === undefined || ch === '' || /\s/.test(ch) || ch === '(' || ch === ')';
+}
+
+function normalizeToken(token) {
+  if (!token) return '';
+  return String(token).replace(/[:,]+$/g, '');
+}
+
+function tokenAt(text, position) {
+  const lines = text.split('\n');
+  const lineText = lines[position.line];
+  if (lineText === undefined) return null;
+  let index = Math.min(Math.max(0, position.character), lineText.length);
+  if (index === lineText.length && index > 0) index--;
+  if (tokenBoundary(lineText[index]) && index > 0 && !tokenBoundary(lineText[index - 1])) {
+    index--;
+  }
+  if (tokenBoundary(lineText[index])) return null;
+
+  let start = index;
+  while (start > 0 && !tokenBoundary(lineText[start - 1])) start--;
+  let end = index + 1;
+  while (end < lineText.length && !tokenBoundary(lineText[end])) end++;
+  const raw = lineText.slice(start, end);
+  const token = normalizeToken(raw);
+  if (!token) return null;
+  return {
+    token,
+    raw,
+    range: {
+      start: { line: position.line, character: start },
+      end: { line: position.line, character: end },
+    },
+  };
+}
+
+function prefixAt(text, position) {
+  const lines = text.split('\n');
+  const lineText = lines[position.line] || '';
+  const before = lineText.slice(0, Math.max(0, position.character));
+  const match = before.match(/[^\s()]*$/);
+  return normalizeToken(match ? match[0] : '');
+}
+
+function findTokenRange(text, span, token) {
+  const lines = text.split('\n');
+  const startLine = Math.max(0, (span?.line || 1) - 1);
+  const needle = String(token);
+  for (let line = startLine; line < lines.length; line++) {
+    let from = line === startLine ? Math.max(0, (span?.col || 1) - 1) : 0;
+    for (;;) {
+      const index = lines[line].indexOf(needle, from);
+      if (index === -1) break;
+      const before = lines[line][index - 1];
+      const after = lines[line][index + needle.length];
+      if (tokenBoundary(before) && tokenBoundary(after)) {
+        return lspRange(line, index, needle.length);
+      }
+      from = index + needle.length;
+    }
+  }
+  return spanToRange(span);
+}
+
+function addDefinition(definitions, name, range, kind, detail) {
+  if (!name) return;
+  definitions.set(name, { name, range, kind, detail });
+}
+
+function addNamespacedDefinition(definitions, namespace, name, range, kind, detail) {
+  addDefinition(definitions, name, range, kind, detail);
+  if (namespace && !name.includes('.')) {
+    addDefinition(definitions, `${namespace}.${name}`, range, kind, detail);
+  }
+}
+
+function constructorName(node) {
+  if (!Array.isArray(node) || node[0] !== 'constructor') return null;
+  if (typeof node[1] === 'string') return node[1];
+  if (Array.isArray(node[1]) && typeof node[1][0] === 'string') return node[1][0];
+  return null;
+}
+
+function collectDefinitions(text, file) {
+  const definitions = new Map();
+  let namespace = null;
+  for (const { node, span } of parseFormsWithSpans(text, file)) {
+    if (!Array.isArray(node) || node.length === 0) continue;
+
+    if (node.length === 2 && node[0] === 'namespace' && typeof node[1] === 'string') {
+      namespace = node[1];
+      continue;
+    }
+
+    if (typeof node[0] === 'string' && node[0].endsWith(':')) {
+      const name = node[0].slice(0, -1);
+      const range = lspRange((span.line || 1) - 1, span.col || 1, name.length);
+      addNamespacedDefinition(definitions, namespace, name, range, 'definition', `Definition \`${name}\``);
+      continue;
+    }
+
+    if (node[0] === 'template' && Array.isArray(node[1]) && typeof node[1][0] === 'string') {
+      const name = node[1][0];
+      const range = findTokenRange(text, span, name);
+      addNamespacedDefinition(definitions, namespace, name, range, 'template', `Template \`${name}\``);
+      continue;
+    }
+
+    if (['relation', 'define', 'inductive', 'coinductive'].includes(node[0]) && typeof node[1] === 'string') {
+      const name = node[1];
+      const range = findTokenRange(text, span, name);
+      addNamespacedDefinition(definitions, namespace, name, range, node[0], `${node[0]} \`${name}\``);
+
+      if (node[0] === 'inductive') {
+        addNamespacedDefinition(definitions, namespace, `${name}-rec`, range, 'eliminator', `Eliminator for \`${name}\``);
+      }
+      if (node[0] === 'coinductive') {
+        addNamespacedDefinition(definitions, namespace, `${name}-corec`, range, 'corecursor', `Corecursor for \`${name}\``);
+      }
+      if (node[0] === 'inductive' || node[0] === 'coinductive') {
+        for (const child of node.slice(2)) {
+          const ctor = constructorName(child);
+          if (ctor) {
+            addNamespacedDefinition(
+              definitions,
+              namespace,
+              ctor,
+              findTokenRange(text, span, ctor),
+              'constructor',
+              `Constructor \`${ctor}\``,
+            );
+          }
+        }
+      }
+    }
+  }
+  return definitions;
+}
+
+function completionItems(env, definitions, prefix) {
+  const labels = new Set([
+    ...envCompletionCandidates(env),
+    ...env.types.keys(),
+    ...env.templates.keys(),
+    ...env.relations.keys(),
+    ...env.definitions.keys(),
+    ...env.inductives.keys(),
+    ...env.coinductives.keys(),
+    ...definitions.keys(),
+    ...BUILTIN_DOCS.keys(),
+  ]);
+
+  return [...labels]
+    .filter(label => !prefix || label.startsWith(prefix))
+    .sort((a, b) => a.localeCompare(b))
+    .map(label => {
+      const definition = definitions.get(label);
+      const builtin = BUILTIN_DOCS.has(label);
+      return {
+        label,
+        kind: builtin
+          ? CompletionItemKind.Keyword
+          : definition && ['template', 'define', 'relation'].includes(definition.kind)
+            ? CompletionItemKind.Function
+            : definition
+              ? CompletionItemKind.Variable
+              : CompletionItemKind.Text,
+        detail: definition ? definition.detail : builtin ? 'RML keyword' : 'RML symbol',
+        insertText: label,
+      };
+    });
+}
+
+function analyzeDocument(uri, text) {
+  const file = uriToFilePath(uri);
+  const env = new Env();
+  const evaluation = evaluate(text, { env, file });
+  const definitions = collectDefinitions(text, file);
+  return {
+    diagnostics: evaluation.diagnostics.map(toLspDiagnostic),
+    definitions,
+    env,
+  };
+}
+
+class RmlLanguageServer {
+  constructor(input = process.stdin, output = process.stdout) {
+    this.input = input;
+    this.output = output;
+    this.documents = new Map();
+    this.buffer = Buffer.alloc(0);
+    this.shutdownRequested = false;
+  }
+
+  start() {
+    this.input.on('data', chunk => this._onData(chunk));
+    this.input.on('end', () => process.exit(0));
+  }
+
+  _onData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    for (;;) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd === -1) return;
+      const header = this.buffer.slice(0, headerEnd).toString('ascii');
+      const lengthMatch = header.match(/Content-Length:\s*(\d+)/i);
+      if (!lengthMatch) {
+        this.buffer = Buffer.alloc(0);
+        return;
+      }
+      const length = Number(lengthMatch[1]);
+      const bodyStart = headerEnd + 4;
+      const bodyEnd = bodyStart + length;
+      if (this.buffer.length < bodyEnd) return;
+      const body = this.buffer.slice(bodyStart, bodyEnd).toString('utf8');
+      this.buffer = this.buffer.slice(bodyEnd);
+      let message;
+      try {
+        message = JSON.parse(body);
+      } catch (err) {
+        this._sendError(null, -32700, `Parse error: ${err.message}`);
+        continue;
+      }
+      this._handleMessage(message);
+    }
+  }
+
+  _send(message) {
+    const body = JSON.stringify(message);
+    this.output.write(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`);
+  }
+
+  _sendResponse(id, result) {
+    this._send({ jsonrpc: '2.0', id, result });
+  }
+
+  _sendError(id, code, message) {
+    this._send({ jsonrpc: '2.0', id, error: { code, message } });
+  }
+
+  _notify(method, params) {
+    this._send({ jsonrpc: '2.0', method, params });
+  }
+
+  _handleMessage(message) {
+    const isRequest = Object.prototype.hasOwnProperty.call(message, 'id');
+    try {
+      const result = this._dispatch(message.method, message.params);
+      if (isRequest) this._sendResponse(message.id, result);
+    } catch (err) {
+      if (isRequest) {
+        const code = err && Number.isInteger(err.code) ? err.code : -32603;
+        this._sendError(message.id, code, err && err.message ? err.message : String(err));
+      } else {
+        process.stderr.write(`rml-lsp notification error: ${err && err.stack ? err.stack : err}\n`);
+      }
+    }
+  }
+
+  _dispatch(method, params = {}) {
+    switch (method) {
+      case 'initialize':
+        return this._initialize();
+      case 'initialized':
+        return undefined;
+      case 'shutdown':
+        this.shutdownRequested = true;
+        return null;
+      case 'exit':
+        process.exit(this.shutdownRequested ? 0 : 1);
+        return undefined;
+      case 'textDocument/didOpen':
+        this._didOpen(params);
+        return undefined;
+      case 'textDocument/didChange':
+        this._didChange(params);
+        return undefined;
+      case 'textDocument/didClose':
+        this._didClose(params);
+        return undefined;
+      case 'textDocument/hover':
+        return this._hover(params);
+      case 'textDocument/definition':
+        return this._definition(params);
+      case 'textDocument/completion':
+        return this._completion(params);
+      default: {
+        const err = new Error(`Method not found: ${method}`);
+        err.code = -32601;
+        throw err;
+      }
+    }
+  }
+
+  _initialize() {
+    return {
+      capabilities: {
+        textDocumentSync: {
+          openClose: true,
+          change: TextDocumentSyncKind.Full,
+        },
+        hoverProvider: true,
+        definitionProvider: true,
+        completionProvider: {
+          triggerCharacters: ['(', ' ', ':'],
+        },
+      },
+      serverInfo: {
+        name: 'rml-lsp',
+      },
+    };
+  }
+
+  _didOpen(params) {
+    const doc = params.textDocument || {};
+    this._setDocument(doc.uri, doc.text || '', doc.version || 0);
+  }
+
+  _didChange(params) {
+    const uri = params.textDocument?.uri;
+    const existing = this.documents.get(uri);
+    const changes = params.contentChanges || [];
+    const last = changes[changes.length - 1];
+    const text = typeof last?.text === 'string' ? last.text : existing?.text || '';
+    this._setDocument(uri, text, params.textDocument?.version || existing?.version || 0);
+  }
+
+  _didClose(params) {
+    const uri = params.textDocument?.uri;
+    if (!uri) return;
+    this.documents.delete(uri);
+    this._notify('textDocument/publishDiagnostics', { uri, diagnostics: [] });
+  }
+
+  _setDocument(uri, text, version) {
+    if (!uri) return;
+    const analysis = analyzeDocument(uri, text);
+    const doc = { uri, text, version, analysis };
+    this.documents.set(uri, doc);
+    this._notify('textDocument/publishDiagnostics', {
+      uri,
+      diagnostics: analysis.diagnostics,
+    });
+  }
+
+  _document(uri) {
+    return this.documents.get(uri) || null;
+  }
+
+  _hover(params) {
+    const uri = params.textDocument?.uri;
+    const doc = this._document(uri);
+    if (!doc) return null;
+    const hit = tokenAt(doc.text, params.position || { line: 0, character: 0 });
+    if (!hit) return null;
+
+    const definition = doc.analysis.definitions.get(hit.token);
+    if (definition) {
+      return {
+        contents: {
+          kind: 'markdown',
+          value: `${definition.detail}\n\nDeclared in this document.`,
+        },
+        range: hit.range,
+      };
+    }
+    if (BUILTIN_DOCS.has(hit.token)) {
+      return {
+        contents: {
+          kind: 'markdown',
+          value: `\`${hit.token}\`: ${BUILTIN_DOCS.get(hit.token)}`,
+        },
+        range: hit.range,
+      };
+    }
+    return null;
+  }
+
+  _definition(params) {
+    const uri = params.textDocument?.uri;
+    const doc = this._document(uri);
+    if (!doc) return null;
+    const hit = tokenAt(doc.text, params.position || { line: 0, character: 0 });
+    if (!hit) return null;
+    const definition = doc.analysis.definitions.get(hit.token);
+    if (!definition) return null;
+    return {
+      uri,
+      range: definition.range,
+    };
+  }
+
+  _completion(params) {
+    const uri = params.textDocument?.uri;
+    const doc = this._document(uri);
+    if (!doc) {
+      return { isIncomplete: false, items: [] };
+    }
+    const prefix = prefixAt(doc.text, params.position || { line: 0, character: 0 });
+    return {
+      isIncomplete: false,
+      items: completionItems(doc.analysis.env, doc.analysis.definitions, prefix),
+    };
+  }
+}
+
+function runServer() {
+  new RmlLanguageServer().start();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runServer();
+}
+
+export {
+  RmlLanguageServer,
+  analyzeDocument,
+  tokenAt,
+  prefixAt,
+  collectDefinitions,
+};

--- a/js/tests/lsp.test.mjs
+++ b/js/tests/lsp.test.mjs
@@ -1,0 +1,181 @@
+// Smoke tests for the stdio Language Server Protocol implementation
+// (issue #78). The test drives the server through real LSP framing so it
+// catches protocol regressions, not just helper-level behavior.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SERVER = path.resolve('src/rml-lsp.mjs');
+
+class LspClient {
+  constructor() {
+    this.child = spawn(process.execPath, [SERVER], {
+      cwd: path.resolve('.'),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.nextId = 1;
+    this.pending = new Map();
+    this.notifications = [];
+    this.buffer = Buffer.alloc(0);
+    this.stderr = '';
+
+    this.child.stdout.on('data', chunk => this._onData(chunk));
+    this.child.stderr.on('data', chunk => { this.stderr += String(chunk); });
+  }
+
+  _onData(chunk) {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    for (;;) {
+      const headerEnd = this.buffer.indexOf('\r\n\r\n');
+      if (headerEnd === -1) return;
+      const header = this.buffer.slice(0, headerEnd).toString('ascii');
+      const lengthMatch = header.match(/Content-Length:\s*(\d+)/i);
+      assert.ok(lengthMatch, `missing Content-Length in ${header}`);
+      const length = Number(lengthMatch[1]);
+      const bodyStart = headerEnd + 4;
+      const bodyEnd = bodyStart + length;
+      if (this.buffer.length < bodyEnd) return;
+      const body = this.buffer.slice(bodyStart, bodyEnd).toString('utf8');
+      this.buffer = this.buffer.slice(bodyEnd);
+      this._onMessage(JSON.parse(body));
+    }
+  }
+
+  _onMessage(message) {
+    if (Object.prototype.hasOwnProperty.call(message, 'id')) {
+      const pending = this.pending.get(message.id);
+      if (pending) {
+        this.pending.delete(message.id);
+        pending.resolve(message);
+        return;
+      }
+    }
+    this.notifications.push(message);
+  }
+
+  _write(message) {
+    const body = JSON.stringify(message);
+    this.child.stdin.write(`Content-Length: ${Buffer.byteLength(body, 'utf8')}\r\n\r\n${body}`);
+  }
+
+  request(method, params) {
+    const id = this.nextId++;
+    this._write({ jsonrpc: '2.0', id, method, params });
+    return this._waitForResponse(id);
+  }
+
+  notify(method, params) {
+    this._write({ jsonrpc: '2.0', method, params });
+  }
+
+  _waitForResponse(id) {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`timed out waiting for response ${id}; stderr: ${this.stderr}`));
+      }, 2000);
+      this.pending.set(id, {
+        resolve: message => {
+          clearTimeout(timeout);
+          resolve(message);
+        },
+      });
+    });
+  }
+
+  waitForNotification(method, predicate = () => true) {
+    return new Promise((resolve, reject) => {
+      const started = Date.now();
+      const timer = setInterval(() => {
+        const index = this.notifications.findIndex(message =>
+          message.method === method && predicate(message.params || {}));
+        if (index !== -1) {
+          const [message] = this.notifications.splice(index, 1);
+          clearInterval(timer);
+          resolve(message);
+          return;
+        }
+        if (Date.now() - started > 2000) {
+          clearInterval(timer);
+          reject(new Error(`timed out waiting for ${method}; stderr: ${this.stderr}`));
+        }
+      }, 10);
+    });
+  }
+
+  async close() {
+    if (!this.child.killed) {
+      this.child.kill();
+    }
+  }
+}
+
+describe('rml-lsp stdio server', () => {
+  it('publishes diagnostics and answers hover, definition, and completion', async t => {
+    const client = new LspClient();
+    t.after(() => client.close());
+
+    const init = await client.request('initialize', {
+      processId: process.pid,
+      rootUri: pathToFileURL(path.resolve('..')).href,
+      capabilities: {},
+    });
+    assert.ifError(init.error);
+    assert.strictEqual(init.result.capabilities.hoverProvider, true);
+    assert.strictEqual(init.result.capabilities.definitionProvider, true);
+    assert.deepStrictEqual(init.result.capabilities.completionProvider.triggerCharacters, ['(', ' ', ':']);
+
+    client.notify('initialized', {});
+
+    const uri = 'file:///workspace/demo.lino';
+    client.notify('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId: 'lino',
+        version: 1,
+        text: '(=: missing_op identity)\n',
+      },
+    });
+    const bad = await client.waitForNotification('textDocument/publishDiagnostics', p =>
+      p.uri === uri && p.diagnostics.length === 1);
+    assert.strictEqual(bad.params.diagnostics[0].code, 'E001');
+    assert.deepStrictEqual(bad.params.diagnostics[0].range.start, { line: 0, character: 0 });
+
+    client.notify('textDocument/didChange', {
+      textDocument: { uri, version: 2 },
+      contentChanges: [{
+        text: '(a: a is a)\n((a = a) has probability 1)\n(? (a = a))\n',
+      }],
+    });
+    await client.waitForNotification('textDocument/publishDiagnostics', p =>
+      p.uri === uri && p.diagnostics.length === 0);
+
+    const hover = await client.request('textDocument/hover', {
+      textDocument: { uri },
+      position: { line: 0, character: 1 },
+    });
+    assert.match(hover.result.contents.value, /Definition `a`/);
+
+    const definition = await client.request('textDocument/definition', {
+      textDocument: { uri },
+      position: { line: 2, character: 4 },
+    });
+    assert.strictEqual(definition.result.uri, uri);
+    assert.deepStrictEqual(definition.result.range.start, { line: 0, character: 1 });
+
+    const completion = await client.request('textDocument/completion', {
+      textDocument: { uri },
+      position: { line: 2, character: 3 },
+    });
+    const labels = completion.result.items.map(item => item.label);
+    assert.ok(labels.includes('a'), labels);
+    assert.ok(labels.includes('probability'), labels);
+
+    const shutdown = await client.request('shutdown', null);
+    assert.strictEqual(shutdown.result, null);
+    client.notify('exit', null);
+  });
+});


### PR DESCRIPTION
Fixes #78

## Summary
- Add `rml-lsp`, a stdio Language Server Protocol server backed by the JavaScript evaluator.
- Publish evaluator diagnostics and provide hover, go-to-definition, and completion for `.lino` documents.
- Add an end-to-end stdio LSP smoke test that drives real JSON-RPC framing.
- Document Neovim and Helix setup, plus the `rml-lsp` package entrypoint.

## Reproduction
Before this change, the repository had no LSP entrypoint, so editors could not launch an RML language server for diagnostics or navigation.

The new smoke test starts the server over stdio, opens an invalid document to verify diagnostics, edits it to a valid document, then verifies hover, go-to-definition, completion, shutdown, and exit.

## Tests
- `node --test tests/lsp.test.mjs` from `js/`
- `node --check src/rml-lsp.mjs` from `js/`
- `npm test` from `js/`
- `npm run lint:english` from `js/`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`
