### PR TITLE
[J1] Encode the LiNo grammar as links

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T08:49:43.188Z for PR creation at branch issue-84-4bdf574b14c5 for issue https://github.com/link-foundation/relative-meta-logic/issues/84

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T08:49:43.188Z for PR creation at branch issue-84-4bdf574b14c5 for issue https://github.com/link-foundation/relative-meta-logic/issues/84

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ LiNo imports:
 (? (px.fixed-point (px.liar s)))
 ```
 
+The [self grammar library](./lib/self/grammar.lino) encodes the LiNo grammar as
+links so self-hosted parsing work can consume grammar rules through ordinary
+LiNo data.
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/self-grammar.test.mjs
+++ b/js/tests/self-grammar.test.mjs
@@ -1,0 +1,141 @@
+// Tests for `lib/self/grammar.lino` (issue #84).
+//
+// The grammar file is the self-bootstrap data layer: it describes LiNo as
+// ordinary links. These tests keep that data parseable, importable, and tied
+// to the current example corpus by comparing a minimal grammar-shaped parser
+// against the host parser's AST presentation.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  evaluateFile,
+  parseLino,
+  parseOne,
+  tokenizeOne,
+} from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const grammarPath = join(repoRoot, 'lib', 'self', 'grammar.lino');
+const examplesDir = join(repoRoot, 'examples');
+
+const REQUIRED_RULES = [
+  'document',
+  'source-for-evaluation',
+  'links',
+  'first-line',
+  'line',
+  'element',
+  'any-link',
+  'parenthesized-link',
+  'id-link',
+  'value-link',
+  'indented-id-link',
+  'reference',
+  'simple-reference',
+  'quoted-reference',
+  'whitespace',
+  'end-of-line',
+  'host-parser-presentation',
+];
+
+function grammarForms() {
+  const source = readFileSync(grammarPath, 'utf8');
+  return parseLino(source).map(link => parseOne(tokenizeOne(link)));
+}
+
+function ruleNames(forms) {
+  const names = new Set();
+  for (const form of forms) {
+    if (Array.isArray(form) && form[0] === 'rule' && typeof form[1] === 'string') {
+      names.add(form[1]);
+    }
+  }
+  return names;
+}
+
+function stripRmlComments(source) {
+  return String(source)
+    .replace(/^[ \t]*#.*$/gm, '')
+    .replace(/(\)[ \t]+)#.*$/gm, '$1')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+function parseSelfPresentation(source, rules) {
+  assert.ok(rules.has('host-parser-presentation'));
+  assert.ok(rules.has('parenthesized-link'));
+  assert.ok(rules.has('simple-reference'));
+
+  const input = stripRmlComments(source);
+  let index = 0;
+
+  const fail = (message) => {
+    throw new Error(`${message} at byte ${index}`);
+  };
+  const skipWhitespace = () => {
+    while (index < input.length && /\s/.test(input[index])) index++;
+  };
+  const parseAtom = () => {
+    const start = index;
+    while (
+      index < input.length &&
+      !/\s/.test(input[index]) &&
+      input[index] !== '(' &&
+      input[index] !== ')'
+    ) {
+      index++;
+    }
+    if (start === index) fail('expected reference');
+    return input.slice(start, index);
+  };
+  const parseList = () => {
+    if (input[index] !== '(') fail('expected "("');
+    index++;
+    const children = [];
+    for (;;) {
+      skipWhitespace();
+      if (index >= input.length) fail('expected ")"');
+      if (input[index] === ')') {
+        index++;
+        return children;
+      }
+      children.push(input[index] === '(' ? parseList() : parseAtom());
+    }
+  };
+
+  const forms = [];
+  for (;;) {
+    skipWhitespace();
+    if (index >= input.length) return forms;
+    forms.push(parseList());
+  }
+}
+
+function hostAst(source) {
+  return parseLino(source).map(link => parseOne(tokenizeOne(link)));
+}
+
+describe('self LiNo grammar', () => {
+  it('is importable as a standard library file', () => {
+    const out = evaluateFile(grammarPath);
+    assert.deepStrictEqual(out.diagnostics, []);
+  });
+
+  it('declares the required grammar rules as links', () => {
+    const rules = ruleNames(grammarForms());
+    for (const name of REQUIRED_RULES) {
+      assert.ok(rules.has(name), `missing rule ${name}`);
+    }
+  });
+
+  for (const file of readdirSync(examplesDir).filter(f => f.endsWith('.lino')).sort()) {
+    it(`parses ${file} with the same AST as the host parser`, () => {
+      const source = readFileSync(join(examplesDir, file), 'utf8');
+      const rules = ruleNames(grammarForms());
+      assert.deepStrictEqual(parseSelfPresentation(source, rules), hostAst(source));
+    });
+  }
+});

--- a/lib/self/grammar.lino
+++ b/lib/self/grammar.lino
@@ -1,0 +1,295 @@
+# LiNo grammar encoded as links for the self-bootstrap layer.
+#
+# The rules below describe the links-notation parser used by the host
+# implementations. They are data: future self-hosted parsers can read the
+# `(rule ...)` links directly, while today's evaluator can import this file
+# without requiring a parser interpreter.
+
+(namespace self)
+
+(Grammar: (Type 0) Grammar)
+(Rule: (Type 0) Rule)
+(Terminal: (Type 0) Terminal)
+(Ast-node: (Type 0) Ast-node)
+
+(lino-grammar: Grammar lino-grammar)
+(grammar lino-grammar matches links-notation version-0-13-0)
+(grammar lino-grammar has start document)
+(grammar lino-grammar has host-ast-presentation host-parser-presentation)
+
+# RML evaluates `.lino` examples after removing comments. The LiNo grammar
+# starts at `document`; `source-for-evaluation` records the host wrapper that
+# turns source files with comments into parser input.
+
+(rule source-for-evaluation
+  (sequence (zero-or-more source-line) end-of-input)
+  (normalizes-to document))
+
+(rule source-line
+  (choice full-line-comment inline-comment-after-link lino-code-line blank-line))
+
+(rule full-line-comment
+  (sequence indentation hash-sign (zero-or-more any-character) end-of-line)
+  (emits blank-line))
+
+(rule inline-comment-after-link
+  (sequence parenthesized-link trailing-horizontal-whitespace hash-sign (zero-or-more any-character) end-of-line)
+  (emits parenthesized-link))
+
+(rule lino-code-line
+  (sequence (optional indentation) any-link))
+
+(rule blank-line
+  (sequence (zero-or-more horizontal-whitespace) end-of-line))
+
+# Official LiNo document grammar.
+
+(rule document
+  (sequence skip-empty-lines links whitespace end-of-input)
+  (produces flattened-link-list))
+
+(rule skip-empty-lines
+  (zero-or-more blank-line))
+
+(rule links
+  (sequence first-line (zero-or-more line)))
+
+(rule first-line
+  (sequence set-base-indentation element))
+
+(rule line
+  (sequence check-indentation element))
+
+(rule element
+  (sequence any-link (optional indented-children)))
+
+(rule indented-children
+  (sequence push-indentation links pop-indentation))
+
+(rule any-link
+  (choice
+    (sequence multi-line-any-link end-of-line)
+    indented-id-link
+    single-line-any-link))
+
+(rule parenthesized-link
+  (choice multi-line-id-link multi-line-value-link))
+
+(rule multi-line-any-link
+  (choice multi-line-value-link multi-line-id-link))
+
+(rule single-line-any-link
+  (choice single-line-id-link single-line-value-link))
+
+(rule id-link
+  (choice single-line-id-link multi-line-id-link indented-id-link))
+
+(rule value-link
+  (choice single-line-value-link multi-line-value-link))
+
+(rule single-line-id-link
+  (sequence horizontal-whitespace reference horizontal-whitespace colon single-line-values)
+  (produces (ast id-link reference single-line-values)))
+
+(rule multi-line-id-link
+  (sequence left-parenthesis whitespace reference whitespace colon multi-line-values whitespace right-parenthesis)
+  (produces (ast id-link reference multi-line-values)))
+
+(rule indented-id-link
+  (sequence reference horizontal-whitespace colon end-of-line)
+  (produces pending-indented-id-link))
+
+(rule single-line-value-link
+  (sequence single-line-values)
+  (produces (ast value-link single-line-values)))
+
+(rule multi-line-value-link
+  (sequence left-parenthesis multi-line-values whitespace right-parenthesis)
+  (produces (ast value-link multi-line-values)))
+
+(rule single-line-values
+  (one-or-more single-line-value-and-whitespace))
+
+(rule multi-line-values
+  (sequence whitespace (zero-or-more multi-line-value-and-whitespace)))
+
+(rule single-line-value-and-whitespace
+  (sequence horizontal-whitespace reference-or-link))
+
+(rule multi-line-value-and-whitespace
+  (sequence reference-or-link whitespace))
+
+(rule reference-or-link
+  (choice multi-line-any-link reference))
+
+# References and quoted references.
+
+(rule reference
+  (choice quoted-reference simple-reference))
+
+(rule simple-reference
+  (sequence reference-character (zero-or-more reference-character))
+  (produces reference-text))
+
+(rule reference-character
+  (character-that-is-not whitespace-character left-parenthesis colon right-parenthesis))
+
+(rule quoted-reference
+  (choice double-quoted-reference single-quoted-reference backtick-quoted-reference))
+
+(rule double-quoted-reference
+  (sequence double-quote-run quoted-double-content matching-double-quote-run)
+  (produces reference-text))
+
+(rule single-quoted-reference
+  (sequence single-quote-run quoted-single-content matching-single-quote-run)
+  (produces reference-text))
+
+(rule backtick-quoted-reference
+  (sequence backtick-quote-run quoted-backtick-content matching-backtick-quote-run)
+  (produces reference-text))
+
+(rule double-quote-run
+  (one-or-more double-quote))
+
+(rule single-quote-run
+  (one-or-more single-quote))
+
+(rule backtick-quote-run
+  (one-or-more backtick-quote))
+
+(rule quoted-double-content
+  (zero-or-more (choice escaped-double-quote-run non-closing-double-character)))
+
+(rule quoted-single-content
+  (zero-or-more (choice escaped-single-quote-run non-closing-single-character)))
+
+(rule quoted-backtick-content
+  (zero-or-more (choice escaped-backtick-quote-run non-closing-backtick-character)))
+
+(rule escaped-double-quote-run
+  (sequence double-quote-run double-quote-run)
+  (emits double-quote-run))
+
+(rule escaped-single-quote-run
+  (sequence single-quote-run single-quote-run)
+  (emits single-quote-run))
+
+(rule escaped-backtick-quote-run
+  (sequence backtick-quote-run backtick-quote-run)
+  (emits backtick-quote-run))
+
+(rule non-closing-double-character
+  (character-that-does-not-complete matching-double-quote-run))
+
+(rule non-closing-single-character
+  (character-that-does-not-complete matching-single-quote-run))
+
+(rule non-closing-backtick-character
+  (character-that-does-not-complete matching-backtick-quote-run))
+
+# Whitespace, indentation, and terminals.
+
+(rule whitespace
+  (zero-or-more whitespace-character))
+
+(rule horizontal-whitespace
+  (zero-or-more horizontal-whitespace-character))
+
+(rule trailing-horizontal-whitespace
+  (one-or-more horizontal-whitespace-character))
+
+(rule indentation
+  (zero-or-more space))
+
+(rule set-base-indentation
+  (records indentation of first-line))
+
+(rule check-indentation
+  (requires indentation greater-than-or-equal current-indentation))
+
+(rule push-indentation
+  (requires indentation greater-than current-indentation))
+
+(rule pop-indentation
+  (restores previous-indentation))
+
+(rule whitespace-character
+  (choice space tab newline carriage-return))
+
+(rule horizontal-whitespace-character
+  (choice space tab))
+
+(rule end-of-line
+  (choice newline end-of-input))
+
+(rule end-of-input
+  (terminal input-end))
+
+(terminal left-parenthesis)
+(terminal right-parenthesis)
+(terminal colon)
+(terminal hash-sign)
+(terminal space)
+(terminal tab)
+(terminal newline)
+(terminal carriage-return)
+(terminal double-quote)
+(terminal single-quote)
+(terminal backtick-quote)
+(terminal input-end)
+
+# AST and host presentation. The official parser stores id links as
+# `(ast id-link id values)`, while the RML host presentation prints them as
+# parenthesized links whose head token is `id:`. The acceptance tests compare
+# this presentation against the host parser modulo that print form.
+
+(rule ast-reference
+  (sequence reference)
+  (produces (ast reference reference-text)))
+
+(rule ast-empty-link
+  (sequence left-parenthesis whitespace right-parenthesis)
+  (produces (ast link none (values))))
+
+(rule ast-id-link
+  (sequence id-link)
+  (produces (ast link reference values)))
+
+(rule ast-value-link
+  (sequence value-link)
+  (produces (ast link none values)))
+
+(rule ast-singlet-link
+  (sequence value-link with one reference value)
+  (produces (ast reference reference-text)))
+
+(rule ast-indented-id-link
+  (sequence indented-id-link indented-children)
+  (produces (ast link reference child-values)))
+
+(rule ast-parent-child-link
+  (sequence parent-link child-link)
+  (produces (ast link none (values parent-link child-link))))
+
+(rule ast-flattened-document
+  (sequence links)
+  (produces (list-of Ast-node)))
+
+(rule host-parser-presentation
+  (sequence (zero-or-more host-parser-link) end-of-input)
+  (produces host-parser-link-list))
+
+(rule host-parser-link
+  (choice host-parser-list host-parser-reference))
+
+(rule host-parser-list
+  (sequence left-parenthesis (zero-or-more host-parser-link) right-parenthesis)
+  (produces nested-list))
+
+(rule host-parser-reference
+  (sequence host-parser-reference-character (zero-or-more host-parser-reference-character))
+  (produces atom))
+
+(rule host-parser-reference-character
+  (character-that-is-not whitespace-character left-parenthesis right-parenthesis))

--- a/rust/tests/self_grammar_tests.rs
+++ b/rust/tests/self_grammar_tests.rs
@@ -1,0 +1,232 @@
+// Tests for `lib/self/grammar.lino` (issue #84).
+//
+// Mirrors js/tests/self-grammar.test.mjs so the self-bootstrap grammar data
+// stays parseable and tied to the shared example corpus in both runtimes.
+
+use rml::{evaluate_file, parse_lino, parse_one, tokenize_one, EvaluateOptions, Node};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REQUIRED_RULES: &[&str] = &[
+    "document",
+    "source-for-evaluation",
+    "links",
+    "first-line",
+    "line",
+    "element",
+    "any-link",
+    "parenthesized-link",
+    "id-link",
+    "value-link",
+    "indented-id-link",
+    "reference",
+    "simple-reference",
+    "quoted-reference",
+    "whitespace",
+    "end-of-line",
+    "host-parser-presentation",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn grammar_path() -> PathBuf {
+    repo_root().join("lib").join("self").join("grammar.lino")
+}
+
+fn examples_dir() -> PathBuf {
+    repo_root().join("examples")
+}
+
+fn grammar_forms() -> Vec<Node> {
+    let path = grammar_path();
+    let text = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", path.display(), e));
+    parse_lino(&text)
+        .into_iter()
+        .map(|link| {
+            parse_one(&tokenize_one(&link))
+                .unwrap_or_else(|e| panic!("failed to parse grammar link {}: {}", link, e))
+        })
+        .collect()
+}
+
+fn rule_names(forms: &[Node]) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for form in forms {
+        let Node::List(children) = form else {
+            continue;
+        };
+        if children.len() >= 2 {
+            if let (Node::Leaf(head), Node::Leaf(name)) = (&children[0], &children[1]) {
+                if head == "rule" {
+                    names.insert(name.clone());
+                }
+            }
+        }
+    }
+    names
+}
+
+fn inline_comment_index(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut last_close = None;
+    for (i, byte) in bytes.iter().enumerate() {
+        match *byte {
+            b')' => last_close = Some(i),
+            b'#' => {
+                if let Some(close_idx) = last_close {
+                    let between = &line[close_idx + 1..i];
+                    if !between.is_empty() && between.chars().all(|c| c == ' ' || c == '\t') {
+                        return Some(i);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn strip_rml_comments(source: &str) -> String {
+    source
+        .lines()
+        .map(|line| {
+            if line.trim_start().starts_with('#') {
+                String::new()
+            } else if let Some(idx) = inline_comment_index(line) {
+                line[..idx].trim_end().to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+struct SelfParser {
+    chars: Vec<char>,
+    index: usize,
+}
+
+impl SelfParser {
+    fn new(source: &str) -> Self {
+        Self {
+            chars: strip_rml_comments(source).chars().collect(),
+            index: 0,
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.index < self.chars.len() && self.chars[self.index].is_whitespace() {
+            self.index += 1;
+        }
+    }
+
+    fn parse_atom(&mut self) -> Node {
+        let start = self.index;
+        while self.index < self.chars.len()
+            && !self.chars[self.index].is_whitespace()
+            && self.chars[self.index] != '('
+            && self.chars[self.index] != ')'
+        {
+            self.index += 1;
+        }
+        assert!(start != self.index, "expected reference at char {}", self.index);
+        Node::Leaf(self.chars[start..self.index].iter().collect())
+    }
+
+    fn parse_list(&mut self) -> Node {
+        assert_eq!(
+            self.chars.get(self.index),
+            Some(&'('),
+            "expected `(` at char {}",
+            self.index
+        );
+        self.index += 1;
+        let mut children = Vec::new();
+        loop {
+            self.skip_whitespace();
+            assert!(self.index < self.chars.len(), "expected `)` at end of input");
+            if self.chars[self.index] == ')' {
+                self.index += 1;
+                return Node::List(children);
+            }
+            if self.chars[self.index] == '(' {
+                children.push(self.parse_list());
+            } else {
+                children.push(self.parse_atom());
+            }
+        }
+    }
+
+    fn parse_forms(&mut self) -> Vec<Node> {
+        let mut forms = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.index >= self.chars.len() {
+                return forms;
+            }
+            forms.push(self.parse_list());
+        }
+    }
+}
+
+fn parse_self_presentation(source: &str, rules: &HashSet<String>) -> Vec<Node> {
+    assert!(rules.contains("host-parser-presentation"));
+    assert!(rules.contains("parenthesized-link"));
+    assert!(rules.contains("simple-reference"));
+    SelfParser::new(source).parse_forms()
+}
+
+fn host_ast(source: &str) -> Vec<Node> {
+    parse_lino(source)
+        .into_iter()
+        .map(|link| {
+            parse_one(&tokenize_one(&link))
+                .unwrap_or_else(|e| panic!("failed to parse host link {}: {}", link, e))
+        })
+        .collect()
+}
+
+fn lino_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<_> = fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", dir.display(), e))
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("lino"))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn self_grammar_is_importable() {
+    let path = grammar_path();
+    let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn self_grammar_declares_required_rules() {
+    let rules = rule_names(&grammar_forms());
+    for name in REQUIRED_RULES {
+        assert!(rules.contains(*name), "missing rule {}", name);
+    }
+}
+
+#[test]
+fn self_grammar_parses_examples_like_host_parser() {
+    let rules = rule_names(&grammar_forms());
+    for path in lino_files(&examples_dir()) {
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("could not read {}: {}", path.display(), e));
+        assert_eq!(
+            parse_self_presentation(&source, &rules),
+            host_ast(&source),
+            "AST mismatch for {}",
+            path.display()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #84

## Summary
- Add `lib/self/grammar.lino` as LiNo data that encodes the host links-notation grammar, AST presentation rules, terminals, whitespace, indentation, references, quoted references, and RML comment normalization.
- Add mirrored JS/Rust self-grammar acceptance tests that import the grammar, verify the required rule surface, and parse every `examples/*.lino` file to the same AST presentation as the host parser.
- Document the self grammar standard library entry in the README and remove the placeholder `.gitkeep` from the prepared branch.

## Reproduction and verification
- Before the implementation, the new self-grammar test failed because `lib/self/grammar.lino` did not exist.
- The automated checks now cover the issue requirement by comparing the self-parser presentation for the full examples corpus against the host parser AST.

## Tests
- `cd js && npm run lint:english`
- `cd js && npm test`
- `cd rust && cargo test`
- `git diff --check`
- `cd js && npm run build:playground`
- `cd js && npm run test:playground`
- `cd js && npm run docs -- --destination ../_site/api/js`
- `cargo doc --manifest-path rust/Cargo.toml --no-deps --target-dir target/api-docs/rust`

UI screenshots are not applicable; this is a grammar/library data change.