### PR TITLE
[H5] Literate `.lino.md` evaluation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-09T03:50:39.316Z for PR creation at branch issue-78-9983c491f4e6 for issue https://github.com/link-foundation/relative-meta-logic/issues/78
+# Updated: 2026-05-09T07:56:06.228Z

--- a/README.md
+++ b/README.md
@@ -93,6 +93,24 @@ Examples are language-agnostic and live in [`/examples/`](./examples/). Both
 implementations execute the same files and are required to produce identical
 output (enforced by `examples/expected.lino` and the shared-examples tests).
 
+### Literate LiNo
+
+Evaluator entry points also accept literate `.lino.md` files. Prose is ignored
+and only fenced `lino` code blocks are evaluated, so mathematical exposition
+and runnable declarations can live in the same file:
+
+````markdown
+# Theorem
+
+```lino
+(a: a is a)
+((a = a) has probability 1)
+(? (a = a))
+```
+````
+
+The same extraction is used for files loaded through `(import "...")`.
+
 ### Standard libraries
 
 Reusable LiNo libraries live under [`/lib/`](./lib/). The classical Boolean

--- a/js/README.md
+++ b/js/README.md
@@ -21,6 +21,10 @@ npm install
 node src/rml-links.mjs <file.lino>
 ```
 
+Literate `.lino.md` files are also accepted by evaluator entry points. Only
+fenced `lino` code blocks are evaluated; prose and other fenced languages are
+ignored. The same extraction applies to files loaded through `(import "...")`.
+
 ### Exporting Lean 4
 
 ```bash

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -4772,6 +4772,70 @@ function stripLinoComments(text) {
     .replace(/\n{3,}/g, '\n\n');
 }
 
+function isLiterateLinoPath(file) {
+  return typeof file === 'string' && /\.lino\.md$/i.test(file);
+}
+
+function parseMarkdownFence(line) {
+  const trimmed = String(line).replace(/^[ \t]*/, '');
+  const match = trimmed.match(/^(`{3,}|~{3,})(.*)$/);
+  if (!match) return null;
+  return {
+    marker: match[1][0],
+    length: match[1].length,
+    info: match[2] || '',
+  };
+}
+
+function isClosingMarkdownFence(line, fence) {
+  const parsed = parseMarkdownFence(line);
+  return parsed &&
+    parsed.marker === fence.marker &&
+    parsed.length >= fence.length &&
+    /^[ \t]*$/.test(parsed.info);
+}
+
+function isLinoFenceInfo(info) {
+  const tag = String(info).trim().split(/\s+/, 1)[0] || '';
+  return tag.toLowerCase() === 'lino';
+}
+
+/**
+ * Extract LiNo code from fenced `lino` blocks in a literate `.lino.md` file.
+ *
+ * Non-LiNo prose and other code fences become blank lines so diagnostics keep
+ * the original Markdown line numbers.
+ */
+function extractLiterateLino(text) {
+  const lines = String(text).split('\n');
+  const out = [];
+  let activeFence = null;
+  for (const line of lines) {
+    if (activeFence) {
+      if (isClosingMarkdownFence(line, activeFence)) {
+        activeFence = null;
+        out.push('');
+      } else {
+        out.push(activeFence.include ? line : '');
+      }
+      continue;
+    }
+    const fence = parseMarkdownFence(line);
+    if (fence) {
+      activeFence = { ...fence, include: isLinoFenceInfo(fence.info) };
+      out.push('');
+      continue;
+    }
+    out.push('');
+  }
+  return out.join('\n');
+}
+
+function sourceForEvaluation(code, file) {
+  const source = String(code);
+  return isLiterateLinoPath(file) ? extractLiterateLino(source) : source;
+}
+
 /**
  * Parse LiNo source text with the official links-notation parser.
  */
@@ -4887,7 +4951,7 @@ function computeFormSpans(text, file) {
 function evaluate(code, options) {
   const opts = options || {};
   const file = opts.file || null;
-  const sourceText = String(code);
+  const sourceText = sourceForEvaluation(code, file);
   const env = opts.env instanceof Env ? opts.env : new Env(opts.env || opts);
   const results = [];
   const diagnostics = [];
@@ -6292,6 +6356,7 @@ export {
   formatDiagnostic,
   formatTraceEvent,
   computeFormSpans,
+  extractLiterateLino,
   parseLino,
   tokenizeOne,
   parseOne,

--- a/js/tests/imports.test.mjs
+++ b/js/tests/imports.test.mjs
@@ -49,6 +49,53 @@ describe('evaluateFile() loads a file from disk', () => {
   });
 });
 
+describe('evaluateFile() loads literate .lino.md files', () => {
+  let dir;
+  before(() => {
+    dir = makeTmp();
+    fs.writeFileSync(path.join(dir, 'literate.lino.md'), `# Literate theorem
+
+This prose mentions (not lino) and must not be parsed.
+
+\`\`\`lino
+(a: a is a)
+((a = a) has probability 1)
+\`\`\`
+
+\`\`\`javascript
+throw new Error('not LiNo');
+\`\`\`
+
+More exposition between blocks.
+
+\`\`\`lino
+(? (a = a))
+\`\`\`
+`);
+    fs.writeFileSync(path.join(dir, 'library.lino.md'), `# Literate library
+
+\`\`\`lino
+(b: b is b)
+((b = b) has probability 1)
+\`\`\`
+`);
+    fs.writeFileSync(path.join(dir, 'host.lino'), '(import "library.lino.md")\n(? (b = b))\n');
+  });
+  after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('extracts only fenced lino code blocks before evaluation', () => {
+    const out = evaluateFile(path.join(dir, 'literate.lino.md'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('extracts fenced lino code blocks from imported literate files', () => {
+    const out = evaluateFile(path.join(dir, 'host.lino'));
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+});
+
 describe('(import "...") — linear chain', () => {
   let dir;
   before(() => {

--- a/rust/README.md
+++ b/rust/README.md
@@ -21,6 +21,10 @@ cargo build
 cargo run -- <file.lino>
 ```
 
+Literate `.lino.md` files are also accepted by evaluator entry points. Only
+fenced `lino` code blocks are evaluated; prose and other fenced languages are
+ignored. The same extraction applies to files loaded through `(import "...")`.
+
 ### Exporting Lean 4
 
 ```bash

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -328,6 +328,71 @@ pub fn parse_lino(text: &str) -> Vec<String> {
     all_links
 }
 
+fn is_literate_lino_path(file: Option<&str>) -> bool {
+    file.map(|path| path.to_ascii_lowercase().ends_with(".lino.md"))
+        .unwrap_or(false)
+}
+
+fn parse_markdown_fence(line: &str) -> Option<(char, usize, &str)> {
+    let trimmed = line.trim_start_matches(|c| c == ' ' || c == '\t');
+    let marker = trimmed.chars().next()?;
+    if marker != '`' && marker != '~' {
+        return None;
+    }
+    let count = trimmed.chars().take_while(|c| *c == marker).count();
+    if count < 3 {
+        return None;
+    }
+    Some((marker, count, &trimmed[count..]))
+}
+
+fn is_closing_markdown_fence(line: &str, marker: char, min_len: usize) -> bool {
+    let Some((found_marker, found_len, rest)) = parse_markdown_fence(line) else {
+        return false;
+    };
+    found_marker == marker
+        && found_len >= min_len
+        && rest.chars().all(|c| c == ' ' || c == '\t')
+}
+
+fn is_lino_fence_info(info: &str) -> bool {
+    info.trim()
+        .split_whitespace()
+        .next()
+        .map(|tag| tag.eq_ignore_ascii_case("lino"))
+        .unwrap_or(false)
+}
+
+/// Extract LiNo code from fenced `lino` blocks in a literate `.lino.md` file.
+///
+/// Non-LiNo prose and other code fences become blank lines so diagnostics keep
+/// the original Markdown line numbers.
+pub fn extract_literate_lino(text: &str) -> String {
+    let mut out = Vec::new();
+    let mut active_fence: Option<(char, usize, bool)> = None;
+    for line in text.split('\n') {
+        if let Some((marker, min_len, include)) = active_fence {
+            if is_closing_markdown_fence(line, marker, min_len) {
+                active_fence = None;
+                out.push(String::new());
+            } else if include {
+                out.push(line.to_string());
+            } else {
+                out.push(String::new());
+            }
+            continue;
+        }
+
+        if let Some((marker, len, info)) = parse_markdown_fence(line) {
+            active_fence = Some((marker, len, is_lino_fence_info(info)));
+            out.push(String::new());
+        } else {
+            out.push(String::new());
+        }
+    }
+    out.join("\n")
+}
+
 // ========== AST ==========
 
 /// AST node: either a leaf string or a list of child nodes.
@@ -9025,9 +9090,15 @@ fn handle_import(
 
 fn evaluate_inner(text: &str, file: Option<&str>, env: &mut Env, options: &EvaluateOptions, ctx: &mut ImportContext) -> EvaluateResult {
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
-    let spans = compute_form_spans(text, file);
+    let extracted_literate = if is_literate_lino_path(file) {
+        Some(extract_literate_lino(text))
+    } else {
+        None
+    };
+    let source_text = extracted_literate.as_deref().unwrap_or(text);
+    let spans = compute_form_spans(source_text, file);
 
-    let links = parse_lino(text);
+    let links = parse_lino(source_text);
     let forms: Vec<Node> = links
         .iter()
         .filter(|link_str| {

--- a/rust/tests/imports_tests.rs
+++ b/rust/tests/imports_tests.rs
@@ -63,6 +63,61 @@ fn evaluate_file_reports_missing_file_as_e007() {
 }
 
 #[test]
+fn evaluate_file_extracts_literate_lino_markdown_blocks() {
+    let dir = make_tmp("literate");
+    let main = write(
+        &dir,
+        "literate.lino.md",
+        r#"# Literate theorem
+
+This prose mentions (not lino) and must not be parsed.
+
+```lino
+(a: a is a)
+((a = a) has probability 1)
+```
+
+```javascript
+throw new Error('not LiNo');
+```
+
+More exposition between blocks.
+
+```lino
+(? (a = a))
+```
+"#,
+    );
+    let out = evaluate_file(main.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
+fn imports_extract_literate_lino_markdown_blocks() {
+    let dir = make_tmp("literate-import");
+    write(
+        &dir,
+        "library.lino.md",
+        r#"# Literate library
+
+```lino
+(b: b is b)
+((b = b) has probability 1)
+```
+"#,
+    );
+    let host = write(&dir, "host.lino", "(import \"library.lino.md\")\n(? (b = b))\n");
+    let out = evaluate_file(host.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(out.results.len(), 1);
+    assert!((expect_num(&out.results[0]) - 1.0).abs() < 1e-9);
+    cleanup(&dir);
+}
+
+#[test]
 fn linear_chain_loads_declarations_across_three_files() {
     let dir = make_tmp("chain");
     write(


### PR DESCRIPTION
Fixes #82

## Summary
- Add JS and Rust literate LiNo extractors for fenced `lino` blocks in `.lino.md` files.
- Invoke the extractor from evaluator entry points when the source path ends in `.lino.md`, preserving Markdown line numbers for diagnostics by blanking ignored prose and non-LiNo fences.
- Cover direct evaluation and imports of literate files in mirrored JS/Rust tests.
- Document literate `.lino.md` evaluator support in the root, JS, and Rust READMEs.

## Reproduction
Before this change, evaluating a `.lino.md` file sent Markdown prose and fences to the LiNo parser, producing parse diagnostics instead of running the fenced program.

The new tests build representative literate files with prose, multiple `lino` blocks, and a non-LiNo fenced block that must be ignored. They also verify that `(import "library.lino.md")` applies the same extraction.

## Tests
- `node --test tests/imports.test.mjs` from `js/`
- `cargo test --test imports_tests` from `rust/`
- `npm test` from `js/`
- `cargo test` from `rust/`
- `npm run docs -- --destination ../_site/api/js` from `js/`
- `cargo doc --no-deps --target-dir ../target/api-docs/rust` from `rust/`
- `git diff --check`
