### PR TITLE
[H3] Generated API/reference docs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,82 @@
+name: api-docs
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/api-docs.yml'
+      - 'docs/api/**'
+      - 'js/**'
+      - 'rust/**'
+      - 'scripts/docs.test.mjs'
+      - 'scripts/write-docs-index.mjs'
+      - 'README.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/api-docs.yml'
+      - 'docs/api/**'
+      - 'js/**'
+      - 'rust/**'
+      - 'scripts/docs.test.mjs'
+      - 'scripts/write-docs-index.mjs'
+      - 'README.md'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
+      - name: Install JavaScript dependencies
+        working-directory: js
+        run: npm ci
+      - name: Build JavaScript API docs
+        working-directory: js
+        run: npm run docs -- --destination ../_site/api/js
+      - name: Build Rust API docs
+        run: cargo doc --manifest-path rust/Cargo.toml --no-deps --target-dir target/api-docs/rust
+      - name: Copy Rust API docs
+        run: |
+          mkdir -p _site/api/rust
+          cp -R target/api-docs/rust/doc/. _site/api/rust/
+      - name: Add reference docs landing page
+        run: node scripts/write-docs-index.mjs _site
+      - name: Configure GitHub Pages
+        if: github.event_name == 'release'
+        uses: actions/configure-pages@v5
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'release'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    if: github.event_name == 'release'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ lib-cov
 coverage
 *.lcov
 
+# Generated documentation and build artifacts
+_site/
+target/
+
 # nyc test coverage
 .nyc_output
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-09T03:50:39.316Z for PR creation at branch issue-78-9983c491f4e6 for issue https://github.com/link-foundation/relative-meta-logic/issues/78
-# Updated: 2026-05-09T05:30:20.748Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-09T03:50:39.316Z for PR creation at branch issue-78-9983c491f4e6 for issue https://github.com/link-foundation/relative-meta-logic/issues/78
+# Updated: 2026-05-09T05:30:20.748Z

--- a/README.md
+++ b/README.md
@@ -935,6 +935,7 @@ The test suites cover:
 ## API
 
 See language-specific documentation:
+- [API reference](https://link-foundation.github.io/relative-meta-logic/) - generated from JSDoc and rustdoc on release
 - [JavaScript API](./js/README.md#api)
 - [Rust API](./rust/README.md#api)
 

--- a/docs/api/jsdoc.json
+++ b/docs/api/jsdoc.json
@@ -1,0 +1,16 @@
+{
+  "source": {
+    "include": ["src"],
+    "includePattern": ".+\\.mjs$"
+  },
+  "plugins": ["plugins/markdown"],
+  "opts": {
+    "encoding": "utf8",
+    "recurse": true,
+    "readme": "README.md"
+  },
+  "templates": {
+    "cleverLinks": true,
+    "monospaceLinks": true
+  }
+}

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -17,9 +17,216 @@
         "rml-lsp": "src/rml-lsp.mjs",
         "rml-meta": "src/rml-meta.mjs"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "jsdoc": "^4.0.5"
+      },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/links-notation": {
@@ -27,6 +234,129 @@
       "resolved": "https://registry.npmjs.org/links-notation/-/links-notation-0.13.0.tgz",
       "integrity": "sha512-52FoUAVOhjfC23bdvrxv6b4Eosp02WeM3qTN9Rsb3ouPof5YVQ5fOMlRPMJmKMmdseVzEnewNLFq3lADRpWTFg==",
       "license": "Unlicense"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
     }
   }
 }

--- a/js/package.json
+++ b/js/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test": "node --test tests/ ../scripts/",
+    "docs": "jsdoc -c ../docs/api/jsdoc.json",
     "demo": "node src/rml-links.mjs ../examples/demo.lino",
     "check": "node src/rml-check.mjs",
     "meta": "node src/rml-meta.mjs",
@@ -31,7 +32,9 @@
   "dependencies": {
     "links-notation": "^0.13.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "jsdoc": "^4.0.5"
+  },
   "engines": {
     "node": ">=18.0.0"
   }

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -20,6 +20,10 @@ import { Parser } from 'links-notation';
 // Every parser/evaluator error is reported as a `Diagnostic` with an error
 // code, human-readable message, and source span (file/line/col, 1-based).
 // See `docs/DIAGNOSTICS.md` for the full code list.
+/**
+ * Structured parser, evaluator, or type-checker diagnostic with a stable code
+ * and 1-based source span.
+ */
 class Diagnostic {
   constructor({ code, message, span }) {
     this.code = code;
@@ -44,6 +48,9 @@ class RmlError extends Error {
 // deterministic sequence of `TraceEvent` objects describing operator
 // resolutions, assignment lookups, and reduction steps. The CLI's `--trace`
 // flag prints each one as `[span <file>:<line>:<col>] <kind> <details>`.
+/**
+ * Trace record emitted when `evaluate()` or the CLI runs with tracing enabled.
+ */
 class TraceEvent {
   constructor({ kind, detail, span }) {
     this.kind = kind;
@@ -193,6 +200,10 @@ function quantize(x, valence, lo, hi) {
 }
 
 // ---------- Environment ----------
+/**
+ * Mutable evaluator environment that stores terms, assignments, operators,
+ * namespaces, imports, and type-checking context.
+ */
 class Env {
   constructor(options){
     const opts = options || {};
@@ -2472,6 +2483,15 @@ function evalEqualityNode(left, op, right, env, options = {}) {
   return env.clamp(env.getOp('not')(eq));
 }
 
+/**
+ * Check definitional equality by normalizing two terms in the supplied context.
+ *
+ * @param {*} left - Left AST term.
+ * @param {*} right - Right AST term.
+ * @param {object} [ctx] - Type-checking context.
+ * @param {object} [options] - Conversion options.
+ * @returns {boolean} True when the terms are convertible.
+ */
 function isConvertible(left, right, ctx, options) {
   const env = ctx instanceof Env ? ctx : new Env(ctx && ctx.env ? ctx.env : ctx);
   const opts = conversionOptionsFrom(ctx, options);
@@ -2511,6 +2531,9 @@ function flattenNeutralApplies(node, env) {
 
 // Public weak-head normal form API (issue #50, D4).
 // Reduces only the spine of `term` — leaves binders and arguments untouched.
+/**
+ * Reduce a term to weak-head normal form without descending into arguments.
+ */
 function whnf(term, ctx, options) {
   const env = ctx instanceof Env ? ctx : new Env(ctx && ctx.env ? ctx.env : ctx);
   const opts = conversionOptionsFrom(ctx, options);
@@ -2520,6 +2543,9 @@ function whnf(term, ctx, options) {
 // Public full normal form API (issue #50, D4).
 // Reduces every redex in `term`, including ones nested under binders and in
 // argument positions, until the term is in beta-(eta-)normal form.
+/**
+ * Reduce a term to normal form.
+ */
 function nf(term, ctx, options) {
   const env = ctx instanceof Env ? ctx : new Env(ctx && ctx.env ? ctx.env : ctx);
   const opts = conversionOptionsFrom(ctx, options);
@@ -4519,6 +4545,9 @@ function _synthOfMembership(node, env, span, diagnostics) {
   return ['Type', '0'];
 }
 
+/**
+ * Synthesize the type of a kernel term.
+ */
 function synth(term, ctx, options) {
   const env = _envFromCtx(ctx);
   const span = _spanFromCtx(ctx, options);
@@ -4640,6 +4669,9 @@ function synth(term, ctx, options) {
   return { type: null, diagnostics };
 }
 
+/**
+ * Check that a kernel term has the expected type.
+ */
 function check(term, expectedType, ctx, options) {
   const env = _envFromCtx(ctx);
   const span = _spanFromCtx(ctx, options);
@@ -4740,6 +4772,9 @@ function stripLinoComments(text) {
     .replace(/\n{3,}/g, '\n\n');
 }
 
+/**
+ * Parse LiNo source text with the official links-notation parser.
+ */
 function parseLino(text) {
   const parser = new Parser();
   return parser.parse(stripLinoComments(text)).map(link => String(link));
@@ -4765,6 +4800,9 @@ function parseLinoForms(text) {
 // like `stripLinoComments` does. Inline `# ...` comments that follow a closing
 // paren (matching `(\)[ \t]+)#.*$` in `stripLinoComments`) are also skipped so
 // parens inside the comment don't disturb the depth counter.
+/**
+ * Compute 1-based source spans for every top-level LiNo form in `text`.
+ */
 function computeFormSpans(text, file) {
   const spans = [];
   const lines = text.split('\n');
@@ -4835,6 +4873,17 @@ function computeFormSpans(text, file) {
 //
 // `options.env` may be an existing `Env` instance (used by the REPL to
 // preserve state across inputs) or a plain options object passed to `new Env`.
+/**
+ * Evaluate LiNo source and return query results plus structured diagnostics.
+ *
+ * @param {string} code - LiNo source text.
+ * @param {object} [options] - Evaluation options.
+ * @param {string} [options.file] - Source file path used in diagnostics.
+ * @param {Env|object} [options.env] - Existing environment or environment options.
+ * @param {boolean} [options.trace=false] - Include deterministic trace events.
+ * @param {boolean} [options.withProofs=false] - Include proof witnesses for queries.
+ * @returns {object} Results, diagnostics, and optional trace/proof arrays.
+ */
 function evaluate(code, options) {
   const opts = options || {};
   const file = opts.file || null;
@@ -5171,6 +5220,9 @@ function handleImport(rawTarget, alias, span, importingFile, env, importStack, i
 // Read a file from disk and evaluate it, honouring (import ...) directives.
 // Mirrors `evaluate()` but takes a path on disk and resolves relative imports
 // against the file's directory.
+/**
+ * Read and evaluate a LiNo file, resolving imports relative to that file.
+ */
 function evaluateFile(filePath, options) {
   const opts = options || {};
   const resolved = path.resolve(filePath);
@@ -5656,6 +5708,9 @@ function compileRustProgram(parsed) {
   return lines.join('\n');
 }
 
+/**
+ * Extract selected LiNo definitions into JavaScript or Rust source code.
+ */
 function extractProgram(code, target = 'js') {
   const normalized = normalizeExtractTarget(target);
   const parsed = parseExtractProgram(code);
@@ -6065,6 +6120,9 @@ class IsabelleExportContext {
   }
 }
 
+/**
+ * Export the supported typed LiNo fragment to Isabelle/HOL source text.
+ */
 function exportIsabelle(sourceText, options = {}) {
   const ctx = new IsabelleExportContext(options);
   let forms;
@@ -6078,6 +6136,9 @@ function exportIsabelle(sourceText, options = {}) {
 }
 
 // ---------- Runner ----------
+/**
+ * Compatibility wrapper that evaluates LiNo text and returns only query values.
+ */
 function run(text, options){
   return evaluate(text, options).results;
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -588,7 +588,7 @@ pub fn dec_round(x: f64) -> f64 {
 /// For N=2 (Boolean): levels are {lo, hi}
 /// For N=3 (ternary): levels are {lo, mid, hi}
 /// For N<2 (continuous/unary): no quantization
-/// See: https://en.wikipedia.org/wiki/Many-valued_logic
+/// See: <https://en.wikipedia.org/wiki/Many-valued_logic>
 pub fn quantize(x: f64, valence: u32, lo: f64, hi: f64) -> f64 {
     if valence < 2 {
         return x; // unary or continuous — no quantization
@@ -2094,7 +2094,7 @@ fn normalize_term(node: &Node, env: &mut Env, options: ConvertOptions) -> Node {
 /// Weak-head normal form (D4): reduce the spine of `node` — i.e. unfold the
 /// head as long as there are arguments to apply to it — without descending
 /// into binders or argument positions. Mirrors `whnfTerm` in the JS runtime
-/// and `nf`/`is_convertible` already use [`normalize_term`] for the full
+/// and `nf`/`is_convertible` already use `normalize_term` for the full
 /// version. Substitution may expose a redex inside the residual body, but
 /// that is no longer on the original spine, so this routine returns it
 /// unevaluated; full normalization is the place that descends into those

--- a/scripts/docs.test.mjs
+++ b/scripts/docs.test.mjs
@@ -46,3 +46,33 @@ describe('soundness documentation', () => {
     }
   });
 });
+
+describe('generated API reference documentation', () => {
+  it('is linked from the README', () => {
+    const readme = read('README.md');
+    assert.match(
+      readme,
+      /\[API reference\]\(https:\/\/link-foundation\.github\.io\/relative-meta-logic\/\)/,
+    );
+  });
+
+  it('builds JavaScript and Rust API docs for GitHub Pages on release', () => {
+    const workflow = read('.github/workflows/api-docs.yml');
+    for (const expected of [
+      'release:',
+      'types: [published]',
+      'npm run docs',
+      'cargo doc',
+      'actions/configure-pages',
+      'actions/upload-pages-artifact',
+      'actions/deploy-pages',
+    ]) {
+      assert.ok(workflow.includes(expected), `missing ${expected}`);
+    }
+  });
+
+  it('defines a JavaScript docs script for JSDoc generation', () => {
+    const packageJson = JSON.parse(read('js/package.json'));
+    assert.equal(packageJson.scripts.docs, 'jsdoc -c ../docs/api/jsdoc.json');
+  });
+});

--- a/scripts/write-docs-index.mjs
+++ b/scripts/write-docs-index.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const outDir = path.resolve(process.argv[2] || '_site');
+fs.mkdirSync(outDir, { recursive: true });
+
+const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>relative-meta-logic API Reference</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    body {
+      margin: 0;
+      padding: 3rem 1.5rem;
+    }
+    main {
+      max-width: 48rem;
+      margin: 0 auto;
+    }
+    h1 {
+      font-size: 2rem;
+      margin: 0 0 0.5rem;
+    }
+    p {
+      margin: 0 0 1.5rem;
+    }
+    ul {
+      padding-left: 1.25rem;
+    }
+    li {
+      margin: 0.5rem 0;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>relative-meta-logic API Reference</h1>
+    <p>Generated from the JavaScript JSDoc comments and Rust rustdoc output.</p>
+    <ul>
+      <li><a href="./api/js/">JavaScript API reference</a></li>
+      <li><a href="./api/rust/rml/">Rust API reference</a></li>
+    </ul>
+  </main>
+</body>
+</html>
+`;
+
+fs.writeFileSync(path.join(outDir, 'index.html'), html, 'utf8');
+fs.writeFileSync(path.join(outDir, '.nojekyll'), '', 'utf8');


### PR DESCRIPTION
## Summary
Fixes #80.

- Adds an api-docs GitHub Actions workflow that validates JSDoc and rustdoc generation on PRs and publishes the generated site to GitHub Pages when a release is published.
- Adds the JSDoc config, JavaScript docs script, generated-docs landing page, and README link to the published API reference.
- Adds focused docs regression tests for the README link, release trigger, Pages deployment actions, and JavaScript docs script.
- Adds JSDoc comments for the main JavaScript evaluator API and cleans up rustdoc warnings in existing public docs.

## Acceptance criteria
- [x] Docs published on GitHub Pages on release via .github/workflows/api-docs.yml.
- [x] README links the published API reference at https://link-foundation.github.io/relative-meta-logic/.

## Verification
- [x] node --test scripts/docs.test.mjs
- [x] cd js && npm run docs -- --destination ../_site/api/js
- [x] cargo doc --manifest-path rust/Cargo.toml --no-deps --target-dir target/api-docs/rust
- [x] node scripts/write-docs-index.mjs _site
- [x] cd js && npm test - 823 tests passed
- [x] cd rust && cargo test - passed
- [x] git diff --check
- [x] GitHub Actions on 080082e: lint-english passed, api-docs passed
