### PR TITLE
Add self type layer rules

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-09T09:56:33.388Z for PR creation at branch issue-85-bb5ecc6ce050 for issue https://github.com/link-foundation/relative-meta-logic/issues/85
+# Updated: 2026-05-09T12:10:28.800Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-09T09:56:33.388Z for PR creation at branch issue-85-bb5ecc6ce050 for issue https://github.com/link-foundation/relative-meta-logic/issues/85
-# Updated: 2026-05-09T12:10:28.800Z

--- a/js/tests/self-types.test.mjs
+++ b/js/tests/self-types.test.mjs
@@ -1,0 +1,514 @@
+// Tests for `lib/self/types.lino` (issue #86).
+//
+// The type file is data: it records the host bidirectional checker as
+// `(rule ...)` links. These tests keep that data parseable, require the
+// `synth`/`check` rule surface, and run a small rule-backed checker against
+// representative acceptance and rejection cases from the host checker.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  Env,
+  evalNode,
+  evaluateFile,
+  isConvertible,
+  isNum,
+  isStructurallySame,
+  keyOf,
+  parseBinding,
+  parseLino,
+  parseOne,
+  subst,
+  synth,
+  check,
+  tokenizeOne,
+} from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const typesPath = join(repoRoot, 'lib', 'self', 'types.lino');
+
+const REQUIRED_SYNTH_RULES = [
+  '(synth symbol)',
+  '(synth numeric-literal)',
+  '(synth (Type level))',
+  '(synth (Prop))',
+  '(synth (Pi binding body))',
+  '(synth (forall type-variable body))',
+  '(synth (lambda binding body))',
+  '(synth (apply function argument))',
+  '(synth (subst term variable replacement))',
+  '(synth (type of expression))',
+  '(synth (expression of expected-type))',
+  '(synth recorded-expression)',
+];
+
+const REQUIRED_CHECK_RULES = [
+  '(check expression expected-type)',
+  '(check numeric-literal expected-type)',
+  '(check (lambda (T x) body) (Pi (T x) U))',
+  '(check (lambda (domain variable) body) (Pi (expected-domain expected-variable) codomain))',
+  '(check (lambda binding body) non-pi-type)',
+  '(check expression expected-type by-synthesis)',
+];
+
+const REQUIRED_DIAGNOSTICS = ['E020', 'E021', 'E022', 'E023', 'E024'];
+
+function parseForms(source) {
+  return parseLino(source).map(link => parseOne(tokenizeOne(link)));
+}
+
+function typeForms() {
+  return parseForms(readFileSync(typesPath, 'utf8'));
+}
+
+function rulePatterns(forms, kind) {
+  const patterns = new Set();
+  for (const form of forms) {
+    if (
+      Array.isArray(form) &&
+      form[0] === 'rule' &&
+      Array.isArray(form[1]) &&
+      form[1][0] === kind
+    ) {
+      patterns.add(keyOf(form[1]));
+    }
+  }
+  return patterns;
+}
+
+function diagnosticCodes(forms) {
+  const codes = new Set();
+  for (const form of forms) {
+    if (
+      Array.isArray(form) &&
+      form[0] === 'rule' &&
+      Array.isArray(form[1]) &&
+      form[1][0] === 'diagnostic'
+    ) {
+      for (const child of form.slice(2)) {
+        if (Array.isArray(child) && child[0] === 'emits' && typeof child[1] === 'string') {
+          codes.add(child[1]);
+        }
+      }
+    }
+  }
+  return codes;
+}
+
+function parseTermInput(term) {
+  if (Array.isArray(term)) return term;
+  if (typeof term === 'string' && term.trim().startsWith('(')) {
+    return parseOne(tokenizeOne(term.trim()));
+  }
+  return term;
+}
+
+function parseUniverseLevelToken(token) {
+  if (typeof token !== 'string' || !/^(0|[1-9]\d*)$/.test(token)) return null;
+  const level = Number(token);
+  return Number.isSafeInteger(level) ? level : null;
+}
+
+function universeTypeKey(node) {
+  if (!Array.isArray(node) || node.length !== 2 || node[0] !== 'Type') return null;
+  const level = parseUniverseLevelToken(node[1]);
+  return level === null ? null : `(Type ${level + 1})`;
+}
+
+function inferTypeKey(node, env) {
+  const recorded = env.getType(node);
+  if (recorded) return recorded;
+  const universeType = universeTypeKey(node);
+  if (universeType) {
+    env.setType(node, universeType);
+    return universeType;
+  }
+  return null;
+}
+
+function typeKeyOf(typeNode) {
+  if (typeNode === null || typeNode === undefined) return null;
+  return typeof typeNode === 'string' ? typeNode : keyOf(typeNode);
+}
+
+function parseTypeKeyToNode(typeKey) {
+  if (typeof typeKey !== 'string') return typeKey;
+  const trimmed = typeKey.trim();
+  if (trimmed.startsWith('(')) return parseOne(tokenizeOne(trimmed));
+  return typeKey;
+}
+
+function isForallNode(node) {
+  return Array.isArray(node) &&
+    node.length === 3 &&
+    node[0] === 'forall' &&
+    typeof node[1] === 'string';
+}
+
+function expandForall(node) {
+  return isForallNode(node) ? ['Pi', ['Type', node[1]], node[2]] : node;
+}
+
+function snapshotTypeBinding(env, name) {
+  return {
+    name,
+    hadTerm: env.terms.has(name),
+    hadType: env.types.has(name),
+    previousType: env.types.get(name),
+  };
+}
+
+function extendTypeBinding(env, name, typeKey) {
+  env.terms.add(name);
+  env.types.set(name, typeKey);
+}
+
+function restoreTypeBinding(env, snap) {
+  if (!snap.hadTerm) env.terms.delete(snap.name);
+  if (snap.hadType) env.types.set(snap.name, snap.previousType);
+  else env.types.delete(snap.name);
+}
+
+function setupNaturalEnv() {
+  const env = new Env();
+  evalNode(['Type:', 'Type', 'Type'], env);
+  evalNode(['Natural:', ['Type', '0'], 'Natural'], env);
+  evalNode(['Boolean:', 'Type', 'Boolean'], env);
+  evalNode(['zero:', 'Natural', 'zero'], env);
+  evalNode(['identity:', 'lambda', ['Natural', 'x'], 'x'], env);
+  evalNode(['succ:', ['Pi', ['Natural', 'n'], 'Natural']], env);
+  return env;
+}
+
+class EncodedTypeChecker {
+  constructor(forms) {
+    this.synthRules = rulePatterns(forms, 'synth');
+    this.checkRules = rulePatterns(forms, 'check');
+    this.diagnosticRules = diagnosticCodes(forms);
+  }
+
+  requireSynth(pattern) {
+    assert.ok(this.synthRules.has(pattern), `missing encoded rule ${pattern}`);
+  }
+
+  requireCheck(pattern) {
+    assert.ok(this.checkRules.has(pattern), `missing encoded rule ${pattern}`);
+  }
+
+  diagnostic(code) {
+    assert.ok(this.diagnosticRules.has(code), `missing encoded diagnostic ${code}`);
+    return { code };
+  }
+
+  typesAgree(a, b, env) {
+    if (a === null || b === null) return false;
+    const left = expandForall(a);
+    const right = expandForall(b);
+    if (isStructurallySame(left, right)) return true;
+    try {
+      return isConvertible(left, right, env);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  synthLeaf(term, env) {
+    this.requireSynth(isNum(term) ? '(synth numeric-literal)' : '(synth symbol)');
+    if (isNum(term)) return null;
+    const recorded = inferTypeKey(term, env);
+    if (recorded) return parseTypeKeyToNode(recorded);
+    const resolved = env._resolveQualified(term);
+    if (resolved !== term) {
+      const fromAlias = env.types.get(resolved);
+      if (fromAlias) return parseTypeKeyToNode(fromAlias);
+    }
+    return null;
+  }
+
+  synthApply(node, env, diagnostics) {
+    this.requireSynth('(synth (apply function argument))');
+    const fnSynth = this.synth(node[1], env);
+    diagnostics.push(...fnSynth.diagnostics);
+    if (!fnSynth.type) {
+      diagnostics.push(this.diagnostic('E020'));
+      return null;
+    }
+
+    const fnType = expandForall(fnSynth.type);
+    if (!Array.isArray(fnType) || fnType.length !== 3 || fnType[0] !== 'Pi') {
+      diagnostics.push(this.diagnostic('E022'));
+      return null;
+    }
+
+    const parsed = parseBinding(fnType[1]);
+    if (!parsed) {
+      diagnostics.push(this.diagnostic('E022'));
+      return null;
+    }
+
+    const argCheck = this.check(node[2], parsed.paramType, env);
+    diagnostics.push(...argCheck.diagnostics);
+    if (!argCheck.ok) return null;
+    return subst(fnType[2], parsed.paramName, node[2]);
+  }
+
+  synthLambda(node, env, diagnostics) {
+    this.requireSynth('(synth (lambda binding body))');
+    const parsed = parseBinding(node[1]);
+    if (!parsed) {
+      diagnostics.push(this.diagnostic('E024'));
+      return null;
+    }
+
+    const snap = snapshotTypeBinding(env, parsed.paramName);
+    extendTypeBinding(env, parsed.paramName, typeKeyOf(parsed.paramType));
+    let bodySynth;
+    try {
+      bodySynth = this.synth(node[2], env);
+    } finally {
+      restoreTypeBinding(env, snap);
+    }
+    diagnostics.push(...bodySynth.diagnostics);
+    if (!bodySynth.type) return null;
+    return ['Pi', [parsed.paramType, parsed.paramName], bodySynth.type];
+  }
+
+  synth(term, env) {
+    const diagnostics = [];
+    const node = parseTermInput(term);
+
+    if (typeof node === 'string') {
+      const type = this.synthLeaf(node, env);
+      if (!type && !isNum(node)) diagnostics.push(this.diagnostic('E020'));
+      return { type, diagnostics };
+    }
+
+    if (!Array.isArray(node)) {
+      diagnostics.push(this.diagnostic('E020'));
+      return { type: null, diagnostics };
+    }
+
+    if (node.length === 2 && node[0] === 'Type') {
+      this.requireSynth('(synth (Type level))');
+      const universeType = universeTypeKey(node);
+      if (universeType) return { type: parseTypeKeyToNode(universeType), diagnostics };
+      diagnostics.push(this.diagnostic('E020'));
+      return { type: null, diagnostics };
+    }
+
+    if (node.length === 1 && node[0] === 'Prop') {
+      this.requireSynth('(synth (Prop))');
+      return { type: ['Type', '1'], diagnostics };
+    }
+
+    if (node.length === 3 && node[0] === 'Pi') {
+      this.requireSynth('(synth (Pi binding body))');
+      if (!parseBinding(node[1])) {
+        diagnostics.push(this.diagnostic('E024'));
+        return { type: null, diagnostics };
+      }
+      return { type: ['Type', '0'], diagnostics };
+    }
+
+    if (isForallNode(node)) {
+      this.requireSynth('(synth (forall type-variable body))');
+      return this.synth(expandForall(node), env);
+    }
+
+    if (node.length === 3 && node[0] === 'lambda') {
+      const type = this.synthLambda(node, env, diagnostics);
+      return { type, diagnostics };
+    }
+
+    if (node.length === 3 && node[0] === 'apply') {
+      const type = this.synthApply(node, env, diagnostics);
+      return { type, diagnostics };
+    }
+
+    if (node.length === 4 && node[0] === 'subst' && typeof node[2] === 'string') {
+      this.requireSynth('(synth (subst term variable replacement))');
+      return this.synth(subst(parseTermInput(node[1]), node[2], parseTermInput(node[3])), env);
+    }
+
+    if (node.length === 3 && node[0] === 'type' && node[1] === 'of') {
+      this.requireSynth('(synth (type of expression))');
+      const inner = this.synth(node[2], env);
+      diagnostics.push(...inner.diagnostics);
+      if (inner.type) return { type: ['Type', '0'], diagnostics };
+      diagnostics.push(this.diagnostic('E020'));
+      return { type: null, diagnostics };
+    }
+
+    if (node.length === 3 && node[1] === 'of') {
+      this.requireSynth('(synth (expression of expected-type))');
+      const result = this.check(node[0], node[2], env);
+      diagnostics.push(...result.diagnostics);
+      return { type: result.ok ? ['Type', '0'] : null, diagnostics };
+    }
+
+    this.requireSynth('(synth recorded-expression)');
+    const recorded = inferTypeKey(node, env);
+    if (recorded) return { type: parseTypeKeyToNode(recorded), diagnostics };
+
+    diagnostics.push(this.diagnostic('E020'));
+    return { type: null, diagnostics };
+  }
+
+  check(term, expectedType, env) {
+    this.requireCheck('(check expression expected-type)');
+    const diagnostics = [];
+    const node = parseTermInput(term);
+    let expectedNode = parseTermInput(expectedType);
+
+    if (isForallNode(expectedNode)) expectedNode = expandForall(expectedNode);
+
+    if (
+      Array.isArray(node) && node.length === 3 && node[0] === 'lambda' &&
+      Array.isArray(expectedNode) && expectedNode.length === 3 && expectedNode[0] === 'Pi'
+    ) {
+      this.requireCheck('(check (lambda (domain variable) body) (Pi (expected-domain expected-variable) codomain))');
+      const lambdaParsed = parseBinding(node[1]);
+      const piParsed = parseBinding(expectedNode[1]);
+      if (lambdaParsed && piParsed) {
+        if (!this.typesAgree(parseTermInput(lambdaParsed.paramType), parseTermInput(piParsed.paramType), env)) {
+          diagnostics.push(this.diagnostic('E021'));
+          return { ok: false, diagnostics };
+        }
+
+        const codomain = subst(expectedNode[2], piParsed.paramName, lambdaParsed.paramName);
+        const snap = snapshotTypeBinding(env, lambdaParsed.paramName);
+        extendTypeBinding(env, lambdaParsed.paramName, typeKeyOf(lambdaParsed.paramType));
+        try {
+          const bodyResult = this.check(node[2], codomain, env);
+          diagnostics.push(...bodyResult.diagnostics);
+          return { ok: bodyResult.ok, diagnostics };
+        } finally {
+          restoreTypeBinding(env, snap);
+        }
+      }
+    }
+
+    if (
+      Array.isArray(node) && node.length === 3 && node[0] === 'lambda' &&
+      !(Array.isArray(expectedNode) && expectedNode[0] === 'Pi')
+    ) {
+      this.requireCheck('(check (lambda binding body) non-pi-type)');
+      diagnostics.push(this.diagnostic('E023'));
+      return { ok: false, diagnostics };
+    }
+
+    if (typeof node === 'string' && isNum(node)) {
+      this.requireCheck('(check numeric-literal expected-type)');
+      return { ok: true, diagnostics };
+    }
+
+    this.requireCheck('(check expression expected-type by-synthesis)');
+    const synthResult = this.synth(node, env);
+    diagnostics.push(...synthResult.diagnostics);
+    if (!synthResult.type) return { ok: false, diagnostics };
+
+    const ok = this.typesAgree(synthResult.type, expectedNode, env);
+    if (!ok) diagnostics.push(this.diagnostic('E021'));
+    return { ok, diagnostics };
+  }
+}
+
+function comparableSynth(result) {
+  return {
+    type: result.type ? keyOf(result.type) : null,
+    codes: result.diagnostics.map(d => d.code),
+  };
+}
+
+function comparableCheck(result) {
+  return {
+    ok: result.ok,
+    codes: result.diagnostics.map(d => d.code),
+  };
+}
+
+const SYNTH_CASES = [
+  { name: 'known term', term: 'zero' },
+  { name: 'universe successor', term: ['Type', '0'] },
+  { name: 'invalid universe', term: ['Type', 'bad'] },
+  { name: 'Prop universe', term: ['Prop'] },
+  { name: 'Pi formation', term: ['Pi', ['Natural', 'n'], 'Natural'] },
+  { name: 'prenex forall formation', term: ['forall', 'A', ['Pi', ['A', 'x'], 'A']] },
+  { name: 'lambda synthesis', term: ['lambda', ['Natural', 'x'], 'x'] },
+  { name: 'application synthesis', term: ['apply', 'identity', 'zero'] },
+  { name: 'substitution synthesis', term: ['subst', 'x', 'x', 'zero'] },
+  { name: 'type-of query', term: ['type', 'of', 'zero'] },
+  { name: 'of-membership query', term: ['zero', 'of', 'Natural'] },
+  { name: 'unknown symbol rejection', term: 'mystery' },
+  { name: 'non-Pi application rejection', term: ['apply', 'zero', 'zero'] },
+  { name: 'malformed lambda binder rejection', term: ['lambda', ['x'], 'x'] },
+];
+
+const CHECK_CASES = [
+  { name: 'recorded term', term: 'zero', expected: 'Natural' },
+  { name: 'lambda against Pi', term: ['lambda', ['Natural', 'x'], 'x'], expected: ['Pi', ['Natural', 'x'], 'Natural'] },
+  { name: 'numeric literal', term: '0.7', expected: 'Natural' },
+  {
+    name: 'lambda body in extended context',
+    term: ['lambda', ['Natural', 'x'], ['apply', 'succ', 'x']],
+    expected: ['Pi', ['Natural', 'n'], 'Natural'],
+  },
+  {
+    name: 'prenex forall expected type',
+    term: ['lambda', ['Type', 'A'], ['lambda', ['A', 'x'], 'x']],
+    expected: ['forall', 'A', ['Pi', ['A', 'x'], 'A']],
+  },
+  { name: 'type mismatch rejection', term: 'zero', expected: 'Boolean' },
+  { name: 'lambda against non-Pi rejection', term: ['lambda', ['Natural', 'x'], 'x'], expected: 'Natural' },
+  { name: 'lambda parameter mismatch rejection', term: ['lambda', ['Boolean', 'x'], 'x'], expected: ['Pi', ['Natural', 'x'], 'Natural'] },
+  { name: 'unknown term rejection', term: 'mystery', expected: 'Natural' },
+];
+
+describe('self type layer', () => {
+  it('is importable as a standard library file', () => {
+    const out = evaluateFile(typesPath);
+    assert.deepStrictEqual(out.diagnostics, []);
+  });
+
+  it('declares the required synth and check rules as links', () => {
+    const forms = typeForms();
+    const synthRules = rulePatterns(forms, 'synth');
+    for (const pattern of REQUIRED_SYNTH_RULES) {
+      assert.ok(synthRules.has(pattern), `missing synth rule ${pattern}`);
+    }
+
+    const checkRules = rulePatterns(forms, 'check');
+    for (const pattern of REQUIRED_CHECK_RULES) {
+      assert.ok(checkRules.has(pattern), `missing check rule ${pattern}`);
+    }
+
+    const diagnostics = diagnosticCodes(forms);
+    for (const code of REQUIRED_DIAGNOSTICS) {
+      assert.ok(diagnostics.has(code), `missing diagnostic ${code}`);
+    }
+  });
+
+  for (const tc of SYNTH_CASES) {
+    it(`synth ${tc.name} like the host checker`, () => {
+      const encoded = new EncodedTypeChecker(typeForms());
+      assert.deepStrictEqual(
+        comparableSynth(encoded.synth(tc.term, setupNaturalEnv())),
+        comparableSynth(synth(tc.term, setupNaturalEnv())),
+      );
+    });
+  }
+
+  for (const tc of CHECK_CASES) {
+    it(`check ${tc.name} like the host checker`, () => {
+      const encoded = new EncodedTypeChecker(typeForms());
+      assert.deepStrictEqual(
+        comparableCheck(encoded.check(tc.term, tc.expected, setupNaturalEnv())),
+        comparableCheck(check(tc.term, tc.expected, setupNaturalEnv())),
+      );
+    });
+  }
+});

--- a/lib/self/types.lino
+++ b/lib/self/types.lino
@@ -1,0 +1,148 @@
+# RML bidirectional type layer encoded as links for the self-bootstrap layer.
+#
+# The rules below are data. They mirror the host `synth` and `check` surface
+# so a future self-hosted checker can consume `(rule ...)` links directly.
+
+(namespace self)
+
+(Type-layer: (Type 0) Type-layer)
+(Typing-context: (Type 0) Typing-context)
+(Typing-rule: (Type 0) Typing-rule)
+(Type-diagnostic: (Type 0) Type-diagnostic)
+
+(rml-type-layer: Type-layer rml-type-layer)
+(type-layer rml-type-layer matches relative-meta-logic version-0-19-0)
+(type-layer rml-type-layer has host-type-checker-presentation rule-links)
+
+# Judgement forms.
+
+(judgement (synth term type) reads context-synthesizes-term-as-type)
+(judgement (check term type) reads context-checks-term-against-type)
+(judgement (convert left right) reads left-and-right-are-definitionally-equal)
+
+(rule (context empty)
+  (has no-recorded-type-facts))
+
+(rule (context (extend context variable type))
+  (records variable type)
+  (restores previous-binding after-scope))
+
+(rule (lookup-type context expression)
+  (first-defined
+    (recorded-type expression)
+    (resolved-qualified-type expression)
+    (universe-successor-type expression)))
+
+# Synthesis mode.
+
+(rule (synth symbol)
+  (when (lookup-type context symbol))
+  (returns recorded-type))
+
+(rule (synth numeric-literal)
+  (returns no-type)
+  (emits no-diagnostic))
+
+(rule (synth (Type level))
+  (when (valid-universe-level level))
+  (returns (Type (successor level))))
+
+(rule (synth (Prop))
+  (returns (Type 1)))
+
+(rule (synth (Pi binding body))
+  (when (well-formed-binding binding))
+  (returns (Type 0)))
+
+(rule (synth (forall type-variable body))
+  (desugars-to (Pi (Type type-variable) body))
+  (continues-with synth))
+
+(rule (synth (lambda binding body))
+  (when (well-formed-binding binding))
+  (extends context with binding)
+  (synthesizes body as body-type)
+  (returns (Pi binding body-type)))
+
+(rule (synth (apply function argument))
+  (synthesizes function as (Pi (domain variable) codomain))
+  (checks argument against domain)
+  (returns (subst codomain variable argument)))
+
+(rule (synth (subst term variable replacement))
+  (reduces-to (subst term variable replacement))
+  (continues-with synth))
+
+(rule (synth (type of expression))
+  (synthesizes expression as expression-type)
+  (returns (Type 0)))
+
+(rule (synth (expression of expected-type))
+  (checks expression against expected-type)
+  (returns (Type 0)))
+
+(rule (synth recorded-expression)
+  (when (lookup-type context recorded-expression))
+  (returns recorded-type))
+
+# Checking mode.
+
+(rule (check expression expected-type)
+  (uses bidirectional-checking)
+  (returns ok-or-diagnostics))
+
+(rule (check numeric-literal expected-type)
+  (accepts any-non-empty-annotation))
+
+(rule (check (lambda (T x) body) (Pi (T x) U))
+  (opens x as T)
+  (checks body against U))
+
+(rule (check (lambda (domain variable) body) (Pi (expected-domain expected-variable) codomain))
+  (requires (convert domain expected-domain))
+  (checks body against (subst codomain expected-variable variable)))
+
+(rule (check (lambda binding body) non-pi-type)
+  (rejects with E023))
+
+(rule (check expression expected-type by-synthesis)
+  (synthesizes expression as actual-type)
+  (requires (convert actual-type expected-type)))
+
+# Convertibility and host helper rules.
+
+(rule (convert left right)
+  (expands-prenex-forall)
+  (normalizes left and right)
+  (compares structural-equality))
+
+(rule (valid-universe-level level)
+  (requires natural-number-token level))
+
+(rule (well-formed-binding (type variable))
+  (requires variable-name variable)
+  (records variable type))
+
+(rule (well-formed-binding (variable: type))
+  (records variable type))
+
+(rule (prenex-forall (forall type-variable body))
+  (desugars-to (Pi (Type type-variable) body)))
+
+(rule (diagnostic cannot-synthesize expression)
+  (emits E020))
+
+(rule (diagnostic type-mismatch expression actual-type expected-type)
+  (emits E021))
+
+(rule (diagnostic application-head-not-pi function actual-type)
+  (emits E022))
+
+(rule (diagnostic lambda-expected-pi expression expected-type)
+  (emits E023))
+
+(rule (diagnostic malformed-binder binding)
+  (emits E024))
+
+(rule (host-type-checker-presentation rml-type-layer)
+  (rule-links with synth-and-check-patterns))

--- a/rust/tests/self_types_tests.rs
+++ b/rust/tests/self_types_tests.rs
@@ -1,0 +1,152 @@
+// Tests for `lib/self/types.lino` (issue #86).
+//
+// Mirrors the data-shape checks from js/tests/self-types.test.mjs so both
+// runtimes keep the encoded type layer importable and parseable.
+
+use rml::{evaluate_file, key_of, parse_lino, parse_one, tokenize_one, EvaluateOptions, Node};
+use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
+
+const REQUIRED_SYNTH_RULES: &[&str] = &[
+    "(synth symbol)",
+    "(synth numeric-literal)",
+    "(synth (Type level))",
+    "(synth Prop)",
+    "(synth (Pi binding body))",
+    "(synth (forall type-variable body))",
+    "(synth (lambda binding body))",
+    "(synth (apply function argument))",
+    "(synth (subst term variable replacement))",
+    "(synth (type of expression))",
+    "(synth (expression of expected-type))",
+    "(synth recorded-expression)",
+];
+
+const REQUIRED_CHECK_RULES: &[&str] = &[
+    "(check expression expected-type)",
+    "(check numeric-literal expected-type)",
+    "(check (lambda (T x) body) (Pi (T x) U))",
+    "(check (lambda (domain variable) body) (Pi (expected-domain expected-variable) codomain))",
+    "(check (lambda binding body) non-pi-type)",
+    "(check expression expected-type by-synthesis)",
+];
+
+const REQUIRED_DIAGNOSTICS: &[&str] = &["E020", "E021", "E022", "E023", "E024"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn types_path() -> PathBuf {
+    repo_root().join("lib").join("self").join("types.lino")
+}
+
+fn parse_forms() -> Vec<Node> {
+    let path = types_path();
+    let text = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", path.display(), e));
+    parse_lino(&text)
+        .into_iter()
+        .map(|link| {
+            parse_one(&tokenize_one(&link))
+                .unwrap_or_else(|e| panic!("failed to parse link {}: {}", link, e))
+        })
+        .collect()
+}
+
+fn rule_patterns(forms: &[Node], kind: &str) -> HashSet<String> {
+    let mut patterns = HashSet::new();
+    for form in forms {
+        let Node::List(children) = form else {
+            continue;
+        };
+        if children.len() >= 2 {
+            if let (Node::Leaf(head), Node::List(pattern)) = (&children[0], &children[1]) {
+                if head == "rule"
+                    && matches!(pattern.first(), Some(Node::Leaf(pattern_head)) if pattern_head == kind)
+                {
+                    patterns.insert(key_of(&children[1]));
+                }
+            }
+        }
+    }
+    patterns
+}
+
+fn diagnostic_codes(forms: &[Node]) -> HashSet<String> {
+    let mut codes = HashSet::new();
+    for form in forms {
+        let Node::List(children) = form else {
+            continue;
+        };
+        if children.len() < 3 {
+            continue;
+        }
+        let Node::Leaf(rule_head) = &children[0] else {
+            continue;
+        };
+        let Node::List(pattern) = &children[1] else {
+            continue;
+        };
+        if rule_head != "rule"
+            || !matches!(pattern.first(), Some(Node::Leaf(pattern_head)) if pattern_head == "diagnostic")
+        {
+            continue;
+        }
+        for child in &children[2..] {
+            if let Node::List(items) = child {
+                if items.len() == 2 {
+                    if let (Node::Leaf(head), Node::Leaf(code)) = (&items[0], &items[1]) {
+                        if head == "emits" {
+                            codes.insert(code.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+    codes
+}
+
+#[test]
+fn self_types_is_importable() {
+    let path = types_path();
+    let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+#[test]
+fn self_types_declares_required_rules() {
+    let forms = parse_forms();
+
+    let synth_rules = rule_patterns(&forms, "synth");
+    for pattern in REQUIRED_SYNTH_RULES {
+        assert!(
+            synth_rules.contains(*pattern),
+            "missing synth rule {}; got {:?}",
+            pattern,
+            synth_rules
+        );
+    }
+
+    let check_rules = rule_patterns(&forms, "check");
+    for pattern in REQUIRED_CHECK_RULES {
+        assert!(
+            check_rules.contains(*pattern),
+            "missing check rule {}; got {:?}",
+            pattern,
+            check_rules
+        );
+    }
+
+    let diagnostics = diagnostic_codes(&forms);
+    for code in REQUIRED_DIAGNOSTICS {
+        assert!(
+            diagnostics.contains(*code),
+            "missing diagnostic {}; got {:?}",
+            code,
+            diagnostics
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #86.

Adds `lib/self/types.lino`, a self-bootstrap data library that encodes the host bidirectional type layer as links. The file covers synthesis, checking, prenex `forall` expansion, convertibility, scoped context extension, and the stable E020-E024 diagnostic surface.

## Verification

- `node --test js/tests/self-types.test.mjs`
- `npm test`
- `npm run lint:english`
- `cargo test --test self_types_tests`
- `cargo test`

## Notes

The JS self-type test includes a small rule-backed checker that requires the encoded `synth`/`check` rules and compares representative accepted and rejected cases against the host checker.
