### PR TITLE
[H7] Tutorials and walkthroughs

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T14:24:08.938Z for PR creation at branch issue-93-9990c681b24d for issue https://github.com/link-foundation/relative-meta-logic/issues/93

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T14:24:08.938Z for PR creation at branch issue-93-9990c681b24d for issue https://github.com/link-foundation/relative-meta-logic/issues/93

--- a/README.md
+++ b/README.md
@@ -31,9 +31,22 @@ For versioning, deprecations, and release expectations, see
 
 ## Tutorials
 
-- [RML in RML self-bootstrap tutorial](./docs/tutorials/self-bootstrap.md) - A beginner-friendly narrative walkthrough of
-  the encoded grammar, evaluator, type layer, operators, metatheorem checker,
-  and bootstrap CI gate.
+- [Tutorial path](./docs/tutorials/) - Start here for the progressive
+  walkthrough sequence.
+- [Classical logic tutorial](./docs/tutorials/classical.md) - Boolean truth
+  values, declarations, assignments, queries, and the classical library.
+- [Fuzzy logic tutorial](./docs/tutorials/fuzzy.md) - Continuous truth values,
+  degree-based predicates, fuzzy connectives, and fuzzy-control helpers.
+- [Probabilistic reasoning tutorial](./docs/tutorials/probabilistic.md) -
+  Independent events, probabilistic sum, Bayesian-network helpers, and Bayes
+  calculations.
+- [Typed LiNo tutorial](./docs/tutorials/typed.md) - Type declarations,
+  universes, `Pi`, `lambda`, `apply`, and type queries.
+- [Metatheory tutorial](./docs/tutorials/metatheory.md) - Modes, coverage,
+  totality, termination, and the `rml-meta` CLI.
+- [RML in RML self-bootstrap tutorial](./docs/tutorials/self-bootstrap.md) -
+  The capstone walkthrough of the encoded grammar, evaluator, type layer,
+  operators, metatheorem checker, and bootstrap CI gate.
 
 ## Overview
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,54 @@
+# RML Tutorial Path
+
+This directory is the beginner path for Relative Meta-Logic. Read the
+tutorials in order: each one adds one idea that the next tutorial relies on.
+
+The tutorials use runnable source files from [`../../examples/`](../../examples/)
+and reusable libraries from [`../../lib/`](../../lib/). Commands are written for
+the repository root unless a section says otherwise.
+
+| Step | Tutorial | What it introduces | Runnable source |
+|------|----------|--------------------|-----------------|
+| 1 | [Classical logic tutorial](./classical.md) | Boolean truth, assignments, queries, and classical laws | [`../../examples/classical-logic.lino`](../../examples/classical-logic.lino) |
+| 2 | [Fuzzy logic tutorial](./fuzzy.md) | Continuous truth values and degree-based predicates | [`../../examples/fuzzy-logic.lino`](../../examples/fuzzy-logic.lino) |
+| 3 | [Probabilistic reasoning tutorial](./probabilistic.md) | Product, probabilistic sum, networks, and Bayes-style calculations | [`../../examples/bayesian-network.lino`](../../examples/bayesian-network.lino) |
+| 4 | [Typed LiNo tutorial](./typed.md) | Type facts, universes, dependent products, lambdas, and applications | [`../../examples/dependent-types.lino`](../../examples/dependent-types.lino) |
+| 5 | [Metatheory tutorial](./metatheory.md) | Modes, coverage, totality, termination, and the metatheorem checker | [`../../docs/METATHEOREMS.md`](../../docs/METATHEOREMS.md) |
+| 6 | [RML in RML self-bootstrap tutorial](./self-bootstrap.md) | The encoded grammar, evaluator, type layer, operators, and bootstrap gate | [`../../lib/self/evaluator.lino`](../../lib/self/evaluator.lino) |
+
+## Quick Setup
+
+Install the JavaScript dependencies once:
+
+```bash
+cd js
+npm install
+cd ..
+```
+
+Then run any tutorial example from the repository root:
+
+```bash
+node js/src/rml-links.mjs examples/classical-logic.lino
+```
+
+For parity with the Rust implementation, run the same file through the Rust
+CLI:
+
+```bash
+cargo run --manifest-path rust/Cargo.toml -- examples/classical-logic.lino
+```
+
+## What To Read Afterward
+
+After the tutorial path, the main reference documents are:
+
+- [`../../README.md`](../../README.md) for the language overview and examples.
+- [`../../ARCHITECTURE.md`](../../ARCHITECTURE.md) for the JavaScript/Rust
+  parity design.
+- [`../../docs/KERNEL.md`](../../docs/KERNEL.md) for the typed-kernel rules.
+- [`../../docs/METATHEOREMS.md`](../../docs/METATHEOREMS.md) for metatheorem
+  checking details.
+- [`../../docs/CONCEPTS-COMPARISION.md`](../../docs/CONCEPTS-COMPARISION.md)
+  and [`../../docs/FEATURE-COMPARISION.md`](../../docs/FEATURE-COMPARISION.md)
+  for positioning against nearby systems.

--- a/docs/tutorials/classical.md
+++ b/docs/tutorials/classical.md
@@ -1,0 +1,135 @@
+# Classical Logic Tutorial
+
+Classical logic is the first RML tutorial because it uses the smallest truth
+space: every proposition is either false (`0`) or true (`1`). The same query
+surface will be reused by the fuzzy, probabilistic, typed, and metatheory
+tutorials.
+
+Run the full example:
+
+```bash
+node js/src/rml-links.mjs examples/classical-logic.lino
+```
+
+The source is [`../../examples/classical-logic.lino`](../../examples/classical-logic.lino).
+
+## 1. Select Boolean Semantics
+
+The example starts by selecting two-valued truth and familiar Boolean
+connectives:
+
+```lino
+(valence: 2)
+(and: min)
+(or: max)
+```
+
+`(valence: 2)` quantizes truth values to `0` and `1`. With that choice:
+
+- `and` as `min` means a conjunction is true only when both sides are true.
+- `or` as `max` means a disjunction is true when either side is true.
+- `not` is available by default and flips truth across the current range.
+
+These settings make the rest of the file behave like ordinary Boolean logic.
+
+## 2. Declare Propositions
+
+RML source is made of links. A simple proposition is declared with the same
+shape used throughout the repository:
+
+```lino
+(p: p is p)
+(q: q is q)
+```
+
+This records `p` and `q` as terms that can be used in later expressions. The
+declaration does not say whether either proposition is true; it only introduces
+the names.
+
+## 3. Assign Truth Values
+
+Truth assignments attach a probability to an expression:
+
+```lino
+((p = true) has probability 1)
+((q = true) has probability 0)
+```
+
+In Boolean mode, these are ordinary truth facts:
+
+- `p` is true.
+- `q` is false.
+
+The word `probability` is still used because the same evaluator also supports
+continuous and probabilistic values in later tutorials.
+
+## 4. Ask Queries
+
+A query is written with `?`:
+
+```lino
+(? (p = true))
+(? (q = true))
+```
+
+The evaluator prints one result per query. For this example, those two lines
+produce `1` and `0`.
+
+The same syntax works for compound expressions:
+
+```lino
+(? ((p = true) and (q = true)))
+(? ((p = true) or (q = true)))
+```
+
+Because `p` is true and `q` is false, the conjunction evaluates to `0` and the
+disjunction evaluates to `1`.
+
+## 5. Check Classical Laws
+
+The example closes with three standard laws:
+
+```lino
+(? ((p = true) or (not (p = true))))
+(? ((p = true) and (not (p = true))))
+(? (not (not (p = true))))
+```
+
+Read these as:
+
+- Excluded middle: `p` or not `p`.
+- Non-contradiction: not both `p` and not `p`.
+- Double negation: not not `p` is equivalent to `p`.
+
+With `valence: 2`, these behave like the classical laws they model.
+
+## 6. Reuse the Classical Library
+
+After the surface syntax is clear, read
+[`../../lib/classical/core.lino`](../../lib/classical/core.lino). It installs the
+same Boolean settings and exports named templates under the `classical`
+namespace:
+
+```lino
+(import "lib/classical/core.lino" as cl)
+
+(p: p is p)
+((p = true) has probability 1)
+
+(? (cl.excluded-middle (p = true)))
+(? (cl.non-contradiction (p = true)))
+```
+
+Use the library when you want named law schemas instead of spelling each
+connective by hand.
+
+## What To Remember
+
+Classical RML programs have three moving parts:
+
+1. Configure the truth space with `(valence: 2)`.
+2. Declare terms and assign truth values.
+3. Query expressions with `(? ...)`.
+
+The next tutorial removes the Boolean restriction and lets truth values live
+anywhere in `[0, 1]`.

--- a/docs/tutorials/fuzzy.md
+++ b/docs/tutorials/fuzzy.md
@@ -1,0 +1,140 @@
+# Fuzzy Logic Tutorial
+
+Fuzzy logic keeps the same declaration, assignment, and query forms from the
+classical tutorial, but it allows intermediate truth values. A proposition can
+be true to degree `0.8`, false to degree `0.2`, or anywhere between.
+
+Run the full example:
+
+```bash
+node js/src/rml-links.mjs examples/fuzzy-logic.lino
+```
+
+The source is [`../../examples/fuzzy-logic.lino`](../../examples/fuzzy-logic.lino).
+
+## 1. Keep Continuous Truth Values
+
+The fuzzy example does not set `(valence: 2)`. RML's default valence is
+continuous, so values are not quantized to `0` or `1`.
+
+It does choose the standard Zadeh-style connectives:
+
+```lino
+(and: min)
+(or: max)
+```
+
+With these settings:
+
+- `and` returns the lower degree.
+- `or` returns the higher degree.
+- `not` maps a degree `x` to `1 - x`.
+
+## 2. Assign Degrees
+
+The example declares three subjects and assigns a degree to the predicate
+`tall`:
+
+```lino
+(a: a is a)
+(b: b is b)
+(c: c is c)
+
+((a = tall) has probability 0.8)
+((b = tall) has probability 0.3)
+((c = tall) has probability 0.6)
+```
+
+These assignments are better read as membership degrees:
+
+- `a` is tall to degree `0.8`.
+- `b` is tall to degree `0.3`.
+- `c` is tall to degree `0.6`.
+
+The syntax still says `has probability` because RML uses one numeric truth
+channel for Boolean, fuzzy, probabilistic, and many-valued logic.
+
+## 3. Query Membership
+
+Direct queries return the assigned degrees:
+
+```lino
+(? (a = tall))
+(? (b = tall))
+```
+
+The first prints `0.8`; the second prints `0.3`.
+
+## 4. Combine Fuzzy Predicates
+
+Fuzzy conjunction takes the smaller degree:
+
+```lino
+(? ((a = tall) and (b = tall)))
+```
+
+The result is `0.3`, because the weaker side limits the conjunction.
+
+Fuzzy disjunction takes the larger degree:
+
+```lino
+(? ((a = tall) or (b = tall)))
+```
+
+The result is `0.8`.
+
+Negation complements the degree:
+
+```lino
+(? (not (a = tall)))
+```
+
+The result is `0.2`.
+
+## 5. Read Nested Queries Inside Out
+
+The last query combines all three subjects:
+
+```lino
+(? ((a = tall) and ((b = tall) or (c = tall))))
+```
+
+Read it inside out:
+
+1. `(b = tall) or (c = tall)` is `max(0.3, 0.6)`, so it is `0.6`.
+2. `(a = tall) and 0.6` is `min(0.8, 0.6)`, so it is `0.6`.
+
+This is the same query shape as classical logic, but the intermediate values
+are now meaningful rather than rounded away.
+
+## 6. Reuse the Fuzzy Library
+
+The reusable fuzzy helpers live in
+[`../../lib/probabilistic/fuzzy.lino`](../../lib/probabilistic/fuzzy.lino). They
+provide named templates for membership, rule activation, and a small centroid
+calculation:
+
+```lino
+(import "lib/probabilistic/fuzzy.lino" as fz)
+
+(fz.membership temperature hot 0.8)
+(fz.membership humidity wet 0.6)
+
+(? (fz.rule (fz.degree temperature hot) (fz.degree humidity wet)))
+(? (fz.two-point-centroid 0.6 0.8 0.4 0.3))
+```
+
+Use this library when the source reads more naturally as fuzzy-control data
+than as raw equality assignments.
+
+## What To Remember
+
+Fuzzy RML keeps the classical workflow but changes the meaning of truth values:
+
+1. Leave valence continuous.
+2. Assign degrees between `0` and `1`.
+3. Choose aggregators such as `min` and `max`.
+4. Read compound query results as degrees, not just pass/fail answers.
+
+The next tutorial keeps continuous values and changes the aggregators to model
+probabilistic events.

--- a/docs/tutorials/metatheory.md
+++ b/docs/tutorials/metatheory.md
@@ -1,0 +1,135 @@
+# Metatheory Tutorial
+
+Metatheory asks whether an encoded system has the structural properties its
+rules claim to have. In RML, the current metatheorem checker focuses on
+Twelf-style relation checks: modes, coverage, totality, and termination.
+
+Start by reading the typed example from the previous tutorial, especially the
+HOAS-oriented source in
+[`../../examples/lambda-calculus.lino`](../../examples/lambda-calculus.lino).
+Then read the reference document:
+[`../../docs/METATHEOREMS.md`](../../docs/METATHEOREMS.md).
+
+Run the canonical metatheorem example:
+
+```bash
+cd js
+node src/rml-meta.mjs ../experiments/metatheorem-plus.lino
+cd ..
+```
+
+## 1. Relations Are Link Clauses
+
+The reference example encodes addition on natural numbers:
+
+```lino
+(inductive Natural
+  (constructor zero)
+  (constructor (succ (Pi (Natural n) Natural))))
+(mode plus +input +input -output)
+(relation plus
+  (plus zero n n)
+  (plus (succ m) n (succ (plus m n))))
+```
+
+The `relation` clauses are data. They describe how `plus` behaves over the
+constructors of `Natural`.
+
+## 2. Modes Explain Direction
+
+The mode declaration says which arguments are inputs and which are outputs:
+
+```lino
+(mode plus +input +input -output)
+```
+
+For `plus`, the first two slots are inputs and the third slot is the output.
+The checker uses this information when deciding whether a recursive call is
+structurally smaller and whether all input constructors are covered.
+
+## 3. Coverage Checks Constructor Cases
+
+Coverage asks whether every input constructor has a matching relation clause.
+For `Natural`, a complete recursive relation usually needs:
+
+- a `zero` case;
+- a `succ` case.
+
+If a relation omits the `succ` case, the checker reports a stable diagnostic
+such as `E037`. The full error shape is documented in
+[`../../docs/METATHEOREMS.md`](../../docs/METATHEOREMS.md).
+
+## 4. Totality Checks Recursive Calls
+
+Totality asks whether the relation can produce an output for every covered
+input shape. For structurally recursive relations, this means recursive calls
+must make progress on an input argument.
+
+The `plus` relation passes because the recursive clause changes:
+
+```lino
+(plus (succ m) n (succ (plus m n)))
+```
+
+into a recursive call on `m`, which is smaller than `(succ m)`.
+
+## 5. Termination Checks Definitions
+
+The metatheorem checker also iterates `(define ...)` forms and runs the
+termination checker. This catches recursive definitions that do not decrease
+under the accepted structural measure.
+
+This matters for larger encoded systems: a relation can have complete-looking
+clauses but still be unsafe if a helper definition loops.
+
+## 6. Use the CLI in CI
+
+The JavaScript CLI:
+
+```bash
+cd js
+node src/rml-meta.mjs ../experiments/metatheorem-plus.lino
+```
+
+The Rust CLI:
+
+```bash
+cd rust
+cargo run --bin rml-meta -- ../experiments/metatheorem-plus.lino
+```
+
+Both CLIs print the same report and exit with status `0` only when all checks
+pass. A successful run includes:
+
+```text
+Relations:
+  OK: plus
+  - totality: pass
+  - coverage: pass
+All metatheorems hold.
+```
+
+## 7. Connect Back To Typed LiNo
+
+Metatheory depends on the earlier typed layer:
+
+- Inductive constructors name the input shapes.
+- `Pi` appears inside constructor types.
+- Relation clauses are links over those constructors.
+- Mode declarations tell the checker which slots are structurally meaningful.
+
+That is why this tutorial comes after
+[`./typed.md`](./typed.md) and before
+[`./self-bootstrap.md`](./self-bootstrap.md). The self-bootstrap tutorial shows
+how the same style is used to describe RML's own grammar, evaluator, operators,
+typed layer, and metatheorem surface.
+
+## What To Remember
+
+The metatheorem checker is a structural guardrail for encoded systems:
+
+1. `mode` tells the checker how to read relation arguments.
+2. Coverage checks constructor cases.
+3. Totality checks relation behavior over input shapes.
+4. Termination checks recursive definitions.
+5. The `rml-meta` CLI turns those checks into a local and CI-friendly gate.

--- a/docs/tutorials/probabilistic.md
+++ b/docs/tutorials/probabilistic.md
@@ -1,0 +1,145 @@
+# Probabilistic Reasoning Tutorial
+
+Probabilistic RML uses the same numeric truth channel as fuzzy logic, but the
+numbers are read as event probabilities. The key change is the choice of
+aggregators: independent conjunction uses multiplication, and disjunction uses
+probabilistic sum.
+
+Run the full example:
+
+```bash
+node js/src/rml-links.mjs examples/bayesian-network.lino
+```
+
+The source is [`../../examples/bayesian-network.lino`](../../examples/bayesian-network.lino).
+
+## 1. Configure Probability Operators
+
+The example starts with four event names:
+
+```lino
+(cloudy: cloudy is cloudy)
+(sprinkler: sprinkler is sprinkler)
+(rain: rain is rain)
+(wet-grass: wet-grass is wet-grass)
+```
+
+Then it configures the operators:
+
+```lino
+(and: product)
+(or: probabilistic_sum)
+```
+
+For independent events:
+
+- `product` reads `A and B` as `P(A) * P(B)`.
+- `probabilistic_sum` reads `A or B` as `1 - (1 - P(A)) * (1 - P(B))`.
+
+These are aggregator choices, not special syntax. The evaluator already knows
+how to ask queries over assignments.
+
+## 2. Assign Marginal Probabilities
+
+The example assigns event probabilities directly:
+
+```lino
+((cloudy = true) has probability 0.5)
+((sprinkler = true) has probability 0.3)
+((rain = true) has probability 0.5)
+```
+
+Direct queries return those numbers:
+
+```lino
+(? (cloudy = true))
+(? (sprinkler = true))
+(? (rain = true))
+```
+
+## 3. Compute Joint and Union Probabilities
+
+Conjunction becomes a joint probability for independent events:
+
+```lino
+(? ((cloudy = true) and (rain = true)))
+```
+
+The result is `0.25`, because `0.5 * 0.5 = 0.25`.
+
+Disjunction becomes probabilistic union:
+
+```lino
+(? ((sprinkler = true) or (rain = true)))
+```
+
+The result is `0.65`, because `1 - (1 - 0.3) * (1 - 0.5) = 0.65`.
+
+The prefix form works for more than two arguments:
+
+```lino
+(? (and (cloudy = true) (sprinkler = true) (rain = true)))
+```
+
+This multiplies all three probabilities.
+
+## 4. Encode a Network Shape
+
+The example comments describe the classic sprinkler network:
+
+```text
+cloudy -> sprinkler -> wet-grass
+cloudy -> rain      -> wet-grass
+```
+
+Plain links are enough to name the events, and probability assignments are
+enough to answer the simple marginal and independent-event queries. Conditional
+probability tables can also be recorded as links when a program needs them.
+
+The example closes with an arithmetic chain-rule calculation:
+
+```lino
+(? (((0.99 * 0.15) + (0.9 * 0.15)) + ((0.9 * 0.35) + (0.01 * 0.35))))
+```
+
+The evaluator treats arithmetic as numeric computation and prints `0.602`.
+
+## 5. Reuse the Bayesian Library
+
+The Bayesian helper library lives in
+[`../../lib/probabilistic/bayesian.lino`](../../lib/probabilistic/bayesian.lino).
+It packages network descriptions, priors, conditionals, joint/union templates,
+and Bayes calculations under the `bayesian` namespace:
+
+```lino
+(import "lib/probabilistic/bayesian.lino" as bn)
+
+(bn.network sprinkler-network
+  (nodes cloudy sprinkler rain wet-grass)
+  (edges (bn.edge cloudy sprinkler)
+         (bn.edge cloudy rain)
+         (bn.edge sprinkler wet-grass)
+         (bn.edge rain wet-grass)))
+
+(bn.prior rain 0.5)
+(bn.prior sprinkler 0.3)
+
+(? (bn.joint (rain = true) (sprinkler = true)))
+(? (bn.union (rain = true) (sprinkler = true)))
+(? (bn.bayes 0.95 0.01 0.059))
+```
+
+The library does not hide the logic. It gives names to common link patterns so
+larger probabilistic files stay readable.
+
+## What To Remember
+
+Probabilistic RML is fuzzy RML with probability-oriented aggregators:
+
+1. Use `product` for independent conjunction.
+2. Use `probabilistic_sum` for independent union.
+3. Use assignments for priors and arithmetic for explicit calculations.
+4. Move repeated network shapes into templates from the Bayesian library.
+
+The next tutorial introduces typed terms so links can carry richer structure
+than truth values alone.

--- a/docs/tutorials/typed.md
+++ b/docs/tutorials/typed.md
@@ -1,0 +1,152 @@
+# Typed LiNo Tutorial
+
+The previous tutorials treated links as propositions with numeric truth values.
+Typed LiNo adds another layer: links can also record that a term belongs to a
+type, that a function has a dependent product type, or that applying a lambda
+reduces to a value.
+
+Run the full example:
+
+```bash
+node js/src/rml-links.mjs examples/dependent-types.lino
+```
+
+The source is [`../../examples/dependent-types.lino`](../../examples/dependent-types.lino).
+The reference rules are in [`../../docs/KERNEL.md`](../../docs/KERNEL.md).
+
+## 1. Declare Types As Links
+
+The example starts with the self-referential root type:
+
+```lino
+(Type: Type Type)
+```
+
+RML allows this because it is a dynamic, many-valued system. Paradoxical or
+circular facts do not crash the evaluator; they are handled by the configured
+truth semantics.
+
+User types use the same declaration pattern:
+
+```lino
+(Natural: Type Natural)
+(Boolean: Type Boolean)
+```
+
+Read `(Natural: Type Natural)` as "install `Natural` as a term of type `Type`."
+
+## 2. Declare Typed Terms
+
+Constructors and values use prefix type notation:
+
+```lino
+(zero: Natural zero)
+(true-val: Boolean true-val)
+(false-val: Boolean false-val)
+```
+
+After these declarations, type-membership queries can ask whether a term has a
+type:
+
+```lino
+(? (zero of Natural))
+(? (Natural of Type))
+(? (Type of Type))
+```
+
+The output is a truth value. In the default range, successful type membership
+prints `1`.
+
+## 3. Use Dependent Product Types
+
+`Pi` forms a dependent product. The example declares a successor function:
+
+```lino
+(succ: (Pi (Natural n) Natural))
+```
+
+Read this as a function that accepts a `Natural` named `n` and returns a
+`Natural`. When the result type does not depend on the binder, this is the
+ordinary function type pattern.
+
+## 4. Define and Apply Lambdas
+
+The example defines identity as a lambda:
+
+```lino
+(identity: lambda (Natural x) x)
+```
+
+Then it applies the lambda:
+
+```lino
+(? (apply identity 0.7))
+```
+
+`apply` runs the kernel's capture-avoiding substitution. In this case the body
+is just `x`, so the query reduces to the argument and prints `0.7`.
+
+The same mechanism supports inline lambdas and higher-order examples. The
+HOAS-focused example in
+[`../../examples/lambda-calculus.lino`](../../examples/lambda-calculus.lino)
+shows how object-language binders can be represented with RML's own binders.
+
+## 5. Ask For Types
+
+Type queries use `(type of ...)`:
+
+```lino
+(? (type of zero))
+```
+
+This prints `Natural` after the earlier `(zero: Natural zero)` declaration.
+
+The same typed layer coexists with truth assignments:
+
+```lino
+((zero = zero) has probability 1)
+(? (zero = zero))
+```
+
+RML does not switch languages when it moves from logic to types. Both are link
+facts in the same environment.
+
+## 6. Use Universe Levels When Needed
+
+The example also shows stratified universes:
+
+```lino
+(Type 0)
+(Type 1)
+(? ((Type 0) of (Type 1)))
+```
+
+The typed kernel treats `(Type N)` as belonging to `(Type N+1)`. This form is
+useful for fragments that need Lean/Rocq-style universe structure, while
+`(Type: Type Type)` remains available for self-referential RML examples.
+
+## 7. Read the Kernel Reference
+
+After the example, read [`../../docs/KERNEL.md`](../../docs/KERNEL.md) for the
+formal surface:
+
+- Type declarations and typed term declarations.
+- Universe hierarchy rules.
+- `Pi` formation.
+- `lambda` formation.
+- `apply` reduction.
+- Convertibility and normalization.
+- The bidirectional checker and its diagnostics.
+
+## What To Remember
+
+Typed LiNo adds structure without leaving the link model:
+
+1. Types are declared as links.
+2. Typed terms use `(name: TypeName name)`.
+3. Functions use `Pi`, `lambda`, and `apply`.
+4. Type questions are ordinary queries, either `(term of Type)` or
+   `(type of term)`.
+
+The next tutorial uses typed declarations and relation clauses as input to
+metatheorem checks.

--- a/scripts/docs.test.mjs
+++ b/scripts/docs.test.mjs
@@ -176,3 +176,77 @@ describe('self-bootstrap tutorial documentation', () => {
     }
   });
 });
+
+describe('progressive tutorial documentation', () => {
+  const tutorials = [
+    ['Classical logic tutorial', './docs/tutorials/classical.md'],
+    ['Fuzzy logic tutorial', './docs/tutorials/fuzzy.md'],
+    ['Probabilistic reasoning tutorial', './docs/tutorials/probabilistic.md'],
+    ['Typed LiNo tutorial', './docs/tutorials/typed.md'],
+    ['Metatheory tutorial', './docs/tutorials/metatheory.md'],
+    ['RML in RML self-bootstrap tutorial', './docs/tutorials/self-bootstrap.md'],
+  ];
+
+  it('links the tutorial path from the README in learning order', () => {
+    const readme = read('README.md');
+
+    let previous = -1;
+    for (const [label, href] of tutorials) {
+      const markdown = `[${label}](${href})`;
+      const index = readme.indexOf(markdown);
+      assert.ok(index > previous, `${markdown} missing or out of order`);
+      previous = index;
+    }
+  });
+
+  it('provides a docs/tutorials index in the same learning order', () => {
+    const indexDoc = read('docs/tutorials/README.md');
+    const orderedPaths = [
+      './classical.md',
+      './fuzzy.md',
+      './probabilistic.md',
+      './typed.md',
+      './metatheory.md',
+      './self-bootstrap.md',
+    ];
+
+    let previous = -1;
+    for (const expected of orderedPaths) {
+      const index = indexDoc.indexOf(expected);
+      assert.ok(index > previous, `${expected} missing or out of order`);
+      previous = index;
+    }
+  });
+
+  it('connects each tutorial to its runnable source material', () => {
+    const expectedReferences = {
+      'docs/tutorials/classical.md': [
+        '../../examples/classical-logic.lino',
+        '../../lib/classical/core.lino',
+      ],
+      'docs/tutorials/fuzzy.md': [
+        '../../examples/fuzzy-logic.lino',
+        '../../lib/probabilistic/fuzzy.lino',
+      ],
+      'docs/tutorials/probabilistic.md': [
+        '../../examples/bayesian-network.lino',
+        '../../lib/probabilistic/bayesian.lino',
+      ],
+      'docs/tutorials/typed.md': [
+        '../../examples/dependent-types.lino',
+        '../../docs/KERNEL.md',
+      ],
+      'docs/tutorials/metatheory.md': [
+        '../../docs/METATHEOREMS.md',
+        '../../examples/lambda-calculus.lino',
+      ],
+    };
+
+    for (const [docPath, references] of Object.entries(expectedReferences)) {
+      const doc = read(docPath);
+      for (const expected of references) {
+        assert.ok(doc.includes(expected), `${docPath} missing ${expected}`);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #93

## Summary
- Add `docs/tutorials/README.md` as the ordered learning path from classical logic through self-bootstrap.
- Add beginner-focused tutorials for classical, fuzzy, probabilistic, typed, and metatheory workflows, reusing existing runnable examples and libraries.
- Expand the README Tutorials section so all required tutorials are linked in learning order, keeping the existing self-bootstrap capstone.
- Add documentation regression coverage for the README links, tutorial index order, and source-material references.
- Remove the prepared-branch `.gitkeep` placeholder now that the PR has real content.

## Reproduction and verification
Before this PR, the progressive tutorial path was missing: only the self-bootstrap tutorial existed, the README did not link classical/probabilistic/typed tutorials, and `docs/tutorials/README.md` did not exist. The new `progressive tutorial documentation` regression failed on those missing artifacts before the tutorials were added. It now passes and guards the issue acceptance criteria.

## Tests
- `node --test scripts/docs.test.mjs`
- `node js/src/rml-links.mjs examples/classical-logic.lino`
- `node js/src/rml-links.mjs examples/fuzzy-logic.lino`
- `node js/src/rml-links.mjs examples/bayesian-network.lino`
- `node js/src/rml-links.mjs examples/dependent-types.lino`
- `cd js && node src/rml-meta.mjs ../experiments/metatheorem-plus.lino`
- `cd js && npm test`
- `cd js && npm run lint:english`
- `cargo test --manifest-path rust/Cargo.toml`
- `git diff --check`

UI screenshots are not applicable; this is a documentation-only change.