### PR TITLE
[H8] Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+node_modules
+**/node_modules
+target
+**/target
+docs
+vscode
+experiments
+**/experiments
+*.log
+.env
+.env.*
+.DS_Store

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,67 @@
+name: docker
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/docker.yml'
+      - '.dockerignore'
+      - 'docker/**'
+      - 'js/**'
+      - 'rust/**'
+      - 'examples/**'
+      - 'lib/**'
+      - 'test-corpus/**'
+      - 'scripts/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/docker.yml'
+      - '.dockerignore'
+      - 'docker/**'
+      - 'js/**'
+      - 'rust/**'
+      - 'examples/**'
+      - 'lib/**'
+      - 'test-corpus/**'
+      - 'scripts/**'
+  workflow_dispatch:
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build JavaScript image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.js
+          tags: rml-js:ci
+          load: true
+          cache-from: type=gha,scope=rml-js
+          cache-to: type=gha,scope=rml-js,mode=max
+
+      - name: Smoke-test JavaScript image
+        run: docker run --rm rml-js:ci
+
+      - name: Build Rust image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.rust
+          tags: rml-rust:ci
+          load: true
+          cache-from: type=gha,scope=rml-rust
+          cache-to: type=gha,scope=rml-rust,mode=max
+
+      - name: Smoke-test Rust image
+        run: docker run --rm rml-rust:ci
+
+      - name: Validate docker-compose configuration
+        run: docker compose -f docker/docker-compose.yml config

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-11T09:50:52.379Z for PR creation at branch issue-94-be12020e9535 for issue https://github.com/link-foundation/relative-meta-logic/issues/94

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-11T09:50:52.379Z for PR creation at branch issue-94-be12020e9535 for issue https://github.com/link-foundation/relative-meta-logic/issues/94

--- a/README.md
+++ b/README.md
@@ -108,6 +108,33 @@ cargo run -- ../examples/demo.lino
 cargo run -- export lean ../examples/lean-export-basic.lino -o out.lean
 ```
 
+### Docker
+
+Container images for both implementations live under
+[`docker/`](./docker/) and are built on every pull request by the
+`docker` GitHub Actions workflow. From the repository root:
+
+```bash
+# JavaScript implementation
+docker build -f docker/Dockerfile.js -t rml-js .
+docker run --rm rml-js                                     # runs examples/demo.lino
+
+# Rust implementation
+docker build -f docker/Dockerfile.rust -t rml-rust .
+docker run --rm rml-rust                                   # runs examples/demo.lino
+```
+
+Both services are also wired into [`docker/docker-compose.yml`](./docker/docker-compose.yml):
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm rml-js
+docker compose -f docker/docker-compose.yml run --rm rml-rust
+```
+
+See [`docker/README.md`](./docker/README.md) for build cache layout,
+mounting local `.lino` files, and using the extra `rml-check` and
+`rml-meta` binaries from the Rust image.
+
 Examples are language-agnostic and live in [`/examples/`](./examples/). Both
 implementations execute the same files and are required to produce identical
 output (enforced by `examples/expected.lino` and the shared-examples tests).

--- a/docker/Dockerfile.js
+++ b/docker/Dockerfile.js
@@ -1,0 +1,38 @@
+# Image for the JavaScript implementation of Relative Meta-Logic (RML).
+#
+# Build (from the repository root):
+#   docker build -f docker/Dockerfile.js -t rml-js .
+#
+# Run the demo knowledge base:
+#   docker run --rm rml-js
+#
+# Run an arbitrary .lino file from the bundled examples:
+#   docker run --rm rml-js node src/rml-links.mjs ../examples/classical-logic.lino
+#
+# Mount a local file to evaluate it:
+#   docker run --rm -v "$PWD/my.lino:/work/my.lino" rml-js \
+#     node src/rml-links.mjs /work/my.lino
+
+FROM node:20-alpine
+
+WORKDIR /repo/js
+
+# Install JS dependencies first so they are cached across source changes.
+COPY js/package.json js/package-lock.json ./
+RUN npm ci --omit=dev
+
+# Copy the JS sources alongside the cached node_modules.
+COPY js/src ./src
+COPY js/tests ./tests
+
+# Copy the language-agnostic resources the entry points read at runtime.
+WORKDIR /repo
+COPY examples ./examples
+COPY lib ./lib
+COPY test-corpus ./test-corpus
+COPY scripts ./scripts
+
+WORKDIR /repo/js
+
+ENTRYPOINT ["node", "src/rml-links.mjs"]
+CMD ["../examples/demo.lino"]

--- a/docker/Dockerfile.rust
+++ b/docker/Dockerfile.rust
@@ -1,0 +1,53 @@
+# Multi-stage image for the Rust implementation of Relative Meta-Logic (RML).
+#
+# Build (from the repository root):
+#   docker build -f docker/Dockerfile.rust -t rml-rust .
+#
+# Run the demo knowledge base:
+#   docker run --rm rml-rust
+#
+# Run an arbitrary .lino file from the bundled examples:
+#   docker run --rm rml-rust /repo/examples/classical-logic.lino
+#
+# Mount a local file to evaluate it:
+#   docker run --rm -v "$PWD/my.lino:/work/my.lino" rml-rust /work/my.lino
+
+# ---------- Build stage ----------
+FROM rust:1.83-slim-bookworm AS builder
+
+WORKDIR /build
+
+# Copy only the manifests first so the dependency layer is cached.
+COPY rust/Cargo.toml rust/Cargo.lock ./
+RUN mkdir -p src src/bin \
+    && echo "fn main() {}" > src/main.rs \
+    && echo "" > src/lib.rs \
+    && echo "fn main() {}" > src/bin/rml-check.rs \
+    && echo "fn main() {}" > src/bin/rml-meta.rs \
+    && cargo build --release --bin rml --bin rml-check --bin rml-meta \
+    && rm -rf src
+
+# Build the real sources.
+COPY rust/src ./src
+RUN cargo build --release --bin rml --bin rml-check --bin rml-meta
+
+# ---------- Runtime stage ----------
+FROM debian:bookworm-slim
+
+# hadolint ignore=DL3008
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /repo
+
+COPY --from=builder /build/target/release/rml /usr/local/bin/rml
+COPY --from=builder /build/target/release/rml-check /usr/local/bin/rml-check
+COPY --from=builder /build/target/release/rml-meta /usr/local/bin/rml-meta
+
+COPY examples ./examples
+COPY lib ./lib
+COPY test-corpus ./test-corpus
+
+ENTRYPOINT ["rml"]
+CMD ["/repo/examples/demo.lino"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,97 @@
+# Docker
+
+Reproducible container images for both implementations of Relative
+Meta-Logic (RML).
+
+## Files
+
+- [`Dockerfile.js`](./Dockerfile.js) - Node.js 20 image that runs the
+  JavaScript evaluator (`js/src/rml-links.mjs`).
+- [`Dockerfile.rust`](./Dockerfile.rust) - Multi-stage Rust image that
+  compiles the `rml`, `rml-check`, and `rml-meta` binaries and ships
+  them on a minimal Debian runtime.
+- [`docker-compose.yml`](./docker-compose.yml) - Compose file that
+  builds and runs both services with the repository mounted read-only
+  at `/repo`.
+
+Build context for both Dockerfiles is the repository root, so commands
+below are run from there.
+
+## Quick start
+
+### JavaScript implementation
+
+Build and run the demo knowledge base:
+
+```bash
+docker build -f docker/Dockerfile.js -t rml-js .
+docker run --rm rml-js
+```
+
+Run an arbitrary `.lino` file from the bundled examples:
+
+```bash
+docker run --rm rml-js node src/rml-links.mjs ../examples/classical-logic.lino
+```
+
+Evaluate a local file by mounting it:
+
+```bash
+docker run --rm -v "$PWD/my.lino:/work/my.lino" rml-js \
+  node src/rml-links.mjs /work/my.lino
+```
+
+### Rust implementation
+
+Build and run the demo knowledge base:
+
+```bash
+docker build -f docker/Dockerfile.rust -t rml-rust .
+docker run --rm rml-rust
+```
+
+Run an arbitrary `.lino` file from the bundled examples:
+
+```bash
+docker run --rm rml-rust /repo/examples/classical-logic.lino
+```
+
+Evaluate a local file by mounting it:
+
+```bash
+docker run --rm -v "$PWD/my.lino:/work/my.lino" rml-rust /work/my.lino
+```
+
+The Rust image also exposes the `rml-check` and `rml-meta` binaries:
+
+```bash
+docker run --rm --entrypoint rml-check rml-rust /repo/examples/classical-logic.lino
+docker run --rm --entrypoint rml-meta rml-rust /repo/examples/classical-logic.lino
+```
+
+## docker compose
+
+The Compose file builds both images and mounts the repository
+read-only so local edits to `examples/` and `lib/` are visible inside
+the containers without rebuilding.
+
+```bash
+docker compose -f docker/docker-compose.yml build
+docker compose -f docker/docker-compose.yml run --rm rml-js
+docker compose -f docker/docker-compose.yml run --rm rml-rust
+```
+
+Override the command to run a different `.lino` file:
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm rml-js \
+  ../examples/classical-logic.lino
+docker compose -f docker/docker-compose.yml run --rm rml-rust \
+  /repo/examples/classical-logic.lino
+```
+
+## Continuous integration
+
+Both images are built on every pull request that touches `docker/`,
+the implementations, the shared examples, or the corpora. See
+[`.github/workflows/docker.yml`](../.github/workflows/docker.yml).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+# docker-compose for the Relative Meta-Logic (RML) reference implementations.
+#
+# From the repository root:
+#   docker compose -f docker/docker-compose.yml build
+#   docker compose -f docker/docker-compose.yml run --rm rml-js
+#   docker compose -f docker/docker-compose.yml run --rm rml-rust
+#
+# Both services mount the repository read-only at /repo so local edits to
+# `.lino` files under `examples/` and `lib/` are visible inside the
+# container without rebuilding.
+
+services:
+  rml-js:
+    image: rml-js
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.js
+    volumes:
+      - ..:/repo:ro
+    working_dir: /repo/js
+    command: ["../examples/demo.lino"]
+
+  rml-rust:
+    image: rml-rust
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.rust
+    volumes:
+      - ..:/repo:ro
+    working_dir: /repo
+    command: ["/repo/examples/demo.lino"]

--- a/docs/FEATURE-COMPARISION.md
+++ b/docs/FEATURE-COMPARISION.md
@@ -88,7 +88,7 @@ Core logical concepts are compared separately in
 | Public source repository | Yes | Yes | N/A/theory | Yes | Yes | Yes | Yes | Yes | Yes/downloads | Yes | Yes | Yes |
 | Active language/runtime ecosystem | Node.js/Rust | Standard ML legacy | N/A | Haskell/Cabal | Isabelle/ML | OCaml/opam | Lean/Lake | Lean/Lake | Isabelle | OCaml/opam | Teyjus/OCaml ecosystem | Python/Docker |
 | CI-friendly batch mode | Yes | Yes | N/A | Yes | Yes | Yes | Yes | Host | Yes | Yes | Yes | Yes |
-| Docker support | No repository-level Docker | No | N/A | No | Ecosystem possible | Ecosystem possible | Ecosystem possible | No | No | No | No | Yes |
+| Docker support | Yes: `docker/Dockerfile.js`, `docker/Dockerfile.rust`, and `docker/docker-compose.yml` for both implementations, built in CI | No | N/A | No | Ecosystem possible | Ecosystem possible | Ecosystem possible | No | No | No | No | Yes |
 | Package manager install | npm/cargo layout; package release dependent | Source/distribution | N/A | Hackage/Cabal | Isabelle distribution | OPAM/packages | Lake/elan | Lake/GitHub | AFP download/releases | OPAM | Depends on implementation | pip requirements/manual |
 | Generated API/reference docs | Part | Part | N/A | Hackage page | Yes | Yes | Yes | Yes | Yes | Part | Part | Manual |
 | Tutorials/walkthroughs | README/examples | Yes | Papers/docs | README/examples | Yes | Yes | Yes | Catalogue/docs | Entry docs | Yes | Manuals/examples | README/manual |


### PR DESCRIPTION
## Summary

Adds repository-level Docker support so both reference implementations
of Relative Meta-Logic run in reproducible containers, fulfilling the
[H8] acceptance criteria (image builds in CI, documented in README).

Fixes #94.

## Changes

- `docker/Dockerfile.js` — Node.js 20 (alpine) image for the JavaScript
  evaluator (`js/src/rml-links.mjs`). Caches `npm ci --omit=dev` on the
  manifests so source-only changes do not invalidate the dependency
  layer.
- `docker/Dockerfile.rust` — multi-stage image: a `rust:1.83-slim`
  builder compiles `rml`, `rml-check`, and `rml-meta` with a
  cached-dependency pre-pass, and a `debian:bookworm-slim` runtime
  copies the three binaries onto `PATH`.
- `docker/docker-compose.yml` — `rml-js` and `rml-rust` services that
  build from `..` and mount the repo read-only at `/repo` so local
  `.lino` edits are visible without rebuilding.
- `docker/README.md` — usage walkthrough (build/run, mounting files,
  switching the entrypoint to `rml-check`/`rml-meta`).
- `.github/workflows/docker.yml` — builds both images with
  `docker/build-push-action@v6` (with `type=gha` cache), smoke-tests
  each by running the bundled `examples/demo.lino`, and validates the
  Compose file with `docker compose ... config`. Triggers on changes
  under `docker/`, the implementations, `examples/`, `lib/`,
  `test-corpus/`, and `scripts/`.
- `.dockerignore` — keeps `.git`, `node_modules`, `target`, etc. out
  of the build context.
- `README.md` — new **Docker** subsection under Quick Start with the
  basic `docker build` / `docker run` / `docker compose` commands.
- `docs/FEATURE-COMPARISION.md` — the "Docker support" row now records
  the new repository-level Dockerfiles and compose file instead of
  "No repository-level Docker".

## Acceptance criteria

- [x] Image builds in CI (`.github/workflows/docker.yml`, both images
      with smoke tests).
- [x] Documented in README (`README.md` + `docker/README.md`).

## Test plan

- [x] `node --test scripts/docs.test.mjs scripts/lint-english.test.mjs`
      — 49 tests pass after README/FEATURE-COMPARISION edits.
- [x] `cd js && npm test` — full JavaScript suite (959 tests) still
      passes.
- [x] `cd js && npm run lint:english` — clean.
- [x] `cd rust && cargo build --bin rml --bin rml-check --bin rml-meta`
      — builds successfully (matches the binaries copied out of the
      Rust image).
- [x] `node js/src/rml-links.mjs examples/demo.lino` and
      `rust/target/debug/rml examples/demo.lino` produce identical
      output (`0.5` / `1`) — same command run as the Docker
      `ENTRYPOINT` + `CMD`.
- [x] `hadolint docker/Dockerfile.js docker/Dockerfile.rust` — clean
      (DL3008 explicitly ignored for `ca-certificates` only).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on
      `docker/docker-compose.yml` and `.github/workflows/docker.yml`
      — valid YAML.
- [ ] CI-side: the new `docker` workflow builds both images and the
      smoke tests run `examples/demo.lino` through each one
      (verified once CI runs on this PR).