### PR TITLE
[J2] Encode the evaluator as links

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T09:56:33.388Z for PR creation at branch issue-85-bb5ecc6ce050 for issue https://github.com/link-foundation/relative-meta-logic/issues/85

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ The [self grammar library](./lib/self/grammar.lino) encodes the LiNo grammar as
 links so self-hosted parsing work can consume grammar rules through ordinary
 LiNo data.
 
+The [self evaluator library](./lib/self/evaluator.lino) encodes the RML host
+evaluator as `(rule ...)` links, including the built-in arithmetic, comparison,
+logical, equality, normalization, and typed-kernel evaluation forms.
+
 ### Isabelle export
 
 ```bash

--- a/js/tests/self-evaluator.test.mjs
+++ b/js/tests/self-evaluator.test.mjs
@@ -1,0 +1,816 @@
+// Tests for `lib/self/evaluator.lino` (issue #85).
+//
+// The evaluator file is data: it records the host evaluator as `(rule ...)`
+// links. These tests keep that data parseable, require the built-in operator
+// rule surface, and run a small rule-backed evaluator against the shared
+// example corpus so the encoded rules stay tied to host behavior.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  decRound,
+  evaluateFile,
+  isNum,
+  isStructurallySame,
+  keyOf,
+  parseBinding,
+  parseLino,
+  parseOne,
+  quantize,
+  run,
+  subst,
+  tokenizeOne,
+} from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const evaluatorPath = join(repoRoot, 'lib', 'self', 'evaluator.lino');
+const examplesDir = join(repoRoot, 'examples');
+const selfCorpusDir = join(repoRoot, 'test-corpus', 'self');
+
+const REQUIRED_EVAL_RULES = [
+  '(eval numeric-literal)',
+  '(eval symbol)',
+  '(eval (range low high))',
+  '(eval (range: low high))',
+  '(eval (valence levels))',
+  '(eval (valence: levels))',
+  '(eval (name: name is name))',
+  '(eval (name: type-name name))',
+  '(eval (name: type-expression name))',
+  '(eval (name: type-expression))',
+  '(eval (operator: aggregator))',
+  '(eval (operator: outer inner))',
+  '(eval (name: lambda binding body))',
+  '(eval ((expression) has probability number))',
+  '(eval (? expression))',
+  '(eval (left + right))',
+  '(eval (left - right))',
+  '(eval (left * right))',
+  '(eval (left / right))',
+  '(eval (left < right))',
+  '(eval (left <= right))',
+  '(eval (not value))',
+  '(eval (and a b))',
+  '(eval (or a b))',
+  '(eval (both a b))',
+  '(eval (neither a b))',
+  '(eval (a and b))',
+  '(eval (a or b))',
+  '(eval (both a and b))',
+  '(eval (neither a nor b))',
+  '(eval (= left right))',
+  '(eval (!= left right))',
+  '(eval (left = right))',
+  '(eval (left != right))',
+  '(eval (Type level))',
+  '(eval (Prop))',
+  '(eval (Pi binding body))',
+  '(eval (lambda binding body))',
+  '(eval (apply function argument))',
+  '(eval (subst term variable replacement))',
+  '(eval (fresh variable in body))',
+  '(eval (whnf expression))',
+  '(eval (nf expression))',
+  '(eval (normal-form expression))',
+  '(eval (type of expression))',
+  '(eval (expression of type))',
+  '(eval (domain name request))',
+];
+
+const REQUIRED_OPERATORS = [
+  'not', 'and', 'or', 'both', 'neither', '=', '!=', '+', '-', '*', '/', '<', '<=',
+];
+
+function parseForms(source) {
+  return parseLino(source).map(link => parseOne(tokenizeOne(link)));
+}
+
+function evaluatorForms() {
+  return parseForms(readFileSync(evaluatorPath, 'utf8'));
+}
+
+function evalRulePatterns(forms) {
+  const patterns = new Set();
+  for (const form of forms) {
+    if (Array.isArray(form) && form[0] === 'rule' && Array.isArray(form[1]) && form[1][0] === 'eval') {
+      patterns.add(keyOf(form[1]));
+    }
+  }
+  return patterns;
+}
+
+function builtInOperators(forms) {
+  const operators = new Set();
+  for (const form of forms) {
+    if (Array.isArray(form) && form[0] === 'built-in-operator' && typeof form[1] === 'string') {
+      operators.add(form[1]);
+    }
+  }
+  return operators;
+}
+
+function desugarHoas(node) {
+  if (!Array.isArray(node)) return node;
+  const mapped = node.map(desugarHoas);
+  if (mapped.length === 3 && mapped[0] === 'forall' && Array.isArray(mapped[1])) {
+    return ['Pi', mapped[1], mapped[2]];
+  }
+  return mapped;
+}
+
+class EncodedEvaluator {
+  constructor(rulePatterns) {
+    this.rulePatterns = rulePatterns;
+    this.reset();
+  }
+
+  reset() {
+    this.lo = 0;
+    this.hi = 1;
+    this.valence = 0;
+    this.assign = new Map();
+    this.symbolProb = new Map();
+    this.terms = new Set();
+    this.types = new Map();
+    this.lambdas = new Map();
+    this.ops = new Map();
+    this.reinitOps();
+  }
+
+  requireRule(pattern) {
+    assert.ok(this.rulePatterns.has(pattern), `missing encoded rule ${pattern}`);
+  }
+
+  reinitOps() {
+    this.ops.set('not', x => this.hi - (x - this.lo));
+    this.ops.set('and', (...xs) => xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : this.lo);
+    this.ops.set('or', (...xs) => xs.length ? Math.max(...xs) : this.lo);
+    this.ops.set('both', (...xs) => xs.length ? decRound(xs.reduce((a, b) => a + b, 0) / xs.length) : this.lo);
+    this.ops.set('neither', (...xs) => xs.length ? decRound(xs.reduce((a, b) => a * b, 1)) : this.lo);
+    this.ops.set('=', (left, right) => isStructurallySame(left, right) ? this.hi : this.lo);
+    this.ops.set('!=', (left, right) => this.ops.get('not')(this.ops.get('=')(left, right)));
+    this.ops.set('+', (a, b) => decRound(a + b));
+    this.ops.set('-', (a, b) => decRound(a - b));
+    this.ops.set('*', (a, b) => decRound(a * b));
+    this.ops.set('/', (a, b) => b === 0 ? 0 : decRound(a / b));
+    this.ops.set('<', (a, b) => a < b ? this.hi : this.lo);
+    this.ops.set('<=', (a, b) => a <= b ? this.hi : this.lo);
+    this.initTruthConstants();
+  }
+
+  initTruthConstants() {
+    this.symbolProb.set('true', this.hi);
+    this.symbolProb.set('false', this.lo);
+    this.symbolProb.set('unknown', this.mid);
+    this.symbolProb.set('undefined', this.mid);
+  }
+
+  get mid() {
+    return (this.lo + this.hi) / 2;
+  }
+
+  clamp(value) {
+    const clamped = Math.max(this.lo, Math.min(this.hi, value));
+    return this.valence >= 2 ? quantize(clamped, this.valence, this.lo, this.hi) : clamped;
+  }
+
+  toNum(token) {
+    return this.clamp(parseFloat(token));
+  }
+
+  setSymbolProb(name, value) {
+    this.symbolProb.set(name, this.clamp(value));
+  }
+
+  getSymbolProb(name) {
+    return this.symbolProb.has(name) ? this.symbolProb.get(name) : this.mid;
+  }
+
+  setType(expr, typeExpr) {
+    this.types.set(typeof expr === 'string' ? expr : keyOf(expr), typeof typeExpr === 'string' ? typeExpr : keyOf(typeExpr));
+  }
+
+  getType(expr) {
+    return this.types.get(typeof expr === 'string' ? expr : keyOf(expr)) ?? null;
+  }
+
+  setExprProb(expr, value) {
+    this.assign.set(keyOf(expr), this.clamp(value));
+  }
+
+  run(source) {
+    this.reset();
+    const results = [];
+    for (const form of parseForms(source)) {
+      const value = this.evalNode(form);
+      if (value && typeof value === 'object' && value.query) {
+        results.push(value.value);
+      }
+    }
+    return results;
+  }
+
+  defineForm(head, rhs) {
+    if (head === 'range' && rhs.length === 2 && isNum(rhs[0]) && isNum(rhs[1])) {
+      this.requireRule('(eval (range: low high))');
+      this.lo = parseFloat(rhs[0]);
+      this.hi = parseFloat(rhs[1]);
+      this.reinitOps();
+      return 1;
+    }
+    if (head === 'valence' && rhs.length === 1 && isNum(rhs[0])) {
+      this.requireRule('(eval (valence: levels))');
+      this.valence = parseInt(rhs[0], 10);
+      return 1;
+    }
+    if (rhs.length === 3 && rhs[0] === head && rhs[1] === 'is' && rhs[2] === head) {
+      this.requireRule('(eval (name: name is name))');
+      this.terms.add(head);
+      return 1;
+    }
+    if (rhs.length === 2 && typeof rhs[0] === 'string' && rhs[1] === head && /^[A-Z]/.test(rhs[0])) {
+      this.requireRule('(eval (name: type-name name))');
+      this.terms.add(head);
+      this.setType(head, rhs[0]);
+      return 1;
+    }
+    if (rhs.length === 2 && Array.isArray(rhs[0]) && rhs[1] === head) {
+      this.requireRule('(eval (name: type-expression name))');
+      this.terms.add(head);
+      this.setType(head, rhs[0]);
+      this.evalNode(rhs[0]);
+      return 1;
+    }
+    if (rhs.length === 1 && Array.isArray(rhs[0]) && !this.isOperatorHead(head)) {
+      this.requireRule('(eval (name: type-expression))');
+      this.terms.add(head);
+      this.setType(head, rhs[0]);
+      this.evalNode(rhs[0]);
+      return 1;
+    }
+    if (rhs.length === 1 && isNum(rhs[0])) {
+      this.requireRule('(eval (name: number))');
+      this.setSymbolProb(head, parseFloat(rhs[0]));
+      return this.toNum(rhs[0]);
+    }
+    if (this.isOperatorHead(head)) {
+      if (rhs.length === 1 && typeof rhs[0] === 'string' && this.ops.has(rhs[0])) {
+        this.requireRule('(eval (operator: aggregator))');
+        const target = this.ops.get(rhs[0]);
+        this.ops.set(head, (...xs) => target(...xs));
+        return 1;
+      }
+      if (rhs.length === 2 && typeof rhs[0] === 'string' && typeof rhs[1] === 'string') {
+        this.requireRule('(eval (operator: outer inner))');
+        const outer = this.ops.get(rhs[0]);
+        const inner = this.ops.get(rhs[1]);
+        this.ops.set(head, (...xs) => this.clamp(outer(inner(...xs))));
+        return 1;
+      }
+      if (['and', 'or', 'both', 'neither'].includes(head) && rhs.length === 1 && typeof rhs[0] === 'string') {
+        this.requireRule('(eval (operator: aggregator))');
+        this.ops.set(head, this.aggregator(rhs[0]));
+        return 1;
+      }
+    }
+    if (rhs.length === 3 && rhs[0] === 'lambda' && Array.isArray(rhs[1])) {
+      this.requireRule('(eval (name: lambda binding body))');
+      const parsed = parseBinding(rhs[1]);
+      if (parsed) {
+        const previous = this.getType(parsed.paramName);
+        this.setType(parsed.paramName, parsed.paramType);
+        this.lambdas.set(head, { param: parsed.paramName, paramType: parsed.paramType, body: rhs[2] });
+        const bodyType = this.getType(rhs[2]) || (typeof rhs[2] === 'string' ? rhs[2] : keyOf(rhs[2]));
+        if (previous === null) this.types.delete(parsed.paramName);
+        else this.setType(parsed.paramName, previous);
+        this.terms.add(head);
+        this.setType(head, `(Pi (${keyOf(parsed.paramType)} ${parsed.paramName}) ${bodyType})`);
+        return 1;
+      }
+    }
+    if (rhs.length === 1 && typeof rhs[0] === 'string') {
+      this.setSymbolProb(head, this.getSymbolProb(rhs[0]));
+      return this.getSymbolProb(head);
+    }
+    return 0;
+  }
+
+  isOperatorHead(head) {
+    return ['=', '!=', 'and', 'or', 'not', 'is', '?:', 'both', 'neither'].includes(head) || /[=!]/.test(head);
+  }
+
+  aggregator(name) {
+    const lo = this.lo;
+    if (name === 'avg') return (...xs) => xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : lo;
+    if (name === 'min') return (...xs) => xs.length ? Math.min(...xs) : lo;
+    if (name === 'max') return (...xs) => xs.length ? Math.max(...xs) : lo;
+    if (name === 'product' || name === 'prod') return (...xs) => xs.reduce((a, b) => a * b, 1);
+    if (name === 'probabilistic_sum' || name === 'ps') {
+      return (...xs) => 1 - xs.reduce((a, b) => a * (1 - b), 1);
+    }
+    throw new Error(`unknown aggregator ${name}`);
+  }
+
+  evalNode(rawNode) {
+    if (typeof rawNode === 'string') {
+      if (isNum(rawNode)) {
+        this.requireRule('(eval numeric-literal)');
+        return this.toNum(rawNode);
+      }
+      this.requireRule('(eval symbol)');
+      return this.getSymbolProb(rawNode);
+    }
+
+    let node = desugarHoas(rawNode);
+    if (!Array.isArray(node) || node.length === 0) return 0;
+
+    if (typeof node[0] === 'string' && node[0].endsWith(':')) {
+      return this.defineForm(node[0].slice(0, -1), node.slice(1));
+    }
+
+    if (node[0] === 'namespace') {
+      this.requireRule('(eval (namespace name))');
+      return 1;
+    }
+
+    if (node[0] === 'import') {
+      this.requireRule(node.length === 4 ? '(eval (import path as alias))' : '(eval (import path))');
+      return 1;
+    }
+
+    if (node[0] === 'domain') {
+      this.requireRule('(eval (domain name request))');
+      if (node[1] === 'automatic-sequences') {
+        for (const request of node.slice(2)) {
+          if (Array.isArray(request) && request[0] === 'theorem' && typeof request[1] === 'string') {
+            this.setSymbolProb(request[1], this.hi);
+          }
+        }
+      }
+      return 1;
+    }
+
+    if (['inductive', 'coinductive', 'constructor', 'define', 'relation', 'mode', 'world'].includes(node[0])) {
+      return 1;
+    }
+
+    if (node.length === 4 && node[1] === 'has' && node[2] === 'probability' && isNum(node[3])) {
+      this.requireRule('(eval ((expression) has probability number))');
+      this.setExprProb(node[0], parseFloat(node[3]));
+      return this.toNum(node[3]);
+    }
+
+    if (node.length === 3 && node[0] === 'range' && isNum(node[1]) && isNum(node[2])) {
+      this.requireRule('(eval (range low high))');
+      this.lo = parseFloat(node[1]);
+      this.hi = parseFloat(node[2]);
+      this.reinitOps();
+      return 1;
+    }
+
+    if (node.length === 2 && node[0] === 'valence' && isNum(node[1])) {
+      this.requireRule('(eval (valence levels))');
+      this.valence = parseInt(node[1], 10);
+      return 1;
+    }
+
+    if (node[0] === '?') {
+      this.requireRule('(eval (? expression))');
+      const target = node.length === 2 ? node[1] : node.slice(1);
+      const value = this.evalNode(target);
+      if (value && typeof value === 'object' && value.query) return value;
+      if (value && typeof value === 'object' && Object.hasOwn(value, 'term')) {
+        return { query: true, value: keyOf(value.term), typeQuery: true };
+      }
+      return { query: true, value: this.clamp(value) };
+    }
+
+    if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+      this.requireRule('(eval (subst term variable replacement))');
+      return { term: this.evalTermNode(node) };
+    }
+
+    if (node.length === 2 && node[0] === 'whnf') {
+      this.requireRule('(eval (whnf expression))');
+      return { term: this.whnfTerm(node[1]) };
+    }
+
+    if (node.length === 2 && (node[0] === 'nf' || node[0] === 'normal-form')) {
+      this.requireRule(node[0] === 'nf' ? '(eval (nf expression))' : '(eval (normal-form expression))');
+      return { term: this.flattenNeutralApplies(this.normalizeTerm(node[1])) };
+    }
+
+    if (node.length === 4 && node[0] === 'fresh' && node[2] === 'in' && typeof node[1] === 'string') {
+      this.requireRule('(eval (fresh variable in body))');
+      this.terms.add(node[1]);
+      return this.evalNode(node[3]);
+    }
+
+    if (node.length === 3 && typeof node[1] === 'string' && ['+', '-', '*', '/'].includes(node[1])) {
+      this.requireRule(`(eval (left ${node[1]} right))`);
+      return this.ops.get(node[1])(this.evalArith(node[0]), this.evalArith(node[2]));
+    }
+
+    if (node.length === 3 && typeof node[1] === 'string' && ['<', '<='].includes(node[1])) {
+      this.requireRule(`(eval (left ${node[1]} right))`);
+      return this.clamp(this.ops.get(node[1])(this.evalArith(node[0]), this.evalArith(node[2])));
+    }
+
+    if (node.length === 3 && typeof node[1] === 'string' && ['and', 'or', 'both', 'neither'].includes(node[1])) {
+      this.requireRule(`(eval (a ${node[1]} b))`);
+      return this.clamp(this.ops.get(node[1])(this.evalNode(node[0]), this.evalNode(node[2])));
+    }
+
+    if (node.length >= 4 && (node[0] === 'both' || node[0] === 'neither')) {
+      const separator = node[0] === 'both' ? 'and' : 'nor';
+      let valid = node.length % 2 === 0;
+      for (let i = 2; valid && i < node.length; i += 2) valid = node[i] === separator;
+      if (valid) {
+        this.requireRule(node[0] === 'both' ? '(eval (both a and b))' : '(eval (neither a nor b))');
+        const values = [];
+        for (let i = 1; i < node.length; i += 2) values.push(this.evalNode(node[i]));
+        return this.clamp(this.ops.get(node[0])(...values));
+      }
+    }
+
+    if (node.length === 3 && typeof node[1] === 'string' && ['=', '!='].includes(node[1])) {
+      this.requireRule(`(eval (left ${node[1]} right))`);
+      return this.evalEqualityNode(node[0], node[1], node[2]);
+    }
+
+    if (node.length === 2 && node[0] === 'Type') {
+      this.requireRule('(eval (Type level))');
+      const level = this.universeLevel(node[1]);
+      if (level !== null) this.setType(node, ['Type', String(level + 1)]);
+      return level === null ? 0 : 1;
+    }
+
+    if (node.length === 1 && node[0] === 'Prop') {
+      this.requireRule('(eval (Prop))');
+      this.setType(['Prop'], ['Type', '1']);
+      return 1;
+    }
+
+    if (node.length === 3 && node[0] === 'Pi') {
+      this.requireRule('(eval (Pi binding body))');
+      const parsed = parseBinding(node[1]);
+      if (parsed) {
+        this.terms.add(parsed.paramName);
+        this.setType(parsed.paramName, parsed.paramType);
+        this.setType(node, ['Type', '0']);
+      }
+      return 1;
+    }
+
+    if (node.length === 3 && node[0] === 'lambda') {
+      this.requireRule('(eval (lambda binding body))');
+      const parsed = parseBinding(node[1]);
+      if (parsed) {
+        this.terms.add(parsed.paramName);
+        this.setType(parsed.paramName, parsed.paramType);
+      }
+      return 1;
+    }
+
+    if (node.length === 3 && node[0] === 'apply') {
+      this.requireRule('(eval (apply function argument))');
+      return this.evalApply(node[1], node[2]);
+    }
+
+    if (node.length === 3 && node[0] === 'type' && node[1] === 'of') {
+      this.requireRule('(eval (type of expression))');
+      return { query: true, value: this.inferType(node[2]) ?? 'unknown', typeQuery: true };
+    }
+
+    if (node.length === 3 && node[1] === 'of') {
+      this.requireRule('(eval (expression of type))');
+      const actual = this.inferType(node[0]);
+      return actual === (typeof node[2] === 'string' ? node[2] : keyOf(node[2])) ? this.hi : this.lo;
+    }
+
+    const [head, ...args] = node;
+    if (typeof head === 'string' && ['=', '!='].includes(head) && args.length === 2) {
+      this.requireRule(`(eval (${head} left right))`);
+      return this.evalEqualityNode(args[0], head, args[1]);
+    }
+
+    if (typeof head === 'string' && this.ops.has(head)) {
+      if (head === 'not') this.requireRule('(eval (not value))');
+      if (['and', 'or', 'both', 'neither'].includes(head)) this.requireRule(`(eval (${head} a b))`);
+      const values = args.map(arg => this.evalNode(arg));
+      return this.clamp(this.ops.get(head)(...values));
+    }
+
+    if (typeof head === 'string' && args.length >= 1 && this.lambdas.has(head)) {
+      this.requireRule('(eval (function argument))');
+      let result = subst(this.lambdas.get(head).body, this.lambdas.get(head).param, args[0]);
+      if (args.length > 1) result = [result, ...args.slice(1)];
+      return this.evalReducedTerm(result);
+    }
+
+    if (Array.isArray(head) && head.length === 3 && head[0] === 'lambda' && args.length >= 1) {
+      this.requireRule('(eval (function argument))');
+      const parsed = parseBinding(head[1]);
+      if (parsed) {
+        let result = subst(head[2], parsed.paramName, args[0]);
+        if (args.length > 1) result = [result, ...args.slice(1)];
+        return this.evalReducedTerm(result);
+      }
+    }
+
+    return 0;
+  }
+
+  evalArith(node) {
+    if (typeof node === 'string' && isNum(node)) return parseFloat(node);
+    const value = this.evalNode(node);
+    if (value && typeof value === 'object' && Object.hasOwn(value, 'term')) {
+      return this.evalArith(value.term);
+    }
+    return value;
+  }
+
+  evalApply(fn, arg) {
+    if (Array.isArray(fn) && fn.length === 3 && fn[0] === 'lambda') {
+      const parsed = parseBinding(fn[1]);
+      if (parsed) return this.evalReducedTerm(subst(fn[2], parsed.paramName, arg));
+    }
+    if (typeof fn === 'string' && this.lambdas.has(fn)) {
+      const lambda = this.lambdas.get(fn);
+      return this.evalReducedTerm(subst(lambda.body, lambda.param, arg));
+    }
+    const fVal = this.evalNode(fn);
+    this.evalNode(arg);
+    return typeof fVal === 'number' ? fVal : 0;
+  }
+
+  evalTermNode(node) {
+    if (!Array.isArray(node)) return node;
+    if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+      return this.evalTermNode(subst(this.evalTermNode(node[1]), node[2], this.evalTermNode(node[3])));
+    }
+    if (node.length === 3 && node[0] === 'apply') {
+      const fn = node[1];
+      const arg = this.evalTermNode(node[2]);
+      if (Array.isArray(fn) && fn.length === 3 && fn[0] === 'lambda') {
+        const parsed = parseBinding(fn[1]);
+        if (parsed) return this.evalTermNode(subst(fn[2], parsed.paramName, arg));
+      }
+      if (typeof fn === 'string' && this.lambdas.has(fn)) {
+        const lambda = this.lambdas.get(fn);
+        return this.evalTermNode(subst(lambda.body, lambda.param, arg));
+      }
+    }
+    return node;
+  }
+
+  evalReducedTerm(reduced) {
+    const term = this.normalizeTerm(reduced);
+    if (this.hasUnresolvedFreeVariables(term)) return { term };
+    return this.evalNode(term);
+  }
+
+  normalizeTerm(rawNode) {
+    const node = desugarHoas(rawNode);
+    if (!Array.isArray(node) || node.length === 0) return node;
+
+    if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+      return this.normalizeTerm(subst(this.normalizeTerm(node[1]), node[2], this.normalizeTerm(node[3])));
+    }
+
+    if (node.length === 3 && node[0] === 'apply') {
+      const fn = this.normalizeTerm(node[1]);
+      const arg = this.normalizeTerm(node[2]);
+      if (Array.isArray(fn) && fn.length === 3 && fn[0] === 'lambda') {
+        const parsed = parseBinding(fn[1]);
+        if (parsed) return this.normalizeTerm(subst(fn[2], parsed.paramName, arg));
+      }
+      if (typeof fn === 'string' && this.lambdas.has(fn)) {
+        const lambda = this.lambdas.get(fn);
+        return this.normalizeTerm(subst(lambda.body, lambda.param, arg));
+      }
+      return ['apply', fn, arg];
+    }
+
+    if (node.length === 3 && node[0] === 'lambda') {
+      return ['lambda', this.normalizeTerm(node[1]), this.normalizeTerm(node[2])];
+    }
+
+    const [head, ...args] = node;
+    if (Array.isArray(head) && head.length === 3 && head[0] === 'lambda' && args.length >= 1) {
+      const parsed = parseBinding(head[1]);
+      if (parsed) {
+        const first = this.normalizeTerm(args[0]);
+        const reduced = subst(head[2], parsed.paramName, first);
+        return this.normalizeTerm(args.length === 1 ? reduced : [reduced, ...args.slice(1)]);
+      }
+    }
+    if (typeof head === 'string' && args.length >= 1 && this.lambdas.has(head)) {
+      const lambda = this.lambdas.get(head);
+      const first = this.normalizeTerm(args[0]);
+      const reduced = subst(lambda.body, lambda.param, first);
+      return this.normalizeTerm(args.length === 1 ? reduced : [reduced, ...args.slice(1)]);
+    }
+    return node.map(child => this.normalizeTerm(child));
+  }
+
+  whnfTerm(rawNode) {
+    const node = desugarHoas(rawNode);
+    if (!Array.isArray(node) || node.length === 0) return node;
+
+    const spineArgs = [];
+    let head = node;
+    while (Array.isArray(head) && head.length === 3 && head[0] === 'apply') {
+      spineArgs.unshift(head[2]);
+      head = head[1];
+    }
+
+    while (spineArgs.length > 0) {
+      if (Array.isArray(head) && head.length === 3 && head[0] === 'lambda') {
+        const parsed = parseBinding(head[1]);
+        if (!parsed) break;
+        head = subst(head[2], parsed.paramName, spineArgs.shift());
+        continue;
+      }
+      if (typeof head === 'string' && this.lambdas.has(head)) {
+        const lambda = this.lambdas.get(head);
+        head = subst(lambda.body, lambda.param, spineArgs.shift());
+        continue;
+      }
+      break;
+    }
+
+    let out = head;
+    for (const arg of spineArgs) out = ['apply', out, arg];
+    return out;
+  }
+
+  flattenNeutralApplies(node) {
+    if (!Array.isArray(node)) return node;
+    const flattened = node.map(child => this.flattenNeutralApplies(child));
+    if (flattened.length === 3 && flattened[0] === 'apply' && typeof flattened[1] === 'string' && !this.lambdas.has(flattened[1])) {
+      return [flattened[1], flattened[2]];
+    }
+    return flattened;
+  }
+
+  evalEqualityNode(left, op, right) {
+    const direct = this.lookupAssignedInfix(op, left, right);
+    if (direct !== null) return this.clamp(direct);
+    const leftTerm = this.normalizeTerm(left);
+    const rightTerm = this.normalizeTerm(right);
+    if (!isStructurallySame(left, leftTerm) || !isStructurallySame(right, rightTerm)) {
+      const normalized = this.lookupAssignedInfix(op, leftTerm, rightTerm);
+      if (normalized !== null) return this.clamp(normalized);
+    }
+    const eq = this.equalityTruthValue(left, right, leftTerm, rightTerm);
+    return op === '=' ? this.clamp(eq) : this.clamp(this.ops.get('not')(eq));
+  }
+
+  equalityTruthValue(left, right, leftTerm, rightTerm) {
+    const assigned = this.lookupAssignedInfix('=', left, right);
+    if (assigned !== null) return this.clamp(assigned);
+    if (!isStructurallySame(left, leftTerm) || !isStructurallySame(right, rightTerm)) {
+      const normalized = this.lookupAssignedInfix('=', leftTerm, rightTerm);
+      if (normalized !== null) return this.clamp(normalized);
+    }
+    if (isStructurallySame(leftTerm, rightTerm)) return this.hi;
+    const leftNum = this.tryEvalNumeric(leftTerm);
+    const rightNum = this.tryEvalNumeric(rightTerm);
+    if (leftNum !== null && rightNum !== null) {
+      return decRound(leftNum) === decRound(rightNum) ? this.hi : this.lo;
+    }
+    return this.lo;
+  }
+
+  lookupAssignedInfix(op, left, right) {
+    for (const expr of [[op, left, right], [left, op, right]]) {
+      const k = keyOf(expr);
+      if (this.assign.has(k)) return this.assign.get(k);
+    }
+    return null;
+  }
+
+  tryEvalNumeric(node) {
+    const term = this.normalizeTerm(node);
+    if (typeof term === 'string') {
+      if (isNum(term)) return parseFloat(term);
+      return this.symbolProb.has(term) ? this.symbolProb.get(term) : null;
+    }
+    if (!Array.isArray(term) || term.length === 0) return null;
+    if (term.length === 3 && typeof term[1] === 'string' && ['+', '-', '*', '/'].includes(term[1])) {
+      const left = this.tryEvalNumeric(term[0]);
+      const right = this.tryEvalNumeric(term[2]);
+      return left === null || right === null ? null : this.ops.get(term[1])(left, right);
+    }
+    if (term.length === 3 && typeof term[1] === 'string' && ['and', 'or', 'both', 'neither'].includes(term[1])) {
+      const left = this.tryEvalNumeric(term[0]);
+      const right = this.tryEvalNumeric(term[2]);
+      return left === null || right === null ? null : this.clamp(this.ops.get(term[1])(left, right));
+    }
+    const [head, ...args] = term;
+    if (typeof head === 'string' && this.ops.has(head) && head !== '=' && head !== '!=') {
+      const vals = args.map(arg => this.tryEvalNumeric(arg));
+      return vals.some(v => v === null) ? null : this.clamp(this.ops.get(head)(...vals));
+    }
+    return null;
+  }
+
+  inferType(node) {
+    const recorded = this.getType(desugarHoas(node));
+    if (recorded) return recorded;
+    if (Array.isArray(node) && node.length === 2 && node[0] === 'Type') {
+      const level = this.universeLevel(node[1]);
+      return level === null ? null : `(Type ${level + 1})`;
+    }
+    return null;
+  }
+
+  universeLevel(token) {
+    if (typeof token !== 'string' || !/^(0|[1-9]\d*)$/.test(token)) return null;
+    const level = Number(token);
+    return Number.isSafeInteger(level) ? level : null;
+  }
+
+  freeVariables(expr, bound = new Set()) {
+    if (typeof expr === 'string') {
+      if (!isNum(expr) && !['lambda', 'Pi', 'apply', 'type', 'of', 'and', 'or', 'not', '=', '!='].includes(expr) && !bound.has(expr)) {
+        return new Set([expr]);
+      }
+      return new Set();
+    }
+    if (!Array.isArray(expr)) return new Set();
+    if (expr.length === 3 && (expr[0] === 'lambda' || expr[0] === 'Pi')) {
+      const parsed = parseBinding(expr[1]);
+      const next = new Set(bound);
+      if (parsed) next.add(parsed.paramName);
+      return this.freeVariables(expr[2], next);
+    }
+    const out = new Set();
+    for (const child of expr) {
+      for (const name of this.freeVariables(child, bound)) out.add(name);
+    }
+    return out;
+  }
+
+  hasUnresolvedFreeVariables(expr) {
+    for (const name of this.freeVariables(expr)) {
+      if (!this.symbolProb.has(name) && !this.terms.has(name) && !this.types.has(name) && !this.lambdas.has(name) && !this.ops.has(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+function assertResultsEqual(actual, expected, label) {
+  assert.strictEqual(actual.length, expected.length, `${label}: result count mismatch`);
+  for (let i = 0; i < expected.length; i++) {
+    if (typeof expected[i] === 'number') {
+      assert.strictEqual(typeof actual[i], 'number', `${label}[${i}] expected number`);
+      assert.ok(Math.abs(actual[i] - expected[i]) < 1e-9, `${label}[${i}] expected ${expected[i]}, got ${actual[i]}`);
+    } else {
+      assert.strictEqual(actual[i], expected[i], `${label}[${i}]`);
+    }
+  }
+}
+
+describe('self evaluator', () => {
+  it('is importable as a standard library file', () => {
+    const out = evaluateFile(evaluatorPath);
+    assert.deepStrictEqual(out.diagnostics, []);
+  });
+
+  it('declares the required built-in operator rules as links', () => {
+    const forms = evaluatorForms();
+    const rules = evalRulePatterns(forms);
+    for (const pattern of REQUIRED_EVAL_RULES) {
+      assert.ok(rules.has(pattern), `missing rule ${pattern}`);
+    }
+
+    const operators = builtInOperators(forms);
+    for (const operator of REQUIRED_OPERATORS) {
+      assert.ok(operators.has(operator), `missing built-in operator ${operator}`);
+    }
+  });
+
+  for (const file of readdirSync(selfCorpusDir).filter(f => f.endsWith('.lino')).sort()) {
+    it(`replays self corpus ${file} like the host evaluator`, () => {
+      const source = readFileSync(join(selfCorpusDir, file), 'utf8');
+      const encoded = new EncodedEvaluator(evalRulePatterns(evaluatorForms()));
+      assertResultsEqual(encoded.run(source), run(source), file);
+    });
+  }
+
+  for (const file of readdirSync(examplesDir).filter(f => f.endsWith('.lino') && f !== 'expected.lino').sort()) {
+    it(`replays example ${file} like the host evaluator`, () => {
+      const source = readFileSync(join(examplesDir, file), 'utf8');
+      const encoded = new EncodedEvaluator(evalRulePatterns(evaluatorForms()));
+      assertResultsEqual(encoded.run(source), run(source), file);
+    });
+  }
+});

--- a/lib/self/evaluator.lino
+++ b/lib/self/evaluator.lino
@@ -1,0 +1,253 @@
+# RML evaluator encoded as links for the self-bootstrap layer.
+#
+# The rules below are data. They mirror the host evaluator surface so a future
+# self-hosted evaluator can consume `(rule ...)` links directly.
+
+(namespace self)
+
+(Evaluator: (Type 0) Evaluator)
+(Evaluation-rule: (Type 0) Evaluation-rule)
+(Operator: (Type 0) Operator)
+(Aggregator: (Type 0) Aggregator)
+
+(rml-evaluator: Evaluator rml-evaluator)
+(evaluator rml-evaluator matches relative-meta-logic version-0-19-0)
+(evaluator rml-evaluator has host-evaluator-presentation rule-links)
+
+# Built-in truth-value environment.
+
+(truth-range default 0 1)
+(truth-constant true high)
+(truth-constant false low)
+(truth-constant unknown midpoint)
+(truth-constant undefined midpoint)
+
+(built-in-operator not unary truth)
+(built-in-operator and variadic truth)
+(built-in-operator or variadic truth)
+(built-in-operator both variadic truth)
+(built-in-operator neither variadic truth)
+(built-in-operator = binary equality)
+(built-in-operator != binary equality)
+(built-in-operator + binary arithmetic)
+(built-in-operator - binary arithmetic)
+(built-in-operator * binary arithmetic)
+(built-in-operator / binary arithmetic)
+(built-in-operator < binary comparison)
+(built-in-operator <= binary comparison)
+
+(built-in-aggregator avg)
+(built-in-aggregator min)
+(built-in-aggregator max)
+(built-in-aggregator product)
+(built-in-aggregator probabilistic_sum)
+
+# Leaf evaluation and configuration forms.
+
+(rule (eval numeric-literal)
+  (clamp numeric-literal))
+
+(rule (eval symbol)
+  (lookup-symbol-probability symbol default midpoint))
+
+(rule (eval (range low high))
+  (set-range low high))
+
+(rule (eval (range: low high))
+  (set-range low high))
+
+(rule (eval (valence levels))
+  (set-valence levels))
+
+(rule (eval (valence: levels))
+  (set-valence levels))
+
+(rule (eval (namespace name))
+  (set-namespace name))
+
+(rule (eval (import path))
+  (evaluate-file path))
+
+(rule (eval (import path as alias))
+  (evaluate-file path with-alias alias))
+
+# Definitions, assignments, queries, and domain hooks.
+
+(rule (eval (name: name is name))
+  (declare-term name))
+
+(rule (eval (name: type-name name))
+  (declare-typed-term name type-name))
+
+(rule (eval (name: type-expression name))
+  (declare-typed-term name type-expression))
+
+(rule (eval (name: type-expression))
+  (declare-typed-term name type-expression))
+
+(rule (eval (name: number))
+  (set-symbol-probability name number))
+
+(rule (eval (operator: aggregator))
+  (set-operator-aggregator operator aggregator))
+
+(rule (eval (operator: outer inner))
+  (compose-operator operator outer inner))
+
+(rule (eval (name: lambda binding body))
+  (declare-lambda name binding body))
+
+(rule (eval ((expression) has probability number))
+  (assign-probability expression number))
+
+(rule (eval (? expression))
+  (query (clamp (eval expression))))
+
+(rule (eval (domain name request))
+  (dispatch-domain-plugin name request))
+
+# Arithmetic and comparison operators. Arithmetic operands are evaluated in an
+# arithmetic context, so numeric literals are not clamped before the operator.
+
+(rule (eval (left + right))
+  (decimal-round (+ (arith left) (arith right))))
+
+(rule (eval (left - right))
+  (decimal-round (- (arith left) (arith right))))
+
+(rule (eval (left * right))
+  (decimal-round (* (arith left) (arith right))))
+
+(rule (eval (left / right))
+  (if (equals (arith right) 0)
+      0
+      (decimal-round (/ (arith left) (arith right)))))
+
+(rule (eval (left < right))
+  (if (< (arith left) (arith right)) high low))
+
+(rule (eval (left <= right))
+  (if (<= (arith left) (arith right)) high low))
+
+# Logical operators and aggregators.
+
+(rule (eval (not value))
+  (clamp (mirror-around-midpoint (eval value))))
+
+(rule (eval (and a b))
+  (clamp (current-and (eval a) (eval b))))
+
+(rule (eval (or a b))
+  (clamp (current-or (eval a) (eval b))))
+
+(rule (eval (both a b))
+  (clamp (current-both (eval a) (eval b))))
+
+(rule (eval (neither a b))
+  (clamp (current-neither (eval a) (eval b))))
+
+(rule (eval (a and b))
+  (clamp (current-and (eval a) (eval b))))
+
+(rule (eval (a or b))
+  (clamp (current-or (eval a) (eval b))))
+
+(rule (eval (a both b))
+  (clamp (current-both (eval a) (eval b))))
+
+(rule (eval (a neither b))
+  (clamp (current-neither (eval a) (eval b))))
+
+(rule (eval (both a and b))
+  (clamp (current-both (eval a) (eval b))))
+
+(rule (eval (neither a nor b))
+  (clamp (current-neither (eval a) (eval b))))
+
+(rule (aggregate avg values)
+  (/ (sum values) (count values)))
+
+(rule (aggregate min values)
+  (minimum values))
+
+(rule (aggregate max values)
+  (maximum values))
+
+(rule (aggregate product values)
+  (product values))
+
+(rule (aggregate probabilistic_sum values)
+  (- 1 (product (map values (lambda (Number x) (- 1 x))))))
+
+# Equality consults explicit assignments first, then normalized assignments,
+# then structural equality, then numeric equality.
+
+(rule (eval (= left right))
+  (equality-truth-value left right))
+
+(rule (eval (!= left right))
+  (clamp (not (equality-truth-value left right))))
+
+(rule (eval (left = right))
+  (equality-truth-value left right))
+
+(rule (eval (left != right))
+  (clamp (not (equality-truth-value left right))))
+
+(rule (equality-truth-value left right)
+  (first-defined
+    (lookup-assignment (left = right))
+    (lookup-assignment (= left right))
+    (lookup-assignment ((normalize left) = (normalize right)))
+    (structural-equality (normalize left) (normalize right))
+    (numeric-equality (numeric left) (numeric right))
+    low))
+
+# Typed kernel and term-normalization forms.
+
+(rule (eval (Type level))
+  (declare-universe level))
+
+(rule (eval (Prop))
+  (declare-prop))
+
+(rule (eval (Pi binding body))
+  (declare-pi binding body))
+
+(rule (eval (lambda binding body))
+  (lambda-value binding body))
+
+(rule (eval (apply function argument))
+  (beta-apply function argument))
+
+(rule (eval (function argument))
+  (prefix-apply function argument))
+
+(rule (eval (subst term variable replacement))
+  (substitute term variable replacement))
+
+(rule (eval (fresh variable in body))
+  (evaluate-with-fresh-variable variable body))
+
+(rule (eval (whnf expression))
+  (weak-head-normal-form expression))
+
+(rule (eval (nf expression))
+  (normal-form expression))
+
+(rule (eval (normal-form expression))
+  (normal-form expression))
+
+(rule (eval (type of expression))
+  (type-query expression))
+
+(rule (eval (expression of type))
+  (type-membership expression type))
+
+# Meta-evaluator declarations used by tests and future self-hosted work.
+
+(rule (host-evaluator-presentation rml-evaluator)
+  (rule-links with eval-patterns))
+
+(rule (eval-top-level forms)
+  (fold forms environment collect-query-results))

--- a/rust/tests/self_evaluator_tests.rs
+++ b/rust/tests/self_evaluator_tests.rs
@@ -1,0 +1,176 @@
+// Tests for `lib/self/evaluator.lino` (issue #85).
+//
+// Mirrors the data-shape checks from js/tests/self-evaluator.test.mjs so both
+// runtimes keep the encoded evaluator importable and parseable.
+
+use rml::{evaluate_file, key_of, parse_lino, parse_one, tokenize_one, EvaluateOptions, Node};
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REQUIRED_EVAL_RULES: &[&str] = &[
+    "(eval numeric-literal)",
+    "(eval symbol)",
+    "(eval (range low high))",
+    "(eval (range: low high))",
+    "(eval (valence levels))",
+    "(eval (valence: levels))",
+    "(eval (name: name is name))",
+    "(eval (name: type-name name))",
+    "(eval (name: type-expression name))",
+    "(eval (name: type-expression))",
+    "(eval (operator: aggregator))",
+    "(eval (operator: outer inner))",
+    "(eval (name: lambda binding body))",
+    "(eval (expression has probability number))",
+    "(eval (? expression))",
+    "(eval (left + right))",
+    "(eval (left - right))",
+    "(eval (left * right))",
+    "(eval (left / right))",
+    "(eval (left < right))",
+    "(eval (left <= right))",
+    "(eval (not value))",
+    "(eval (and a b))",
+    "(eval (or a b))",
+    "(eval (both a b))",
+    "(eval (neither a b))",
+    "(eval (a and b))",
+    "(eval (a or b))",
+    "(eval (both a and b))",
+    "(eval (neither a nor b))",
+    "(eval (= left right))",
+    "(eval (!= left right))",
+    "(eval (left = right))",
+    "(eval (left != right))",
+    "(eval (Type level))",
+    "(eval Prop)",
+    "(eval (Pi binding body))",
+    "(eval (lambda binding body))",
+    "(eval (apply function argument))",
+    "(eval (subst term variable replacement))",
+    "(eval (fresh variable in body))",
+    "(eval (whnf expression))",
+    "(eval (nf expression))",
+    "(eval (normal-form expression))",
+    "(eval (type of expression))",
+    "(eval (expression of type))",
+    "(eval (domain name request))",
+];
+
+const REQUIRED_OPERATORS: &[&str] = &[
+    "not", "and", "or", "both", "neither", "=", "!=", "+", "-", "*", "/", "<", "<=",
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn evaluator_path() -> PathBuf {
+    repo_root().join("lib").join("self").join("evaluator.lino")
+}
+
+fn self_corpus_dir() -> PathBuf {
+    repo_root().join("test-corpus").join("self")
+}
+
+fn parse_forms(path: &Path) -> Vec<Node> {
+    let text = fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", path.display(), e));
+    parse_lino(&text)
+        .into_iter()
+        .map(|link| {
+            parse_one(&tokenize_one(&link))
+                .unwrap_or_else(|e| panic!("failed to parse link {}: {}", link, e))
+        })
+        .collect()
+}
+
+fn eval_rule_patterns(forms: &[Node]) -> HashSet<String> {
+    let mut patterns = HashSet::new();
+    for form in forms {
+        let Node::List(children) = form else {
+            continue;
+        };
+        if children.len() >= 2 {
+            if let (Node::Leaf(head), Node::List(pattern)) = (&children[0], &children[1]) {
+                if head == "rule"
+                    && matches!(pattern.first(), Some(Node::Leaf(eval)) if eval == "eval")
+                {
+                    patterns.insert(key_of(&children[1]));
+                }
+            }
+        }
+    }
+    patterns
+}
+
+fn built_in_operators(forms: &[Node]) -> HashSet<String> {
+    let mut operators = HashSet::new();
+    for form in forms {
+        let Node::List(children) = form else {
+            continue;
+        };
+        if children.len() >= 2 {
+            if let (Node::Leaf(head), Node::Leaf(operator)) = (&children[0], &children[1]) {
+                if head == "built-in-operator" {
+                    operators.insert(operator.clone());
+                }
+            }
+        }
+    }
+    operators
+}
+
+fn lino_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<_> = fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", dir.display(), e))
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().and_then(|s| s.to_str()) == Some("lino"))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn self_evaluator_is_importable() {
+    let path = evaluator_path();
+    let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn self_evaluator_declares_required_builtin_rules() {
+    let forms = parse_forms(&evaluator_path());
+    let patterns = eval_rule_patterns(&forms);
+    for pattern in REQUIRED_EVAL_RULES {
+        assert!(
+            patterns.contains(*pattern),
+            "missing rule {}; got {:?}",
+            pattern,
+            patterns
+        );
+    }
+
+    let operators = built_in_operators(&forms);
+    for operator in REQUIRED_OPERATORS {
+        assert!(
+            operators.contains(*operator),
+            "missing operator {}",
+            operator
+        );
+    }
+}
+
+#[test]
+fn self_evaluator_corpus_is_host_parseable() {
+    for path in lino_files(&self_corpus_dir()) {
+        let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+        assert!(
+            out.diagnostics.is_empty(),
+            "{} diagnostics: {:?}",
+            path.display(),
+            out.diagnostics
+        );
+    }
+}

--- a/test-corpus/self/evaluator-operators.lino
+++ b/test-corpus/self/evaluator-operators.lino
@@ -1,0 +1,41 @@
+# Representative corpus for the encoded evaluator rules.
+
+(and: product)
+(or: probabilistic_sum)
+
+(p: p is p)
+(q: q is q)
+
+((p = true) has probability 0.25)
+((q = true) has probability 0.8)
+
+(? (p = true))
+(? (q != true))
+(? ((p = true) and (q = true)))
+(? ((p = true) or (q = true)))
+(? (not (p = true)))
+
+(? ((0.1 + 0.2) = 0.3))
+(? (4 / 2))
+(? (1 < 2))
+(? (2 <= 2))
+
+(Term: (Type 0) Term)
+(zero: Term zero)
+(identity: lambda (Term x) x)
+
+(? (zero of Term))
+(? (type of zero))
+(? (apply identity 0.42))
+(? (whnf (apply identity zero)))
+(? (normal-form (apply identity zero)))
+
+(range: -1 1)
+(? true)
+(? false)
+(? unknown)
+
+(valence: 3)
+(? 0.25)
+(and: avg)
+(? (1 and -1))


### PR DESCRIPTION
Fixes #85

## Summary
- Add `lib/self/evaluator.lino` as LiNo data encoding the host evaluator rule surface, built-in operators, aggregators, equality, normalization, and typed-kernel forms.
- Add `test-corpus/self/evaluator-operators.lino` with representative evaluator cases.
- Add JS/Rust self-evaluator tests; the JS rule-backed evaluator cross-checks the self corpus and every root `examples/*.lino` against host outputs.

## Reproduction and verification
- Before the implementation, `lib/self/evaluator.lino` did not exist, so the self-evaluator import/cross-check failed immediately.
- The JS self-evaluator test now parses the encoded rules and replays the self corpus plus root examples against the host evaluator.

## Tests
- `node --test js/tests/self-evaluator.test.mjs`
- `cargo test self_evaluator --manifest-path rust/Cargo.toml`
- `cd js && npm run lint:english`
- `cd js && npm test`
- `cd rust && cargo test`
- `git diff --check`

UI screenshots are not applicable; this is a self-bootstrap library/test data change.
