### PR TITLE
[J6] Bootstrap encoded RML corpus CI

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,38 @@
+name: bootstrap
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/bootstrap.yml'
+      - 'js/**'
+      - 'lib/self/**'
+      - 'test-corpus/**'
+      - 'README.md'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/bootstrap.yml'
+      - 'js/**'
+      - 'lib/self/**'
+      - 'test-corpus/**'
+      - 'README.md'
+  workflow_dispatch:
+
+jobs:
+  encoded-rml-corpus:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: js/package-lock.json
+      - name: Install JavaScript dependencies
+        working-directory: js
+        run: npm ci
+      - name: Replay corpus through encoded RML
+        working-directory: js
+        run: npm run test:bootstrap

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T12:54:00.085Z for PR creation at branch issue-91-d1ff8a6a8a5d for issue https://github.com/link-foundation/relative-meta-logic/issues/91

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T12:54:00.085Z for PR creation at branch issue-91-d1ff8a6a8a5d for issue https://github.com/link-foundation/relative-meta-logic/issues/91

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ cargo build --manifest-path rust/Cargo.toml --bin rml
 node scripts/check-corpus-parity.mjs
 ```
 
+The `bootstrap` GitHub Actions workflow runs the host-driven encoded evaluator
+from [`lib/self/evaluator.lino`](./lib/self/evaluator.lino) over every root
+`test-corpus/*.lino` file and fails if any encoded RML result diverges from the
+host JavaScript evaluator. To run the same bootstrap gate locally:
+
+```bash
+cd js
+npm ci
+npm run test:bootstrap
+```
+
 ### Literate LiNo
 
 Evaluator entry points also accept literate `.lino.md` files. Prose is ignored

--- a/js/package.json
+++ b/js/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test": "node --test tests/ ../scripts/",
+    "test:bootstrap": "node --test --test-name-pattern \"replays self corpus\" tests/self-evaluator.test.mjs",
     "docs": "jsdoc -c ../docs/api/jsdoc.json",
     "build:playground": "node ../scripts/build-playground.mjs",
     "test:playground": "node --test ../scripts/playground.test.mjs",


### PR DESCRIPTION
Fixes #91

## Summary
- Add a dedicated `bootstrap` GitHub Actions workflow for PRs and main-branch pushes that touch the encoded evaluator, JS runtime/tests, shared corpus, or README documentation.
- Add `npm run test:bootstrap` as the local entry point for replaying every root `test-corpus/*.lino` file through the host-driven encoded evaluator from `lib/self/evaluator.lino` and comparing against the host JavaScript evaluator.
- Document the bootstrap CI gate and local command in the README.

## Reproduction and verification
Before this PR, the encoded evaluator corpus replay existed only inside the JS self-evaluator tests and was not wired to a dedicated CI job. The new workflow runs the same corpus replay on relevant changes and fails if encoded RML output diverges from host output.

## Tests
- `cd js && npm ci`
- `cd js && npm run test:bootstrap`
- `cd js && npm test`
- `node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/*/*.lino`
- `cargo build --manifest-path rust/Cargo.toml --bin rml`
- `node scripts/check-corpus-parity.mjs`
- `cd js && npm run build:playground`
- `cd js && npm run test:playground`
- `cd js && npm run docs -- --destination ../_site/api/js`
- `cargo doc --manifest-path rust/Cargo.toml --no-deps --target-dir target/api-docs/rust`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`

UI screenshots are not applicable; this is a CI and documentation change.
