### PR TITLE
[I2] Parity CI job

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,0 +1,46 @@
+name: parity
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/parity.yml'
+      - 'js/**'
+      - 'rust/**'
+      - 'scripts/check-corpus-parity.mjs'
+      - 'scripts/check-corpus-parity.test.mjs'
+      - 'test-corpus/**'
+      - 'README.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/parity.yml'
+      - 'js/**'
+      - 'rust/**'
+      - 'scripts/check-corpus-parity.mjs'
+      - 'scripts/check-corpus-parity.test.mjs'
+      - 'test-corpus/**'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  test-corpus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
+      - name: Install JavaScript dependencies
+        working-directory: js
+        run: npm ci
+      - name: Run parity runner tests
+        run: node --test scripts/check-corpus-parity.test.mjs
+      - name: Build Rust CLI
+        working-directory: rust
+        run: cargo build --bin rml
+      - name: Compare JavaScript and Rust corpus output
+        run: node scripts/check-corpus-parity.mjs

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T12:41:55.633Z for PR creation at branch issue-90-09d1f436800b for issue https://github.com/link-foundation/relative-meta-logic/issues/90

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T12:41:55.633Z for PR creation at branch issue-90-09d1f436800b for issue https://github.com/link-foundation/relative-meta-logic/issues/90

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ Shared regression inputs live in [`/test-corpus/`](./test-corpus/). Both
 implementations walk `test-corpus/*.lino` and compare query results against
 `test-corpus/expected.lino`.
 
+The `parity` GitHub Actions workflow also builds the Rust CLI and runs
+`node scripts/check-corpus-parity.mjs`, which executes every root
+`test-corpus/*.lino` file through both implementations and fails when their
+exit status, stdout, or stderr diverge. To run the same parity gate locally:
+
+```bash
+cd js && npm ci
+cd ..
+cargo build --manifest-path rust/Cargo.toml --bin rml
+node scripts/check-corpus-parity.mjs
+```
+
 ### Literate LiNo
 
 Evaluator entry points also accept literate `.lino.md` files. Prose is ignored

--- a/scripts/check-corpus-parity.mjs
+++ b/scripts/check-corpus-parity.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+function normalizeOutput(text) {
+  return String(text ?? '').replace(/\r\n/g, '\n');
+}
+
+function statusOf(result) {
+  if (result.error) return `spawn error: ${result.error.message}`;
+  if (result.signal) return `signal ${result.signal}`;
+  return String(result.status ?? 0);
+}
+
+function runCommand(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    maxBuffer: 16 * 1024 * 1024,
+  });
+
+  return {
+    status: result.status,
+    signal: result.signal,
+    stdout: normalizeOutput(result.stdout),
+    stderr: normalizeOutput(result.stderr),
+    error: result.error ?? null,
+  };
+}
+
+export function compareCommandResults(jsResult, rustResult) {
+  const failures = [];
+  if (statusOf(jsResult) !== statusOf(rustResult)) {
+    failures.push(`exit status differs: js=${statusOf(jsResult)} rust=${statusOf(rustResult)}`);
+  }
+  if (jsResult.stdout !== rustResult.stdout) {
+    failures.push([
+      'stdout differs:',
+      '--- JavaScript stdout ---',
+      jsResult.stdout || '<empty>',
+      '--- Rust stdout ---',
+      rustResult.stdout || '<empty>',
+    ].join('\n'));
+  }
+  if (jsResult.stderr !== rustResult.stderr) {
+    failures.push([
+      'stderr differs:',
+      '--- JavaScript stderr ---',
+      jsResult.stderr || '<empty>',
+      '--- Rust stderr ---',
+      rustResult.stderr || '<empty>',
+    ].join('\n'));
+  }
+  return failures;
+}
+
+function parseArgs(argv) {
+  const options = {
+    corpusDir: resolve(repoRoot, 'test-corpus'),
+    jsCli: resolve(repoRoot, 'js', 'src', 'rml-links.mjs'),
+    rustBin: resolve(repoRoot, 'rust', 'target', 'debug', process.platform === 'win32' ? 'rml.exe' : 'rml'),
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      return { ...options, help: true };
+    }
+    if (arg === '--corpus-dir' && argv[i + 1]) {
+      options.corpusDir = resolve(repoRoot, argv[++i]);
+      continue;
+    }
+    if (arg === '--js-cli' && argv[i + 1]) {
+      options.jsCli = resolve(repoRoot, argv[++i]);
+      continue;
+    }
+    if (arg === '--rust-bin' && argv[i + 1]) {
+      options.rustBin = resolve(repoRoot, argv[++i]);
+      continue;
+    }
+    throw new Error(`unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function listCorpusFiles(corpusDir) {
+  return readdirSync(corpusDir)
+    .filter((name) => name.endsWith('.lino') && name !== 'expected.lino')
+    .sort();
+}
+
+function printHelp() {
+  console.log([
+    'Usage: node scripts/check-corpus-parity.mjs [options]',
+    '',
+    'Runs every root test-corpus/*.lino input through the JavaScript and Rust CLIs',
+    'and fails if exit status, stdout, or stderr diverge.',
+    '',
+    'Options:',
+    '  --corpus-dir <dir>  Corpus directory, defaults to test-corpus',
+    '  --js-cli <file>     JavaScript CLI, defaults to js/src/rml-links.mjs',
+    '  --rust-bin <file>   Built Rust CLI, defaults to rust/target/debug/rml',
+  ].join('\n'));
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  if (!existsSync(options.jsCli)) {
+    throw new Error(`JavaScript CLI not found: ${options.jsCli}`);
+  }
+  if (!existsSync(options.rustBin)) {
+    throw new Error(`Rust CLI not found: ${options.rustBin}\nRun: cargo build --manifest-path rust/Cargo.toml --bin rml`);
+  }
+
+  const files = listCorpusFiles(options.corpusDir);
+  if (files.length === 0) {
+    throw new Error(`no .lino corpus files found in ${options.corpusDir}`);
+  }
+
+  const failures = [];
+  for (const file of files) {
+    const filePath = join(options.corpusDir, file);
+    const jsResult = runCommand(process.execPath, [options.jsCli, filePath]);
+    const rustResult = runCommand(options.rustBin, [filePath]);
+    const fileFailures = compareCommandResults(jsResult, rustResult);
+    if (fileFailures.length > 0) {
+      failures.push(`${file}\n  ${fileFailures.join('\n  ')}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`Corpus parity failed for ${failures.length} file(s):\n\n${failures.join('\n\n')}`);
+    return 1;
+  }
+
+  console.log(`Corpus parity passed for ${files.length} file(s).`);
+  return 0;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main();
+  } catch (err) {
+    console.error(err && err.message ? err.message : String(err));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/check-corpus-parity.test.mjs
+++ b/scripts/check-corpus-parity.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { compareCommandResults } from './check-corpus-parity.mjs';
+
+function result({ status = 0, stdout = '', stderr = '', signal = null, error = null } = {}) {
+  return { status, stdout, stderr, signal, error };
+}
+
+describe('corpus parity comparison', () => {
+  it('accepts identical command results', () => {
+    assert.deepStrictEqual(
+      compareCommandResults(
+        result({ stdout: '1\n(type of x)\n' }),
+        result({ stdout: '1\n(type of x)\n' }),
+      ),
+      [],
+    );
+  });
+
+  it('rejects output divergence', () => {
+    const failures = compareCommandResults(
+      result({ stdout: '1\n' }),
+      result({ stdout: '0\n' }),
+    );
+
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /stdout differs/);
+  });
+
+  it('rejects status divergence', () => {
+    const failures = compareCommandResults(
+      result({ status: 0 }),
+      result({ status: 1 }),
+    );
+
+    assert.equal(failures.length, 1);
+    assert.match(failures[0], /exit status differs/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #90.

- Adds a dedicated `parity` GitHub Actions workflow for PRs and pushes that touch JS, Rust, the shared corpus, or the parity runner.
- Adds `scripts/check-corpus-parity.mjs` to run every root `test-corpus/*.lino` file through the JavaScript CLI and built Rust CLI, failing on exit status, stdout, or stderr divergence.
- Adds focused Node tests for the parity comparison logic and README documentation for running the gate locally.

## How to Reproduce / Test

Before this PR, the repository had shared JS/Rust corpus fixture tests but no CI job that directly compared implementation CLI output for `test-corpus/*.lino`.

Manual parity gate:

```bash
cd js && npm ci
cd ..
cargo build --manifest-path rust/Cargo.toml --bin rml
node scripts/check-corpus-parity.mjs
```

Local verification run on this branch:

- `node --test scripts/check-corpus-parity.test.mjs` - pass
- `cd js && npm ci` - pass
- `cd rust && cargo build --bin rml` - pass
- `node scripts/check-corpus-parity.mjs` - pass, corpus parity passed for 1 file
- `cd js && npm test` - pass, 954 tests
- `cargo test --manifest-path rust/Cargo.toml` - pass

No UI changes; screenshots are not applicable.