### PR TITLE
[J4] Encode operators and aggregators as links

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-09T09:56:33.388Z for PR creation at branch issue-85-bb5ecc6ce050 for issue https://github.com/link-foundation/relative-meta-logic/issues/85
+# Updated: 2026-05-09T15:43:04.444Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T09:56:33.388Z for PR creation at branch issue-85-bb5ecc6ce050 for issue https://github.com/link-foundation/relative-meta-logic/issues/85
-# Updated: 2026-05-09T15:43:04.444Z

--- a/docs/playground/rml-playground-runtime.mjs
+++ b/docs/playground/rml-playground-runtime.mjs
@@ -4142,6 +4142,15 @@ function parseRelationForm(node) {
   if (node.length < 3) {
     throw new RmlError("E032", `Relation declaration for "${name}" must list at least one clause`);
   }
+  if (node.length === 4) {
+    const pattern = node[2];
+    const body = node[3];
+    const patternMatches = Array.isArray(pattern) && pattern.length >= 2 && pattern[0] === name;
+    const bodyLooksLikeClause = Array.isArray(body) && body.length >= 2 && body[0] === name;
+    if (patternMatches && !bodyLooksLikeClause) {
+      return { name, clauses: [[...pattern, body]] };
+    }
+  }
   const clauses = [];
   for (let i = 2; i < node.length; i++) {
     const clause = node[i];

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -2617,9 +2617,11 @@ function isGroundForMode(arg, env) {
 // `(relation <name> <clause>...)` records the clause list of a Twelf-style
 // relation. Each clause is shaped `(<name> arg1 arg2 ... result)`, where
 // `result` is the right-most argument (typically populated for relations
-// whose mode declaration ends with `-output`). The body may contain
-// recursive references to `<name>` whose `+input` slots must be strictly
-// smaller than the head's; the totality checker enforces that decrease.
+// whose mode declaration ends with `-output`). A single-rule shorthand
+// `(relation <name> (<name> arg...) body)` is normalized to that clause shape.
+// The body may contain recursive references to `<name>` whose `+input` slots
+// must be strictly smaller than the head's; the totality checker enforces
+// that decrease.
 //
 // `(total <name>)` triggers `isTotal(env, name)` and lifts the diagnostics
 // it returns into the active diagnostic list. The same `isTotal` helper is
@@ -2632,6 +2634,15 @@ function parseRelationForm(node) {
   const name = node[1];
   if (node.length < 3) {
     throw new RmlError('E032', `Relation declaration for "${name}" must list at least one clause`);
+  }
+  if (node.length === 4) {
+    const pattern = node[2];
+    const body = node[3];
+    const patternMatches = Array.isArray(pattern) && pattern.length >= 2 && pattern[0] === name;
+    const bodyLooksLikeClause = Array.isArray(body) && body.length >= 2 && body[0] === name;
+    if (patternMatches && !bodyLooksLikeClause) {
+      return { name, clauses: [[...pattern, body]] };
+    }
   }
   const clauses = [];
   for (let i = 2; i < node.length; i++) {

--- a/js/tests/self-operators.test.mjs
+++ b/js/tests/self-operators.test.mjs
@@ -1,0 +1,133 @@
+// Tests for `lib/self/operators.lino` (issue #87).
+// The file encodes host operator semantics as relation links and exposes
+// executable templates whose outputs are checked to 12 decimal places.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  decRound,
+  Env,
+  evaluate,
+  evaluateFile,
+  keyOf,
+} from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const operatorsPath = join(repoRoot, 'lib', 'self', 'operators.lino');
+const virtualRootFile = join(repoRoot, 'inline-self-operators-test.lino');
+
+const REQUIRED_RELATIONS = new Map([
+  ['avg', '(avg a b ((a + b) / 2))'],
+  ['min', '(min a b (self.not (self.or (self.not a) (self.not b))))'],
+  ['max', '(max a b (self.or a b))'],
+  ['product', '(product a b (a * b))'],
+  ['probabilistic_sum', '(probabilistic_sum a b (1 - ((1 - a) * (1 - b))))'],
+  ['decimal-sum', '(decimal-sum left right (left + right))'],
+  ['decimal-difference', '(decimal-difference left right (left - right))'],
+  ['decimal-product', '(decimal-product left right (left * right))'],
+  ['decimal-quotient', '(decimal-quotient left right (left / right))'],
+]);
+
+const OUTPUT_CASES = [
+  {
+    name: 'avg',
+    encoded: '(? (ops.avg 0.1 0.2))',
+    host: '(and: avg)\n(? (0.1 and 0.2))',
+  },
+  {
+    name: 'min',
+    encoded: '(? (ops.min 0.42 0.9))',
+    host: '(and: min)\n(? (0.42 and 0.9))',
+  },
+  {
+    name: 'max',
+    encoded: '(? (ops.max 0.42 0.9))',
+    host: '(or: max)\n(? (0.42 or 0.9))',
+  },
+  {
+    name: 'product',
+    encoded: '(? (ops.product 0.2 0.3))',
+    host: '(and: product)\n(? (0.2 and 0.3))',
+  },
+  {
+    name: 'probabilistic_sum',
+    encoded: '(? (ops.probabilistic_sum 0.2 0.3))',
+    host: '(or: probabilistic_sum)\n(? (0.2 or 0.3))',
+  },
+  {
+    name: 'decimal-sum',
+    encoded: '(? (ops.decimal-sum 0.1 0.2))',
+    host: '(? (0.1 + 0.2))',
+  },
+  {
+    name: 'decimal-difference',
+    encoded: '(? (ops.decimal-difference 0.3 0.1))',
+    host: '(? (0.3 - 0.1))',
+  },
+  {
+    name: 'decimal-product',
+    encoded: '(? (ops.decimal-product 0.1 0.2))',
+    host: '(? (0.1 * 0.2))',
+  },
+  {
+    name: 'decimal-quotient',
+    encoded: '(? (ops.decimal-quotient 1 3))',
+    host: '(? (1 / 3))',
+  },
+  {
+    name: 'decimal-quotient-zero',
+    encoded: '(? (ops.decimal-quotient 1 0))',
+    host: '(? (1 / 0))',
+  },
+];
+
+function evaluateFromRoot(source) {
+  return evaluate(source, { file: virtualRootFile });
+}
+
+function assertClean(out) {
+  assert.deepStrictEqual(out.diagnostics, []);
+}
+
+function singleNumber(out, label) {
+  assertClean(out);
+  assert.strictEqual(out.results.length, 1, `${label}: expected one result`);
+  assert.strictEqual(typeof out.results[0], 'number', `${label}: expected numeric result`);
+  return out.results[0];
+}
+
+describe('lib/self/operators.lino', () => {
+  it('is importable as a standard library file', () => {
+    const out = evaluateFile(operatorsPath);
+    assertClean(out);
+  });
+
+  it('declares the operator relations using the issue surface', () => {
+    const env = new Env();
+    const source = readFileSync(operatorsPath, 'utf8');
+    const out = evaluate(source, { env, file: operatorsPath });
+    assertClean(out);
+
+    for (const [name, expectedClause] of REQUIRED_RELATIONS) {
+      const clauses = env.relations.get(name);
+      assert.ok(clauses, `missing relation ${name}`);
+      assert.deepStrictEqual(clauses.map(keyOf), [expectedClause]);
+    }
+  });
+
+  for (const testCase of OUTPUT_CASES) {
+    it(`matches host output for ${testCase.name} to 12 decimal places`, () => {
+      const encoded = singleNumber(evaluateFromRoot(`
+(import "lib/self/operators.lino" as ops)
+${testCase.encoded}
+`), testCase.name);
+      const host = singleNumber(evaluateFromRoot(testCase.host), `${testCase.name} host`);
+
+      assert.strictEqual(decRound(encoded), decRound(host));
+    });
+  }
+});

--- a/lib/self/operators.lino
+++ b/lib/self/operators.lino
@@ -1,0 +1,84 @@
+# RML operators encoded as links for the self-bootstrap layer.
+#
+# The relations are data: each `(relation name (name inputs...) output)`
+# records a host operator or aggregator output expression. The templates below
+# make the same encoded surface executable for conformance tests.
+
+(namespace self)
+
+# Private operator slots used by the executable templates. They are qualified
+# by the `self` namespace, so importing this file does not reconfigure the
+# caller's unqualified logical operators.
+
+(not: not)
+(and: avg)
+(or: max)
+(both: product)
+(neither: probabilistic_sum)
+
+# Aggregator operators.
+
+(relation avg
+  (avg a b)
+  ((a + b) / 2))
+
+(relation min
+  (min a b)
+  (self.not (self.or (self.not a) (self.not b))))
+
+(relation max
+  (max a b)
+  (self.or a b))
+
+(relation product
+  (product a b)
+  (a * b))
+
+(relation probabilistic_sum
+  (probabilistic_sum a b)
+  (1 - ((1 - a) * (1 - b))))
+
+(template (avg a b)
+  (self.and a b))
+
+(template (min a b)
+  (self.not (self.or (self.not a) (self.not b))))
+
+(template (max a b)
+  (self.or a b))
+
+(template (product a b)
+  (self.both a b))
+
+(template (probabilistic_sum a b)
+  (self.neither a b))
+
+# Decimal arithmetic operators.
+
+(relation decimal-sum
+  (decimal-sum left right)
+  (left + right))
+
+(relation decimal-difference
+  (decimal-difference left right)
+  (left - right))
+
+(relation decimal-product
+  (decimal-product left right)
+  (left * right))
+
+(relation decimal-quotient
+  (decimal-quotient left right)
+  (left / right))
+
+(template (decimal-sum left right)
+  (left + right))
+
+(template (decimal-difference left right)
+  (left - right))
+
+(template (decimal-product left right)
+  (left * right))
+
+(template (decimal-quotient left right)
+  (left / right))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5390,8 +5390,20 @@ fn check_mode_at_call(name: &str, args: &[Node], env: &Env) {
 // ---------- Relation declarations & totality (issue #44, D12) ----------
 // Mirrors the JavaScript helpers in `js/src/rml-links.mjs`. The
 // `(relation <name> <clause>...)` form stores the clause list per
-// relation, `(total <name>)` triggers `is_total`, and the same
-// `is_total` helper is exported for programmatic callers.
+// relation, and the single-rule shorthand
+// `(relation <name> (<name> arg...) body)` is normalized to that clause
+// shape. `(total <name>)` triggers `is_total`, and the same helper is
+// exported for programmatic callers.
+
+fn is_relation_clause_head(node: &Node, name: &str) -> bool {
+    match node {
+        Node::List(items) if items.len() >= 2 => match &items[0] {
+            Node::Leaf(head) => head == name,
+            _ => false,
+        },
+        _ => false,
+    }
+}
 
 fn parse_relation_form(children: &[Node]) -> (String, Vec<Node>) {
     // Caller already verified `children[0]` is the leaf `relation`.
@@ -5407,6 +5419,17 @@ fn parse_relation_form(children: &[Node]) -> (String, Vec<Node>) {
             "Relation declaration error: declaration for \"{}\" must list at least one clause",
             name
         );
+    }
+    if children.len() == 4 {
+        let pattern = &children[2];
+        let body = &children[3];
+        if is_relation_clause_head(pattern, &name) && !is_relation_clause_head(body, &name) {
+            if let Node::List(items) = pattern {
+                let mut clause = items.clone();
+                clause.push(body.clone());
+                return (name, vec![Node::List(clause)]);
+            }
+        }
     }
     let mut clauses = Vec::with_capacity(children.len() - 2);
     for (idx, clause) in children[2..].iter().enumerate() {

--- a/rust/tests/self_operators_tests.rs
+++ b/rust/tests/self_operators_tests.rs
@@ -1,0 +1,157 @@
+// Tests for `lib/self/operators.lino` (issue #87).
+//
+// Mirrors js/tests/self-operators.test.mjs so both runtimes keep the encoded
+// operator library importable and tied to host arithmetic/aggregator outputs.
+
+use rml::{
+    dec_round, evaluate, evaluate_file, evaluate_with_env, key_of, Env, EvaluateOptions,
+    EvaluateResult, RunResult,
+};
+use std::fs;
+use std::path::PathBuf;
+
+const REQUIRED_RELATIONS: &[(&str, &str)] = &[
+    ("avg", "(avg a b ((a + b) / 2))"),
+    (
+        "min",
+        "(min a b (self.not (self.or (self.not a) (self.not b))))",
+    ),
+    ("max", "(max a b (self.or a b))"),
+    ("product", "(product a b (a * b))"),
+    (
+        "probabilistic_sum",
+        "(probabilistic_sum a b (1 - ((1 - a) * (1 - b))))",
+    ),
+    ("decimal-sum", "(decimal-sum left right (left + right))"),
+    (
+        "decimal-difference",
+        "(decimal-difference left right (left - right))",
+    ),
+    (
+        "decimal-product",
+        "(decimal-product left right (left * right))",
+    ),
+    (
+        "decimal-quotient",
+        "(decimal-quotient left right (left / right))",
+    ),
+];
+
+const OUTPUT_CASES: &[(&str, &str, &str)] = &[
+    (
+        "avg",
+        "(? (ops.avg 0.1 0.2))",
+        "(and: avg)\n(? (0.1 and 0.2))",
+    ),
+    (
+        "min",
+        "(? (ops.min 0.42 0.9))",
+        "(and: min)\n(? (0.42 and 0.9))",
+    ),
+    (
+        "max",
+        "(? (ops.max 0.42 0.9))",
+        "(or: max)\n(? (0.42 or 0.9))",
+    ),
+    (
+        "product",
+        "(? (ops.product 0.2 0.3))",
+        "(and: product)\n(? (0.2 and 0.3))",
+    ),
+    (
+        "probabilistic_sum",
+        "(? (ops.probabilistic_sum 0.2 0.3))",
+        "(or: probabilistic_sum)\n(? (0.2 or 0.3))",
+    ),
+    (
+        "decimal-sum",
+        "(? (ops.decimal-sum 0.1 0.2))",
+        "(? (0.1 + 0.2))",
+    ),
+    (
+        "decimal-difference",
+        "(? (ops.decimal-difference 0.3 0.1))",
+        "(? (0.3 - 0.1))",
+    ),
+    (
+        "decimal-product",
+        "(? (ops.decimal-product 0.1 0.2))",
+        "(? (0.1 * 0.2))",
+    ),
+    (
+        "decimal-quotient",
+        "(? (ops.decimal-quotient 1 3))",
+        "(? (1 / 3))",
+    ),
+    (
+        "decimal-quotient-zero",
+        "(? (ops.decimal-quotient 1 0))",
+        "(? (1 / 0))",
+    ),
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn operators_path() -> PathBuf {
+    repo_root().join("lib").join("self").join("operators.lino")
+}
+
+fn evaluate_from_root(source: &str) -> EvaluateResult {
+    let virtual_root_file = repo_root().join("inline-self-operators-test.lino");
+    evaluate(source, Some(virtual_root_file.to_str().unwrap()), None)
+}
+
+fn assert_clean(out: &EvaluateResult) {
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+}
+
+fn single_number(out: EvaluateResult, label: &str) -> f64 {
+    assert_clean(&out);
+    assert_eq!(out.results.len(), 1, "{}: expected one result", label);
+    match out.results[0] {
+        RunResult::Num(value) => value,
+        RunResult::Type(ref value) => panic!("{}: expected number, got {}", label, value),
+    }
+}
+
+#[test]
+fn self_operators_is_importable() {
+    let path = operators_path();
+    let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+    assert_clean(&out);
+}
+
+#[test]
+fn self_operators_declares_issue_surface_relations() {
+    let path = operators_path();
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("could not read {}: {}", path.display(), err));
+    let mut env = Env::new(None);
+    let out = evaluate_with_env(&source, Some(path.to_str().unwrap()), &mut env);
+    assert_clean(&out);
+
+    for (name, expected_clause) in REQUIRED_RELATIONS {
+        let clauses = env
+            .relations
+            .get(*name)
+            .unwrap_or_else(|| panic!("missing relation {}", name));
+        let actual: Vec<String> = clauses.iter().map(key_of).collect();
+        assert_eq!(actual, vec![expected_clause.to_string()]);
+    }
+}
+
+#[test]
+fn self_operator_outputs_match_host_to_12_decimal_places() {
+    for (name, encoded, host) in OUTPUT_CASES {
+        let encoded_source = format!(
+            "\n(import \"lib/self/operators.lino\" as ops)\n{}\n",
+            encoded
+        );
+        let encoded_value = single_number(evaluate_from_root(&encoded_source), name);
+        let host_value = single_number(evaluate_from_root(host), &format!("{} host", name));
+
+        assert_eq!(dec_round(encoded_value), dec_round(host_value), "{}", name);
+    }
+}


### PR DESCRIPTION
Fixes #87

## Summary
- Add `lib/self/operators.lino` with encoded relations and executable templates for `avg`, `min`, `max`, `product`, `probabilistic_sum`, and decimal arithmetic.
- Teach the JS and Rust relation parsers to normalize the issue shorthand `(relation name (name args...) output)` into the existing relation clause shape.
- Add mirrored JS/Rust self-operators tests that import the new library, assert the relation clauses, and compare encoded outputs against host operators to 12 decimal places.
- Rebuild the checked-in playground runtime so browser evaluation accepts the same relation shorthand.

## Reproduction and verification
- Before the implementation, `lib/self/operators.lino` did not exist, so a self-operators import test failed immediately.
- The new self-operators tests now verify importability, relation encoding shape, and 12-decimal output equivalence with host arithmetic/aggregators.

## Tests
- `node --test tests/self-operators.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test self_operators_tests`
- `node --test tests/self-operators.test.mjs tests/totality.test.mjs tests/coverage.test.mjs`
- `cargo test --manifest-path rust/Cargo.toml --test self_operators_tests --test totality_tests --test coverage_tests`
- `npm test`
- `npm run lint:english`
- `npm run build:playground`
- `npm run test:playground`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`

UI screenshots are not applicable; this is a self-bootstrap library/parser/test change.