### PR TITLE
Universal CST converters for Rust/JS/Lean/Rocq (issue #138)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-11T14:00:52.960Z for PR creation at branch issue-138-559eef049155 for issue https://github.com/link-foundation/relative-meta-logic/issues/138

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-11T14:00:52.960Z for PR creation at branch issue-138-559eef049155 for issue https://github.com/link-foundation/relative-meta-logic/issues/138

--- a/docs/case-studies/issue-138/README.md
+++ b/docs/case-studies/issue-138/README.md
@@ -1,0 +1,368 @@
+# Case Study: Universal CST converters between RML/`.lino` and Rust, JavaScript, Lean, Rocq
+
+**Issue:** [#138 — We need to make sure we have relative meta logic converters to and from Rust/JavaScript, and also Lean, Rocq](https://github.com/link-foundation/relative-meta-logic/issues/138)
+**Pull request:** [#169](https://github.com/link-foundation/relative-meta-logic/pull/169)
+**Sibling artefacts in this folder:** [`requirements.md`](./requirements.md), [`existing-tools.md`](./existing-tools.md), [`solution-plans.md`](./solution-plans.md), [`cst-model.md`](./cst-model.md), [`acceptance-tests.md`](./acceptance-tests.md), [`risks-and-open-questions.md`](./risks-and-open-questions.md).
+
+## Table of contents
+
+1. [Executive summary](#executive-summary)
+2. [Goal restated and scoped](#goal-restated-and-scoped)
+3. [Where RML stands today](#where-rml-stands-today)
+4. [Why the four target languages are hard](#why-the-four-target-languages-are-hard)
+5. [Key design decisions](#key-design-decisions)
+6. [Proposed conversion architecture](#proposed-conversion-architecture)
+7. [Per-language conversion plan](#per-language-conversion-plan)
+8. [Phased roadmap and recommended issue split](#phased-roadmap-and-recommended-issue-split)
+9. [Test strategy](#test-strategy)
+10. [Existing components and libraries that help](#existing-components-and-libraries-that-help)
+11. [Open questions](#open-questions)
+12. [References](#references)
+
+---
+
+## Executive summary
+
+Issue #138 asks for **lossless concrete-syntax-tree (CST) converters** between RML's `.lino` notation and four host languages — Rust, JavaScript, Lean 4 and Rocq — so that `.lino` can serve as a **universal intermediate CST**. The conversion must round-trip without data loss, preserve comments, names and (where it matters) whitespace, and cover enough of each language's concepts that translation is unambiguous.
+
+This is a substantially larger ambition than the converters that already exist in RML today: `rml export lean`, `rml export rocq` and `rml extract js|rust` are one-way, narrow-fragment, *AST-level* exporters (see [`docs/LEAN_EXPORT.md`](../../LEAN_EXPORT.md), [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md), [`README.md`](../../../README.md#program-extraction-issue-f7)). Filling the gap to a true universal CST converter is roughly the size of the J-EPIC parity programme tracked under [issue #95](https://github.com/link-foundation/relative-meta-logic/issues/95): it is a multi-phase, multi-issue effort.
+
+The recommended approach is to:
+
+1. Adopt a **trivia-bearing concrete-syntax tree** for `.lino`, modelled on rust-analyzer's rowan CST and Roslyn/libsyntax (see [Easy Lossless Trees with Nom and Rowan](https://blog.kiranshila.com/post/easy_cst), [rust-analyzer syntax docs](https://rust-lang.github.io/rust-analyzer/syntax/index.html)). Whitespace, comments and original token spelling are first-class.
+2. Encode each host language as a small set of **CST shapes in `.lino`** — one `.lino` link family per host-language production — so that round-trip is purely a tree mapping, not a guess.
+3. Use **existing, vendor-blessed parsers** for each host language (`syn`/`proc-macro2` for Rust, `swc`/`recast` for JavaScript, `Lean.Syntax` via the Lean toolchain for Lean 4, `coq-lsp` `--record_comments` and the Rocq vernac parser for Rocq) rather than reimplementing them. RML owns only the `.lino` ↔ host-CST mapping.
+4. Ship the work as an epic split into 8 phases (A–H), each landing a vertical slice (one direction, one language, one test set), with bootstrap and round-trip tests gating CI.
+
+This case study captures the data we collected, lists every requirement extracted from issue #138, names existing libraries that solve each part, and proposes one or more solution plans per requirement. It does not itself land the converters; their implementation is broken out into the per-language phase issues recommended in [§ Phased roadmap](#phased-roadmap-and-recommended-issue-split).
+
+---
+
+## Goal restated and scoped
+
+Quoting issue #138 directly:
+
+> So it is possible to convert between lino notation and other languages, we also should use CST, so we should be able to encode comments, every variable and other name, and even whitespace if needed.
+>
+> So for example it should be possible to convert lean to .lino (relative meta logic) and after that convert it to JavaScript.
+>
+> And from JavaScript to .lino, to Rocq and so on. So .lino with relative meta logic dialect will become universal intermediate CST (not AST) language.
+>
+> Meaning conversion should not result in data loss, and should be as precise as possible.
+>
+> And relative meta logic should have enough concepts to strictly without ambiguity encode each concept of Rocq/Lean/Rust/JavaScript.
+
+Concretely the goal is:
+
+| Goal | Scope |
+|------|-------|
+| **G1** | A `.lino` CST dialect (the "relative meta-logic CST dialect") that can encode every syntactic concept of each target language. |
+| **G2** | Bidirectional converters between `.lino` CST and the host language CST for Rust, JavaScript, Lean 4 and Rocq. |
+| **G3** | Round-trip lossless: `host → .lino → host` equals the original source byte-for-byte (modulo a documented canonicalisation list). |
+| **G4** | Cross-language transpilation: `host_A → .lino → host_B` produces compilable source in `host_B` for the **shared semantic fragment** of the two languages, and explicit, structured `unrepresentable` markers elsewhere. |
+| **G5** | Test coverage proportional to the surface area: each production has at least one positive and one negative round-trip test. |
+| **G6** | Documentation of how to add a fifth language, so the universal-CST claim is supported by the ease of extension. |
+
+This case study scopes G1–G6 and produces a plan for each. Item G3 (byte-for-byte) is the hardest acceptance criterion; we discuss in [§ Key design decisions](#key-design-decisions) what minimal canonicalisation we recommend allowing.
+
+---
+
+## Where RML stands today
+
+The current repository already has *parts* of this story:
+
+| Capability | Status | Location |
+|------------|--------|----------|
+| LiNo as the surface notation for RML | Yes | [`ARCHITECTURE.md`](../../../ARCHITECTURE.md) |
+| AST-level export from typed `.lino` fragment to Lean 4 | Yes (one-way) | [`docs/LEAN_EXPORT.md`](../../LEAN_EXPORT.md), [`js/src/lean-export.mjs`](../../../js/src/lean-export.mjs), [`rust/src/lean_export.rs`](../../../rust/src/lean_export.rs) |
+| AST-level export from typed `.lino` fragment to Rocq | Yes (one-way) | [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md), [`js/src/rml-rocq.mjs`](../../../js/src/rml-rocq.mjs), [`rust/src/rocq.rs`](../../../rust/src/rocq.rs) |
+| AST-level extraction from typed `.lino` fragment to JavaScript and Rust | Yes (one-way, λ-only) | [`README.md`](../../../README.md#program-extraction-issue-f7), [`js/src/rml-links.mjs`](../../../js/src/rml-links.mjs) (`Program extraction (issue #66)`), [`rust/src/lib.rs`](../../../rust/src/lib.rs) (`Program extraction (issue #66)`) |
+| Comment preservation in `.lino` | **No** — `#`-comments are stripped during tokenisation per [`ARCHITECTURE.md` § Stage 2](../../../ARCHITECTURE.md#stage-2-tokenization-and-ast-construction) |
+| Whitespace preservation in `.lino` | **No** — only structural `(` and `)` survive |
+| Identifier-collision detection on export | Yes | [`docs/ROCQ-EXPORT.md` § Supported subset](../../ROCQ-EXPORT.md#supported-subset) |
+| Import direction (host → `.lino`) | **No** for all four targets |
+| Cross-language transpilation through `.lino` | **No** |
+
+So we have one-way **AST** exporters for a typed sub-fragment, no importers, and no CST infrastructure. The four importers plus the CST infrastructure are what issue #138 asks us to add.
+
+The relative size of the new work, against the parity epic in [issue #95](https://github.com/link-foundation/relative-meta-logic/issues/95), is roughly:
+
+- **Smaller** than D-phase (typed kernel maturation) — the type theory is reused.
+- **Comparable** to F-phase (bridges to mature provers and ATP/SMT) — same shape (one issue per target).
+- **Larger** than F1/F2 (Lean/Rocq export) alone, because importers and round-trip tests are harder than emitters.
+
+---
+
+## Why the four target languages are hard
+
+Each target has its own pitfalls; treating them uniformly would be a mistake.
+
+### Rust
+
+- The official tokeniser, `proc_macro2`, and the parser `syn` operate on **proc-macro token streams** which strip `//` line comments and most whitespace. Doc-comments (`///`) survive as `#[doc = "..."]` attributes. See [syn](https://github.com/dtolnay/syn) and [proc_macro2 docs](https://docs.rs/proc-macro2). This means `syn` alone cannot give us a lossless CST.
+- For a lossless tree we want **rust-analyzer's rowan-based syntax tree** (`ra_ap_syntax`, see [Lossless Syntax Trees](https://dev.to/cad97/lossless-syntax-trees-280c) and the [rust-analyzer syntax module docs](https://rust-lang.github.io/rust-analyzer/syntax/index.html)). Rowan stores **trivia** (whitespace and comments) as ordinary tokens attached to leaves.
+- Macros are an open problem: rust-analyzer keeps the unexpanded form alongside an expanded view; we should mirror this by storing macro invocations as opaque `.lino` blocks until a separate expansion pass is requested.
+
+### JavaScript / TypeScript
+
+- The de-facto fast parser is **SWC** (`swc_ecma_parser`, [crate](https://lib.rs/crates/swc_ecma_parser)). SWC's `Parser::take_comments` API and `Comments` trait let us harvest a comments table alongside the AST; recast and Babel preserve comments by attaching them to surrounding nodes. See [SWC `swc_common::comments`](https://rustdoc.swc.rs/swc_common/comments/trait.Comments.html), [SWC #4079 — full-fidelity comments](https://github.com/swc-project/swc/discussions/4079).
+- For round-trip pretty printing we want **`recast`** (used inside `jscodeshift`) — its philosophy of "mutate AST nodes rather than rebuild" matches the `.lino` strategy of round-tripping through the CST shape, not the token stream. See [jscodeshift docs](https://jscodeshift.com/overview/introduction).
+
+### Lean 4
+
+- Lean 4 ships its own surface CST type, `Lean.Syntax`, and a pretty-printer pipeline (delaborator → parenthesizer → formatter, see [Lean 4 Pretty Printing chapter](https://leanprover-community.github.io/lean4-metaprogramming-book/extra/03_pretty-printing.html)). With `pp.all := true`, the round-trip `Syntax → format → Syntax` is documented to be the inverse of macro expansion.
+- Trivia (comments, whitespace) live inside `Lean.Syntax.SourceInfo` and are preserved by the parser.
+- Because Lean's macro system is extensible, our `.lino` CST has to either (a) carry the unexpanded syntax kind verbatim or (b) re-expand on import. The same tension exists in Rocq.
+
+### Rocq
+
+- Rocq's parser (`pcoq.ml`, `clexer.ml`) is built on Camlp5 and can be extended **by user code** (`Notation`/`Tactic Notation`), so a stand-alone parser is not feasible in the general case — see [coq/dev/doc/parsing.md](https://github.com/coq/coq/blob/master/dev/doc/parsing.md). The advice from upstream is to delegate parsing to Rocq itself.
+- The replacement for SerAPI is **`coq-lsp`**. As of v0.2.x, `coq-lsp` supports comment recording behind `--record_comments`; comments are returned in `doc.comments` (see [rocq-community/rocq-lsp](https://github.com/rocq-community/rocq-lsp)). This is the recommended channel for both directions.
+- For tooling that does not need full elaboration, the small **`tree-sitter-rocq`** grammars by [`lamg/tree-sitter-rocq`](https://github.com/lamg/tree-sitter-rocq) and [`krathul/tree-sitter-rocq`](https://github.com/krathul/tree-sitter-rocq) cover a useful subset and are CST-shaped.
+
+The takeaway: **we do not write any of these parsers ourselves**. We bind to the canonical one per language and own only the tree mapping.
+
+---
+
+## Key design decisions
+
+### D1. `.lino` becomes a CST, not just a syntax for ASTs
+
+Today `.lino` tokenisation strips `#` comments and discards whitespace. We extend the LiNo *evaluator* contract with a CST view:
+
+- Every original byte of the source is reachable through a `lino-cst.*` link, with three categories of nodes:
+  - **Structural** — the existing parenthesised list nodes.
+  - **Token** — leaf nodes carrying the original lexeme.
+  - **Trivia** — whitespace runs and comments, attached to the *following* token (the Roslyn/libsyntax convention) by default, with a configurable "leading vs trailing" policy.
+- A round-trip is a tree walk that emits leaves in document order, concatenating trivia and tokens — exactly the rowan strategy described in [Easy Lossless Trees with Nom and Rowan](https://blog.kiranshila.com/post/easy_cst).
+
+This preserves backward compatibility: the existing AST view is the same tree with trivia and tokens hidden. The diagnostic, evaluator and check tooling can opt-in to the CST view per request.
+
+### D2. Each host language gets its own `.lino` CST dialect
+
+Rather than try to find a "common AST" between Rust and Lean, we declare four sibling `.lino` dialects:
+
+- `lino-cst.rust.*` — one link tag per `ra_ap_syntax` `SyntaxKind` (matches [Ungrammar](https://rust-analyzer.github.io//blog/2020/10/24/introducing-ungrammar.html) productions).
+- `lino-cst.js.*` — one link tag per `estree` / `swc_ecma_ast` node kind.
+- `lino-cst.lean.*` — one link tag per `Lean.SyntaxNodeKind`.
+- `lino-cst.rocq.*` — one link tag per `Vernacexpr`/`constr_expr` constructor, as serialised by `coq-lsp`.
+
+The result is **four faithful CST mirrors of the host languages**, all expressed inside `.lino`. Cross-language transpilation (`host_A → host_B`) is then a separate, named transformation that consumes one dialect and emits another, with the explicit semantic mapping documented and tested.
+
+This pattern is what the **Spoofax** / **SDF3** community calls "concrete syntax in the IR" and is the same idea behind [CrossTL](https://arxiv.org/abs/2508.21256). It avoids the "lowest-common-denominator AST" trap that has historically killed universal transpiler projects.
+
+### D3. The shared semantic dialect (`lino-cst.shared.*`) is opt-in
+
+Issue #138 emphasises that conversion must be unambiguous. To achieve that, the **default** transformation is dialect-preserving: `Rust → lino-cst.rust → Rust` is byte-equal, and `Rust → lino-cst.rust → JavaScript` is **explicitly undefined** unless a translator from `lino-cst.rust` to `lino-cst.js` exists.
+
+We additionally define a shared **semantic** dialect `lino-cst.shared.*` that encodes the intersection (typed λ-calculus + ADT/inductive types + Pi + records + match) and is the existing typed RML fragment. Translation through `lino-cst.shared` is the cross-language path and is the only one that may lose host-specific concepts. The four host dialects are the *lossless* path; the shared dialect is the *bridge*.
+
+### D4. Round-trip is tested as a contract
+
+Following the [coq-serapi round-trip infrastructure contributed by Karl Palmskog](https://github.com/rocq-archive/coq-serapi/blob/main/CHANGES.md) and rust-analyzer's "syntax round-trip" tests, we adopt:
+
+- `host_source` → `.lino` CST → `host_source'` and assert byte equality, modulo a documented list of canonicalisations.
+- A failure produces a diff and a structured diagnostic; CI gates on green.
+
+### D5. The four converters all ship in both JS and Rust
+
+To preserve the existing dual-implementation discipline of RML (see the parity-CI work in [issue #93/#168](https://github.com/link-foundation/relative-meta-logic/pull/168)), every converter has a JavaScript implementation and a Rust implementation. Where the upstream parser only exists for one of the two host runtimes (e.g. `syn` is Rust-only, `Lean.Syntax` is Lean-only), the other implementation either calls out via a subprocess or uses a JS port (e.g. for SWC the JS implementation can use `@swc/core`, the Rust one uses `swc_ecma_parser`).
+
+---
+
+## Proposed conversion architecture
+
+```
+              ┌─────────────────────────┐
+   .rs ─────► │  syn + ra_ap_syntax     │ ───►  lino-cst.rust.*
+   .mjs ────► │  swc_ecma_parser        │ ───►  lino-cst.js.*
+   .lean ───► │  Lean.Syntax (subproc)  │ ───►  lino-cst.lean.*
+   .v ──────► │  coq-lsp --record_       │ ───►  lino-cst.rocq.*
+              │  comments                │
+              └─────────────────────────┘
+                            │
+                            ▼
+               ┌──────────────────────────┐
+               │  lino-cst.* trees (RML)  │  ← lossless, comments, trivia
+               └──────────────────────────┘
+                  │            ▲          │
+                  │ shared/    │ identity │
+                  ▼            │          ▼
+              lino-cst.       (per-       lino-cst.<other>.*
+              shared.*         dialect)
+                  │
+                  ▼
+                <host-B source>
+```
+
+The four upstream parser bindings, the four `.lino` dialect serialisers, the shared-dialect translator, and the four printers are the work items in [§ Phased roadmap](#phased-roadmap-and-recommended-issue-split).
+
+---
+
+## Per-language conversion plan
+
+The detail for each language lives in dedicated artefacts; this section is a précis.
+
+### Rust ↔ `.lino`
+
+- **Parser:** `ra_ap_syntax` (rowan-based, lossless).
+- **Trivia model:** Rowan tokens already carry trivia; map every `SyntaxToken` to a `.lino` token leaf.
+- **Macros:** keep unexpanded form as opaque `lino-cst.rust.macro_call` with the raw token stream stored as a list of `.lino` token leaves.
+- **Identifiers:** preserve raw spellings, including raw identifiers (`r#match`) and unicode.
+- **Round-trip tests:** corpus drawn from rust-analyzer's own `tests/parser` fixtures plus the existing `lib/` and `rust/src/` files.
+
+### JavaScript ↔ `.lino`
+
+- **Parser:** `swc_ecma_parser` (Rust) and `@swc/core` (JS) for AST; comments via the `Comments` interface. For full-fidelity round-trip prefer `recast` (already used by `jscodeshift`).
+- **Trivia model:** attach leading comments to nodes; preserve quote style and parenthesisation via a small "format" sidecar link (e.g. `(format quote double)`).
+- **Module syntax:** support both ESM and CommonJS; default to ESM in the dialect.
+- **Round-trip tests:** corpus drawn from `js/src/` and the test262 conformance suite (sampled).
+
+### Lean 4 ↔ `.lino`
+
+- **Parser:** `Lean.Syntax` via a small Lean tool we call as a subprocess (`lean --run rml/lean_to_lino.lean`). This avoids reimplementing Lean's extensible parser.
+- **Trivia model:** read `Lean.Syntax.SourceInfo` for leading/trailing whitespace and comments.
+- **Macros:** keep raw `Syntax` plus a separate "expanded" branch produced by Lean's elaborator if requested.
+- **Round-trip tests:** corpus drawn from `examples/lean-export-basic.lean` plus a hand-curated set of small Mathlib snippets.
+
+### Rocq ↔ `.lino`
+
+- **Parser:** `coq-lsp` via JSON-RPC with `--record_comments` (subprocess from both JS and Rust).
+- **Trivia model:** `coq-lsp` provides `doc.comments`; we attach them to the following vernac.
+- **Notations:** when a `Notation` command is encountered, recurse and record both the notation declaration and the parser state delta so future vernacs are parsed correctly.
+- **Round-trip tests:** corpus drawn from `examples/rocq-export.lino`'s compiled `.v` form and the `tree-sitter-rocq` test cases for sanity.
+
+---
+
+## Phased roadmap and recommended issue split
+
+This work should be tracked as a new epic, sister to [#95](https://github.com/link-foundation/relative-meta-logic/issues/95). Suggested phases (one issue each unless noted):
+
+### Phase K — `.lino` CST infrastructure
+
+- **K1** Add trivia-aware tokeniser to the LiNo parser (preserve `#…` comments and whitespace runs as nodes; opt-in flag).
+- **K2** Add the rowan-style `lino-cst.*` link family and a tree-printer that round-trips the original source.
+- **K3** Add round-trip tests for every file in `examples/` and `lib/`.
+
+### Phase L — Rust converter
+
+- **L1** Rust → `.lino` importer (binds `ra_ap_syntax`).
+- **L2** `.lino` → Rust printer.
+- **L3** Round-trip CI gate.
+
+### Phase M — JavaScript converter
+
+- **M1** JS → `.lino` importer (binds `swc_ecma_parser` / `@swc/core`).
+- **M2** `.lino` → JS printer (recast-style).
+- **M3** Round-trip CI gate.
+
+### Phase N — Lean 4 converter
+
+- **N1** Lean → `.lino` importer (Lean subprocess).
+- **N2** `.lino` → Lean printer (via `Lean.PrettyPrinter`).
+- **N3** Round-trip CI gate.
+
+### Phase O — Rocq converter
+
+- **O1** Rocq → `.lino` importer (`coq-lsp` subprocess, `--record_comments`).
+- **O2** `.lino` → Rocq printer (uses `coq-lsp`'s pretty-printer for safe outputs, falls back to a hand-written one for our own dialect).
+- **O3** Round-trip CI gate.
+
+### Phase P — Cross-language bridges
+
+- **P1** Define `lino-cst.shared.*` (typed λ + ADT + Pi + records + match) and prove it embeds existing RML kernel terms.
+- **P2** Rust ↔ shared, JS ↔ shared, Lean ↔ shared, Rocq ↔ shared translators (4 issues).
+- **P3** End-to-end demos: Lean → `.lino` → JS, JS → `.lino` → Rocq, etc., each with at least one example and one regression test.
+
+### Phase Q — Documentation and tutorial
+
+- **Q1** Single-page tutorial in `docs/tutorials/universal-cst.md`.
+- **Q2** "Add a fifth language" guide (Python suggested as the worked example).
+
+This split is intentionally fine-grained so each issue can land in a self-contained PR, the way the parity epic was delivered.
+
+---
+
+## Test strategy
+
+Cribbed from rust-analyzer, SWC and SerAPI's round-trip suites:
+
+1. **Trivia round-trip** — `parse(source).print() == source` for every fixture, byte-for-byte.
+2. **Idempotent canonicalisation** — for the documented canonicalisations (e.g. CRLF → LF), `parse(parse(source).print()).print() == parse(source).print()`.
+3. **Cross-language identity** — when translating from `lino-cst.rust → lino-cst.shared → lino-cst.rust`, the result equals the input up to canonicalisation.
+4. **Negative tests** — every "rejected" construct in [`docs/LEAN_EXPORT.md`](../../LEAN_EXPORT.md) / [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md) becomes a structured `unrepresentable` `.lino` node and is asserted to round-trip into the same node.
+5. **Bootstrap** — the case-study tree (`docs/case-studies/issue-138/`) itself is included in the bootstrap corpus so the converters keep working over their own deliverable.
+
+These map cleanly onto five new CI jobs, one per phase.
+
+---
+
+## Existing components and libraries that help
+
+A full catalogue is in [`existing-tools.md`](./existing-tools.md). Top picks per language:
+
+| Need | Library | Notes |
+|------|---------|-------|
+| Rust lossless CST | [`ra_ap_syntax`](https://docs.rs/ra_ap_syntax) | rust-analyzer's rowan-based CST; preserves all trivia. |
+| Rust AST (proc-macro shape) | [`syn`](https://github.com/dtolnay/syn), [`proc-macro2`](https://docs.rs/proc-macro2) | Stable surface for codegen; **strips comments**. |
+| JS lossless CST | [`swc_ecma_parser`](https://lib.rs/crates/swc_ecma_parser) + [`recast`](https://github.com/benjamn/recast) | SWC for parsing; recast for round-trip printing. |
+| JS codemod ergonomics | [`jscodeshift`](https://jscodeshift.com/) | Demonstrates "mutate, don't rebuild" pattern. |
+| Lean CST + delaborator | [`Lean.Syntax`](https://leanprover-community.github.io/lean4-metaprogramming-book/main/05_syntax.html), [Lean PrettyPrinter](https://leanprover-community.github.io/lean4-metaprogramming-book/extra/03_pretty-printing.html) | `pp.all := true` documents round-trip. |
+| Rocq parsing | [`coq-lsp`](https://github.com/rocq-community/rocq-lsp) | Use `--record_comments` for trivia; SerAPI is deprecated. |
+| Tree-sitter grammars (reference) | [`tree-sitter-lean`](https://github.com/Julian/tree-sitter-lean), [`tree-sitter-rocq`](https://github.com/lamg/tree-sitter-rocq), [`tree-sitter-rust`](https://github.com/tree-sitter/tree-sitter-rust) | Useful for CST sanity-checks; not authoritative. |
+| Generic CST library | [`rowan`](https://github.com/rust-analyzer/rowan), [`cstree`](https://crates.io/crates/cstree) | Reusable rowan-style CST in Rust if we want our own. |
+| Universal-IR research | [CrossTL (arXiv 2508.21256)](https://arxiv.org/pdf/2508.21256), [Spoofax](https://spoofax.dev/), [Rascal](https://www.rascal-mpl.org/) | Background on this design pattern. |
+
+---
+
+## Open questions
+
+Tracked separately in [`risks-and-open-questions.md`](./risks-and-open-questions.md). The two largest:
+
+- **Q1** How aggressively should the importers preserve formatting that is *not* part of the surface syntax (alignment, indentation widths)? Rowan-style trees can preserve it, but two host pretty-printers may not be able to reproduce it. Recommendation: preserve in `.lino`, accept that the printer may canonicalise.
+- **Q2** How do we deal with **extensible parsers** in Lean and Rocq (`macro`, `Notation`)? Recommendation: store the un-elaborated `Syntax`/`constr_expr` plus the parser-state delta, and only attempt elaboration on the `lino-cst.shared.*` path.
+
+---
+
+## References
+
+### Linked from this case study
+
+- [Easy Lossless Trees with Nom and Rowan — Kiran Shila](https://blog.kiranshila.com/post/easy_cst)
+- [Lossless Syntax Trees — Christopher Durham](https://dev.to/cad97/lossless-syntax-trees-280c)
+- [rust-analyzer — syntax module docs](https://rust-lang.github.io/rust-analyzer/syntax/index.html)
+- [rust-analyzer — Introducing Ungrammar](https://rust-analyzer.github.io//blog/2020/10/24/introducing-ungrammar.html)
+- [rust-analyzer / rowan](https://github.com/rust-analyzer/rowan)
+- [cstree crate](https://crates.io/crates/cstree)
+- [syn crate](https://github.com/dtolnay/syn)
+- [proc-macro2 crate](https://docs.rs/proc-macro2)
+- [swc_ecma_parser crate](https://lib.rs/crates/swc_ecma_parser)
+- [SWC `swc_common::comments`](https://rustdoc.swc.rs/swc_common/comments/trait.Comments.html)
+- [SWC discussion #4079 — full-fidelity comments](https://github.com/swc-project/swc/discussions/4079)
+- [SWC compilation docs — comments](https://swc.rs/docs/configuration/compilation)
+- [recast](https://github.com/benjamn/recast)
+- [jscodeshift](https://jscodeshift.com/overview/introduction)
+- [Lean 4 — Pretty Printing chapter](https://leanprover-community.github.io/lean4-metaprogramming-book/extra/03_pretty-printing.html)
+- [Lean 4 — Syntax chapter](https://leanprover-community.github.io/lean4-metaprogramming-book/main/05_syntax.html)
+- [Lean 4 source — PrettyPrinter](https://github.com/leanprover/lean4/blob/master/src/Lean/PrettyPrinter.lean)
+- [tree-sitter-lean (experimental)](https://github.com/Julian/tree-sitter-lean)
+- [tree-sitter-rocq — lamg](https://github.com/lamg/tree-sitter-rocq)
+- [tree-sitter-rocq — krathul](https://github.com/krathul/tree-sitter-rocq)
+- [rocq-community/rocq-lsp](https://github.com/rocq-community/rocq-lsp)
+- [coq-serapi (deprecated, superseded by coq-lsp)](https://github.com/rocq-archive/coq-serapi)
+- [coq/dev/doc/parsing.md](https://github.com/coq/coq/blob/master/dev/doc/parsing.md)
+- [Spoofax language workbench](https://spoofax.dev/)
+- [Rascal metaprogramming language](https://www.rascal-mpl.org/)
+- [CrossTL — Universal Programming Language Translator (arXiv 2508.21256)](https://arxiv.org/pdf/2508.21256)
+- [c2rust — Migrate C code to Rust](https://github.com/immunant/c2rust)
+- [awesome-transpilers — milahu](https://github.com/milahu/awesome-transpilers)
+
+### Internal references
+
+- [`ARCHITECTURE.md`](../../../ARCHITECTURE.md)
+- [`README.md` — Program extraction](../../../README.md#program-extraction-issue-f7)
+- [`docs/LEAN_EXPORT.md`](../../LEAN_EXPORT.md)
+- [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md)
+- [`docs/case-studies/issue-13/` — Dependent types case study](../issue-13/)
+- [`docs/case-studies/issue-22/` — Competitor concepts and feature comparison](../issue-22/)
+- [`docs/case-studies/issue-95/` — Feature-parity epic audit](../issue-95/)

--- a/docs/case-studies/issue-138/acceptance-tests.md
+++ b/docs/case-studies/issue-138/acceptance-tests.md
@@ -1,0 +1,107 @@
+# Acceptance tests — Issue #138
+
+This artefact lists the test categories every converter must pass before the corresponding phase issue closes. Phase numbering follows [`README.md` § Phased roadmap](./README.md#phased-roadmap-and-recommended-issue-split).
+
+The five categories are intentionally a thin generalisation of [Karl Palmskog's round-trip suite for Coq SerAPI](https://github.com/rocq-archive/coq-serapi/blob/main/CHANGES.md) and rust-analyzer's syntax round-trip tests.
+
+## Category 1 — Trivia round-trip
+
+For every fixture `s`:
+
+```text
+assert print_cst(parse_lino(host_to_lino(s), { mode: 'cst' })) == s
+```
+
+byte-for-byte, modulo the canonicalisation list documented in [`cst-model.md` § 8](./cst-model.md#8-canonicalisations-documented).
+
+Concrete fixtures per phase:
+
+- **Phase K** (`.lino` itself): every `.lino` file under `examples/` and `lib/`.
+- **Phase L** (Rust): every `.rs` file under `rust/src/` plus a curated 10-file subset of the rust-analyzer parser test corpus.
+- **Phase M** (JavaScript): every `.mjs` file under `js/src/` plus a 10-file subset of test262.
+- **Phase N** (Lean): `examples/lean-export-basic.lean` plus 5 small Mathlib snippets.
+- **Phase O** (Rocq): the compiled `.v` form of `examples/rocq-export.lino` plus 5 small Rocq stdlib snippets.
+
+The bootstrap corpus job ([issue #91](https://github.com/link-foundation/relative-meta-logic/issues/91)) is extended to include every fixture in this category.
+
+## Category 2 — Idempotent canonicalisation
+
+For every fixture `s` and every documented canonicalisation `c`:
+
+```text
+let s' = print_cst(parse_lino(host_to_lino(s), { mode: 'cst' }), { canonicalise: c })
+assert print_cst(parse_lino(host_to_lino(s'), { mode: 'cst' }), { canonicalise: c }) == s'
+```
+
+This is the contract that canonicalisations are themselves stable: once the source has been canonicalised, applying the same canonicalisation again is a no-op.
+
+## Category 3 — Cross-language identity (shared dialect)
+
+For every fixture in the shared semantic fragment (typed λ + ADT + Pi + records + match):
+
+```text
+let shared = host_to_lino(s) -> lino_cst_shared
+let s'     = lino_cst_shared -> host_to_lino -> print
+assert ast(s) ≡ ast(s')      # semantic equality, not byte equality
+```
+
+That is: when we round-trip through the shared dialect, the result is semantically equivalent to the input, even though the printer may pick different formatting.
+
+This is the test that backs the issue's example "convert lean to .lino and after that convert it to JavaScript": the Lean source need not survive byte-for-byte through the JS leg, but the typed kernel it encodes must.
+
+## Category 4 — Negative `unrepresentable` tests
+
+For every construct outside the shared dialect (probabilistic operators, fuzzy aggregators, range/valence config, `Notation`, Lean macros, Rust macros …):
+
+```text
+let lino = host_to_lino(s, dialect)
+let shared = try_to_shared(lino)
+assert shared.is_unrepresentable()
+assert shared.diagnostic.matches('E0XX: <construct> has no shared encoding')
+```
+
+The point is that every host-specific construct produces a **structured** diagnostic, not a silent loss. The error code list is appended to the existing diagnostics catalogue in [`docs/DIAGNOSTICS.md`](../../DIAGNOSTICS.md).
+
+## Category 5 — Bootstrap corpus inclusion
+
+The case-study folder itself (`docs/case-studies/issue-138/`) and all per-language round-trip fixtures are added to the bootstrap corpus gate (see [issue #91](https://github.com/link-foundation/relative-meta-logic/issues/91) and [issue #92](https://github.com/link-foundation/relative-meta-logic/issues/92)) so the converters cannot regress without CI catching it.
+
+## CI integration
+
+We add one workflow per phase, named after the phase letter:
+
+| Workflow | Trigger | Jobs |
+|----------|---------|------|
+| `.github/workflows/round-trip-lino.yml` (Phase K) | PR + cron | Category 1, 2 on `.lino` corpus |
+| `.github/workflows/round-trip-rust.yml` (Phase L) | PR + cron | Categories 1, 2, 3, 4 on Rust corpus |
+| `.github/workflows/round-trip-js.yml` (Phase M) | PR + cron | Same for JS |
+| `.github/workflows/round-trip-lean.yml` (Phase N) | PR + cron | Same for Lean |
+| `.github/workflows/round-trip-rocq.yml` (Phase O) | PR + cron | Same for Rocq |
+| `.github/workflows/bootstrap.yml` (existing, extended) | PR + cron | Category 5 |
+
+Each workflow runs both the JS and Rust implementations, matching the existing parity-CI shape ([PR #168](https://github.com/link-foundation/relative-meta-logic/pull/168)).
+
+## Coverage targets
+
+| Phase | Fixtures (initial) | Fixtures (steady-state) |
+|-------|--------------------|--------------------------|
+| K | 30 (existing `examples/`, `lib/`) | 50+ |
+| L | 10 (rust-analyzer subset) | 100+ |
+| M | 10 (test262 subset) | 100+ |
+| N | 5 (Mathlib snippets) | 30+ |
+| O | 5 (Rocq stdlib snippets) | 30+ |
+| P | 10 (cross-language demos) | 50+ |
+
+The steady-state numbers are not blockers for the first PR of each phase — they are the targets the per-phase epic closes against.
+
+## What "passes" looks like for issue #138
+
+The case-study deliverable itself (this PR) is reviewed against the rubric in [`requirements.md`](./requirements.md). Implementation issues track their own acceptance criteria.
+
+Issue #138 itself is considered closed when all of:
+
+- All five Phase letters K–O have green CI.
+- Phase P round-trip identity (Category 3) is green on at least one example per cross-language pair.
+- The tutorial in Phase Q is published and linked from `README.md`.
+
+This matches the closure pattern used for [issue #95 (the parity epic)](https://github.com/link-foundation/relative-meta-logic/issues/95), recorded in [`docs/case-studies/issue-95/README.md`](../issue-95/README.md).

--- a/docs/case-studies/issue-138/cst-model.md
+++ b/docs/case-studies/issue-138/cst-model.md
@@ -1,0 +1,206 @@
+# `.lino` CST data model — Issue #138
+
+This is the data-model artefact for the case study; it specifies how `.lino` is extended into a trivia-aware concrete syntax tree, and how each host language's CST is encoded inside it. The high-level rationale is in [`README.md`](./README.md); the per-requirement plans are in [`solution-plans.md`](./solution-plans.md).
+
+## 1. Why a CST at all
+
+A standard `.lino` AST today drops two pieces of source information:
+
+1. **Comments** (`# foo`) — discarded during tokenisation, see [`ARCHITECTURE.md` § Stage 2](../../../ARCHITECTURE.md#stage-2-tokenization-and-ast-construction).
+2. **Whitespace** (indentation, blank lines, CRLF vs LF) — never represented.
+
+Both are required by issue #138 ("encode comments, every variable and other name, and even whitespace if needed"). The same problem has been solved twice in the ecosystem we sit next to:
+
+- [Rust-analyzer / rowan](https://github.com/rust-analyzer/rowan) attaches whitespace and comments as **trivia tokens** to a lossless CST.
+- [Roslyn / Swift libsyntax](https://github.com/rust-lang/rust-analyzer/issues/6584) does the same with a "trivia attached to the following non-trivia token" convention.
+
+We adopt the rowan/Roslyn approach.
+
+## 2. Three CST node kinds
+
+| Node kind | Encodes | Children allowed | Round-trip |
+|-----------|---------|------------------|------------|
+| `lino-cst.list` | A parenthesised LiNo list. The existing AST list node. | List, token, trivia | Emit `(`, then children in order, then `)`. |
+| `lino-cst.token` | A single non-trivia lexeme (identifier, number, operator, etc.). | None (leaf). | Emit the original lexeme. |
+| `lino-cst.trivia` | A run of whitespace, or a `#`-comment, or any other byte sequence the parser considers non-significant. | None (leaf). | Emit the original bytes. |
+
+A complete `.lino` file is a `lino-cst.list` whose children are top-level lists, with trivia leaves interspersed. By convention trivia attaches to the **following** non-trivia leaf.
+
+Both modes share the same data type. The AST view simply hides `lino-cst.trivia` nodes and treats `lino-cst.token` leaves as bare strings, matching today's parser output.
+
+## 3. CLI / API surface
+
+### LiNo parser flag (R24)
+
+```text
+parseLinks(src)                       # AST view (default, today's behaviour)
+parseLinks(src, { mode: 'cst' })      # CST view (new)
+```
+
+The Rust parser API mirrors this with `parse(&str)` and `parse_cst(&str)`.
+
+### Tree-printer API
+
+```text
+printCst(tree) → string               # byte-faithful round-trip
+printCst(tree, { canonicalise })      # opt-in canonicalisations
+```
+
+## 4. Host-language dialects
+
+A *dialect* of the `.lino` CST is a set of conventional tags on `lino-cst.list` nodes. We propose four host dialects and one shared semantic dialect.
+
+| Dialect | Top-level tag prefix | Authoritative source for the tag set |
+|---------|----------------------|---------------------------------------|
+| Rust | `lino-cst.rust.*` | rust-analyzer's [`ungrammar`](https://rust-analyzer.github.io//blog/2020/10/24/introducing-ungrammar.html) spec. |
+| JavaScript | `lino-cst.js.*` | `swc_ecma_ast` enum constructors. |
+| Lean 4 | `lino-cst.lean.*` | `Lean.SyntaxNodeKind` plus the parser's reserved `name` table. |
+| Rocq | `lino-cst.rocq.*` | `coq-lsp`'s S-expression schema for `Vernacexpr` and `constr_expr`. |
+| Shared (typed RML kernel) | `lino-cst.shared.*` | The existing typed `.lino` kernel documented in [`docs/case-studies/issue-13/`](../issue-13/). |
+
+The dialect tag is the **first child** of every host-language `lino-cst.list` node. For example, a Rust function declaration becomes:
+
+```lino
+(lino-cst.list lino-cst.rust.fn
+  (lino-cst.token "fn ")
+  (lino-cst.list lino-cst.rust.name (lino-cst.token "foo"))
+  (lino-cst.token "(")
+  (lino-cst.list lino-cst.rust.param_list)
+  (lino-cst.token ")")
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.rust.block (lino-cst.token "{") (lino-cst.token "}")))
+```
+
+This is verbose by design: the original Rust source is fully recoverable by concatenating leaves in order, and any tool that knows the `lino-cst.rust.*` vocabulary can semantically traverse the tree.
+
+## 5. Generated dialect grammars
+
+Each dialect ships a self-describing grammar file under `lib/lino-cst/<host>.lino`. The grammar is itself a `.lino` document that enumerates every node kind and its expected children. The shape is exactly what [`lib/programming-language/core.lino`](../../../lib/programming-language/core.lino) does for the typed RML fragment today.
+
+The benefit of generating the grammar is that:
+
+- We can run the existing RML evaluator on the grammar file and check it is well-formed.
+- We can mechanically diff our grammar against the upstream source of truth (`ungrammar`, `swc_ecma_ast`, etc.) and gate CI on the diff.
+
+## 6. Examples
+
+The following examples are illustrative; the full set lives in `examples/round-trip-*.lino` after Phase L–O lands.
+
+### Rust `fn id<T>(x: T) -> T { x }`
+
+```lino
+(lino-cst.list lino-cst.rust.fn
+  (lino-cst.token "fn ")
+  (lino-cst.list lino-cst.rust.name (lino-cst.token "id"))
+  (lino-cst.list lino-cst.rust.generic_param_list
+    (lino-cst.token "<")
+    (lino-cst.list lino-cst.rust.type_param (lino-cst.token "T"))
+    (lino-cst.token ">"))
+  (lino-cst.token "(")
+  (lino-cst.list lino-cst.rust.param
+    (lino-cst.list lino-cst.rust.ident_pat (lino-cst.token "x"))
+    (lino-cst.token ": ")
+    (lino-cst.list lino-cst.rust.path_type (lino-cst.token "T")))
+  (lino-cst.token ")")
+  (lino-cst.token " -> ")
+  (lino-cst.list lino-cst.rust.path_type (lino-cst.token "T"))
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.rust.block
+    (lino-cst.token "{")
+    (lino-cst.trivia " ")
+    (lino-cst.list lino-cst.rust.path_expr (lino-cst.token "x"))
+    (lino-cst.trivia " ")
+    (lino-cst.token "}")))
+```
+
+### JavaScript `const id = (x) => x;`
+
+```lino
+(lino-cst.list lino-cst.js.variable_declaration
+  (lino-cst.token "const ")
+  (lino-cst.list lino-cst.js.variable_declarator
+    (lino-cst.list lino-cst.js.identifier (lino-cst.token "id"))
+    (lino-cst.token " = ")
+    (lino-cst.list lino-cst.js.arrow_function_expression
+      (lino-cst.token "(")
+      (lino-cst.list lino-cst.js.identifier (lino-cst.token "x"))
+      (lino-cst.token ") => ")
+      (lino-cst.list lino-cst.js.identifier (lino-cst.token "x"))))
+  (lino-cst.token ";"))
+```
+
+### Lean 4 `def id {α : Type} (x : α) : α := x`
+
+```lino
+(lino-cst.list lino-cst.lean.command_definition
+  (lino-cst.token "def ")
+  (lino-cst.list lino-cst.lean.decl_id (lino-cst.token "id"))
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.lean.implicit_binder
+    (lino-cst.token "{") (lino-cst.token "α") (lino-cst.token " : ")
+    (lino-cst.list lino-cst.lean.sort (lino-cst.token "Type"))
+    (lino-cst.token "}"))
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.lean.binder
+    (lino-cst.token "(") (lino-cst.token "x") (lino-cst.token " : ")
+    (lino-cst.list lino-cst.lean.var (lino-cst.token "α"))
+    (lino-cst.token ")"))
+  (lino-cst.token " : ")
+  (lino-cst.list lino-cst.lean.var (lino-cst.token "α"))
+  (lino-cst.token " := ")
+  (lino-cst.list lino-cst.lean.var (lino-cst.token "x")))
+```
+
+### Rocq `Definition id {A : Type} (x : A) : A := x.`
+
+```lino
+(lino-cst.list lino-cst.rocq.vernac_definition
+  (lino-cst.token "Definition ")
+  (lino-cst.list lino-cst.rocq.ident (lino-cst.token "id"))
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.rocq.implicit_binder
+    (lino-cst.token "{") (lino-cst.token "A") (lino-cst.token " : ")
+    (lino-cst.list lino-cst.rocq.sort (lino-cst.token "Type"))
+    (lino-cst.token "}"))
+  (lino-cst.trivia " ")
+  (lino-cst.list lino-cst.rocq.binder
+    (lino-cst.token "(") (lino-cst.token "x") (lino-cst.token " : ")
+    (lino-cst.list lino-cst.rocq.var (lino-cst.token "A"))
+    (lino-cst.token ")"))
+  (lino-cst.token " : ")
+  (lino-cst.list lino-cst.rocq.var (lino-cst.token "A"))
+  (lino-cst.token " := ")
+  (lino-cst.list lino-cst.rocq.var (lino-cst.token "x"))
+  (lino-cst.token "."))
+```
+
+## 7. Round-trip walk
+
+The round-trip printer is the same five lines for every dialect:
+
+```text
+def print(node):
+    if node is token or trivia:
+        emit(node.text)
+    elif node is list:
+        for child in node.children:
+            print(child)
+```
+
+If `parse(src).children` preserves source order, that is the entire correctness proof.
+
+## 8. Canonicalisations (documented)
+
+In a small set of cases the printer is allowed to canonicalise. Each one is gated behind an explicit option so the default remains byte-faithful.
+
+| Canonicalisation | Default | Notes |
+|------------------|---------|-------|
+| Trailing newline at end of file | Preserved | We never add or remove one unless asked. |
+| CRLF → LF | Preserved | We may add a `--normalize-line-endings` flag in a later phase. |
+| Tabs vs spaces | Preserved | Same. |
+| Lean macro expansion | Off | `--expand-macros` triggers Lean to elaborate; the result is no longer round-trip-equal. |
+| Rocq notation expansion | Off | Same idea via `coq-lsp`. |
+
+## 9. Open questions
+
+See [`risks-and-open-questions.md`](./risks-and-open-questions.md).

--- a/docs/case-studies/issue-138/existing-tools.md
+++ b/docs/case-studies/issue-138/existing-tools.md
@@ -1,0 +1,111 @@
+# Existing Tools and Libraries — Issue #138
+
+This document catalogues the libraries and tools we recommend reusing — and the ones we deliberately reject — for the universal CST converters proposed in [`README.md`](./README.md). The breakdown follows the same tiering as [`docs/case-studies/issue-13/existing-tools.md`](../issue-13/existing-tools.md): direct reuse, reference implementations, and academic background.
+
+## Tier 1 — Directly reusable
+
+### Rust
+
+#### `ra_ap_syntax` (rust-analyzer)
+
+- **Docs:** <https://docs.rs/ra_ap_syntax>
+- **Background:** [rust-analyzer syntax module](https://rust-lang.github.io/rust-analyzer/syntax/index.html), [Introducing Ungrammar](https://rust-analyzer.github.io//blog/2020/10/24/introducing-ungrammar.html)
+- **Why:** Produces a **lossless rowan-based CST** with whitespace and comments retained as trivia tokens. The same library is consumed by rust-analyzer itself, so its surface is stable enough for our needs.
+- **Use:** Phase L1 (Rust → `.lino`) binds `ra_ap_syntax::SourceFile::parse` and walks every `SyntaxToken` to emit a matching `lino-cst.rust.*` leaf. Phase L2 reverses the walk.
+
+#### `rowan` and `cstree`
+
+- **Repos:** [`rust-analyzer/rowan`](https://github.com/rust-analyzer/rowan), [`cstree`](https://crates.io/crates/cstree)
+- **Why:** If we ever want our **own** lossless CST inside RML (rather than going via `ra_ap_syntax`'s rowan tree), these are the reusable generics. `cstree` is the actively maintained fork.
+- **Use:** Optional. Recommended only if we discover `ra_ap_syntax`'s shape is too coupled to rust-specific kinds.
+
+#### `syn` + `proc-macro2`
+
+- **Repos:** [`dtolnay/syn`](https://github.com/dtolnay/syn), [`proc-macro2`](https://docs.rs/proc-macro2)
+- **Status:** Stable, but **strips `//` line comments** at tokenisation — only `///` doc-comments survive as `#[doc = "..."]` attributes. Confirmed by [SWC discussion noting the same proc-macro2 limitation](https://github.com/swc-project/swc/discussions/4079) and the [Rust reference on procedural macros](https://doc.rust-lang.org/reference/procedural-macros.html).
+- **Why:** Useful for the *output* side (Phase L2) when we generate a syntactically valid Rust file from a `lino-cst.rust.*` tree — `syn`'s `quote!` macro is the lightest way to emit clean Rust.
+- **Use:** Phase L2 as a printing helper; not the parser.
+
+### JavaScript / TypeScript
+
+#### `swc_ecma_parser` and `@swc/core`
+
+- **Docs:** [`swc_ecma_parser`](https://lib.rs/crates/swc_ecma_parser), [`@swc/core`](https://swc.rs/docs/usage/core)
+- **Comments interface:** [`swc_common::comments`](https://rustdoc.swc.rs/swc_common/comments/trait.Comments.html)
+- **Why:** SWC is the de-facto fast JS/TS parser. Comments can be harvested through the `Comments` trait so the AST stays clean while we keep a side table of trivia. SWC ships in both Rust and Node bindings, which lets the JS and Rust sides of RML share the same parser version.
+- **Caveats:** SWC's `preserveAllComments` option keeps comments in the AST but does not lock down their *exact* position; for byte-equal round-trips we layer `recast`/`magic-string` on top. See [SWC compilation docs](https://swc.rs/docs/configuration/compilation).
+- **Use:** Phase M1 (JS → `.lino`).
+
+#### `recast`
+
+- **Repo:** [`benjamn/recast`](https://github.com/benjamn/recast)
+- **Wrapper:** [`jscodeshift`](https://jscodeshift.com/overview/introduction)
+- **Why:** Recast's philosophy is to **mutate the AST in place and re-print only the changed regions**, preserving original formatting elsewhere. This is exactly the contract the issue asks for ("conversion should not result in data loss, and should be as precise as possible"). It is the parser babel-codemod, jscodeshift and most JS refactor tools sit on.
+- **Use:** Phase M2 (`.lino` → JS) uses recast's printer.
+
+### Lean 4
+
+#### `Lean.Syntax` and the Lean pretty-printer pipeline
+
+- **Docs:** [Lean 4 Syntax chapter](https://leanprover-community.github.io/lean4-metaprogramming-book/main/05_syntax.html), [Lean 4 Pretty Printing chapter](https://leanprover-community.github.io/lean4-metaprogramming-book/extra/03_pretty-printing.html), [Lean 4 source — PrettyPrinter](https://github.com/leanprover/lean4/blob/master/src/Lean/PrettyPrinter.lean)
+- **Why:** Lean ships its own parser, its own `Syntax` CST type (with `SourceInfo` carrying leading/trailing trivia), and a documented round-trip path via the delaborator. With `pp.all := true`, Lean's pretty printer is the inverse of macro expansion.
+- **Use:** Phase N1 calls `Lean.Parser.parseHeader` + `Lean.Parser.parseCommand` in a tiny Lean program we invoke as a subprocess; Phase N2 calls `Lean.PrettyPrinter.format` to emit Lean.
+
+#### `Lake` / `elan`
+
+- **Why:** The Lean toolchain manager. Required to call Lean as a subprocess. Already used by `examples/lean-export-basic.lean` testing.
+
+### Rocq
+
+#### `coq-lsp`
+
+- **Repo:** [`rocq-community/rocq-lsp`](https://github.com/rocq-community/rocq-lsp)
+- **Flag:** `--record_comments` (experimental, documented in the README).
+- **Why:** Rocq's parser is extensible at run-time via `Notation` / `Tactic Notation`, so no third-party tool can parse all Rocq files correctly without delegating to Rocq itself. `coq-lsp` is the supported way to do that and has explicit comment recording. Coq SerAPI is **deprecated** in favour of `coq-lsp` ([coq-serapi CHANGES](https://github.com/rocq-archive/coq-serapi/blob/main/CHANGES.md)).
+- **Use:** Phases O1 and O2 talk to a `coq-lsp` subprocess via JSON-RPC.
+
+#### Coq SerAPI (deprecated)
+
+- **Repo:** [`rocq-archive/coq-serapi`](https://github.com/rocq-archive/coq-serapi)
+- **Why we are *not* using it:** Development has stopped; upstream recommends `coq-lsp`. We mention it only because previous research on round-trip Rocq tooling (Karl Palmskog's round-trip infrastructure) lives here.
+
+## Tier 2 — Reference implementations and grammars
+
+### Reference CST grammars
+
+| Grammar | Repo | Notes |
+|---------|------|-------|
+| Rust | [`tree-sitter/tree-sitter-rust`](https://github.com/tree-sitter/tree-sitter-rust) | Useful as a sanity check; not authoritative — rust-analyzer's grammar is. |
+| JavaScript | [`tree-sitter/tree-sitter-javascript`](https://github.com/tree-sitter/tree-sitter-javascript) | Same; used for editor highlighting. |
+| Lean 4 | [`Julian/tree-sitter-lean`](https://github.com/Julian/tree-sitter-lean) | Experimental; useful for our CST sanity checks. |
+| Rocq | [`lamg/tree-sitter-rocq`](https://github.com/lamg/tree-sitter-rocq), [`krathul/tree-sitter-rocq`](https://github.com/krathul/tree-sitter-rocq) | Both grammars are incomplete by design; the second targets a minimal subset. |
+
+### Source-to-source / language-workbench inspiration
+
+| Project | Why it matters |
+|---------|----------------|
+| [Spoofax](https://spoofax.dev/) | Language workbench with SDF3 for parsing + pretty printing in one declarative spec, the closest historical analogue to what `.lino` aims to be. |
+| [Rascal MPL](https://www.rascal-mpl.org/) | Source-to-source transformation language with a unified CST model. |
+| [CrossTL (arXiv 2508.21256)](https://arxiv.org/pdf/2508.21256) | Recent (2025) paper on a universal IR for programming-language translation; supports the architectural choice in [`README.md` § D2](./README.md#d2-each-host-language-gets-its-own-lino-cst-dialect). |
+| [c2rust](https://github.com/immunant/c2rust) | A real-world transpiler that explicitly punts on comment preservation; useful as a *what not to do* reference. |
+| [awesome-transpilers (milahu)](https://github.com/milahu/awesome-transpilers) | Curated index. |
+
+## Tier 3 — Academic and historical references
+
+| Paper / post | Why it matters |
+|--------------|----------------|
+| [Easy Lossless Trees with Nom and Rowan — Kiran Shila](https://blog.kiranshila.com/post/easy_cst) | Hands-on explanation of how rowan attaches trivia. |
+| [Lossless Syntax Trees — Christopher Durham](https://dev.to/cad97/lossless-syntax-trees-280c) | Why a CST is needed for refactoring tooling; we use the same arguments for cross-language transpilation. |
+| [RFC: transition to Roslyn's model for trivia — rust-analyzer #6584](https://github.com/rust-lang/rust-analyzer/issues/6584) | Trade-offs between IntelliJ-style "trivia between tokens" and Roslyn-style "trivia attached to following token". We adopt Roslyn-style. |
+| [coq/dev/doc/parsing.md](https://github.com/coq/coq/blob/master/dev/doc/parsing.md) | Authoritative description of Rocq's extensible parser; justifies delegating to `coq-lsp`. |
+| [Karl Palmskog's round-trip testing infrastructure for SerAPI](https://github.com/rocq-archive/coq-serapi/blob/main/CHANGES.md) | Template for our round-trip tests. |
+| [Lean 4 — The Lean 4 Theorem Prover and Programming Language (Moura, Ullrich, 2021)](https://link.springer.com/chapter/10.1007/978-3-030-79876-5_37) | Background on Lean's macro system, which informs Phase N. |
+
+## What we deliberately do **not** use
+
+| Tool | Why we skip it |
+|------|----------------|
+| Hand-written parsers for any of the four languages. | The upstream parsers are battle-tested; any divergence is a recurring source of bugs (see c2rust's history). |
+| Tree-sitter grammars as the *authoritative* parser. | Incomplete for Lean and Rocq because of extensible syntax. Acceptable as a CST sanity check, not as the primary parser. |
+| The deprecated Coq SerAPI. | Upstream points users at `coq-lsp` instead. |
+| Translating directly between host AST pairs (Rust ↔ JS), bypassing `.lino`. | Loses the universal-IR property the issue asks for. |

--- a/docs/case-studies/issue-138/requirements.md
+++ b/docs/case-studies/issue-138/requirements.md
@@ -1,0 +1,58 @@
+# Requirements — Issue #138
+
+This document extracts every distinguishable requirement from the text of [issue #138](https://github.com/link-foundation/relative-meta-logic/issues/138) and pairs each one with a status flag and a proposed solution plan. Detail of the plans is in [`solution-plans.md`](./solution-plans.md). The umbrella analysis is in [`README.md`](./README.md).
+
+## Legend
+
+| Mark | Meaning |
+|------|---------|
+| Today | Already true in `main` (cite the artefact). |
+| Partial | Partial support today; needs an extension. |
+| Missing | Not implemented; new work. |
+| Out of scope (OOS) | Mentioned but explicitly excluded by the issue text or by the recommended plan. |
+
+## Requirements table
+
+| ID | Requirement (paraphrased from #138) | Status | Where it lives today / where it needs to land |
+|----|-------------------------------------|--------|------------------------------------------------|
+| **R1** | Convert between LiNo notation and other host languages. | Partial | One-way AST exporters exist: [`docs/LEAN_EXPORT.md`](../../LEAN_EXPORT.md), [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md), [`README.md` § Program extraction](../../../README.md#program-extraction-issue-f7). Importers missing for all four targets. |
+| **R2** | The conversion must use a **concrete syntax tree (CST)**, not just an AST. | Missing | `.lino` is currently tokenised into an AST that discards comments and whitespace ([`ARCHITECTURE.md` § Stage 2](../../../ARCHITECTURE.md#stage-2-tokenization-and-ast-construction)). Plan K introduces a trivia-aware CST. |
+| **R3** | Encode comments. | Missing | `#`-comments are stripped during tokenisation. Plan K1 makes them first-class CST nodes; per-language dialects (Plans L–O) map host-language comments to `.lino` trivia. |
+| **R4** | Encode every variable and every other name. | Today, on the typed subset | Existing exporters preserve identifiers with a sanitisation pass ([`docs/ROCQ-EXPORT.md` § Supported subset](../../ROCQ-EXPORT.md#supported-subset)). The CST must preserve **raw spellings** verbatim — including raw identifiers (`r#match`) and unicode. Plans L1, M1, N1, O1. |
+| **R5** | Encode whitespace where needed. | Missing | Same plan as R3. Whitespace runs become trivia leaves attached to the following token, à la rust-analyzer's rowan trees. |
+| **R6** | Round-trip: Lean → `.lino` → JS must compile. | Missing | Requires the four importers (R1) **and** a defined `lino-cst.shared.*` dialect (Phase P). Cross-language compilation is only meaningful on the shared semantic fragment. |
+| **R7** | Round-trip in the other direction: JS → `.lino` → Rocq, etc. | Missing | Same as R6. |
+| **R8** | `.lino` becomes the **universal intermediate CST**, not AST. | Missing | This is the architectural goal of the whole epic. Met when Phases K–O are green. |
+| **R9** | Conversion is **lossless**: no data loss between source and CST. | Missing | Met by the CST round-trip contract in Phase K (`parse(s).print() == s`) and per-language round-trips in Phases L–O. |
+| **R10** | Conversion is **as precise as possible**. | Missing | Met by binding to the canonical upstream parser per language (`ra_ap_syntax`, `swc_ecma_parser`, `Lean.Syntax`, `coq-lsp`) instead of writing our own; see [`existing-tools.md`](./existing-tools.md). |
+| **R11** | RML has **enough concepts to strictly, unambiguously encode each concept** of Rocq, Lean, Rust, JavaScript. | Missing (per-language dialects), Today (shared fragment) | Achieved by declaring four sibling `.lino` dialects (`lino-cst.rust.*`, `lino-cst.js.*`, `lino-cst.lean.*`, `lino-cst.rocq.*`) — one tag per host-language syntactic production. The shared semantic dialect (`lino-cst.shared.*`) covers the typed fragment already present (see [`docs/case-studies/issue-13/`](../issue-13/)). |
+| **R12** | Once successful with these four, more languages become a **formal, automated translation** target. | Missing | Phase Q2 ships a "Add a fifth language" guide (Python suggested), which is the concrete demonstration of this requirement. |
+| **R13** | Everything is covered extensively with tests. | Missing for new code; the existing exporters are tested | Each new converter ships with the five test categories in [`acceptance-tests.md`](./acceptance-tests.md): trivia round-trip, idempotent canonicalisation, cross-language identity, negative `unrepresentable` tests, and inclusion in the bootstrap corpus. |
+| **R14** | Collect data related to the issue into `docs/case-studies/issue-138/`. | Met by this PR | The folder structure follows the convention of [`docs/case-studies/issue-13/`](../issue-13/) and [`docs/case-studies/issue-95/`](../issue-95/). |
+| **R15** | Do deep case-study analysis, search online for additional facts. | Met by this PR | [`README.md` § Why the four target languages are hard](./README.md#why-the-four-target-languages-are-hard) and [`existing-tools.md`](./existing-tools.md) cite external sources. |
+| **R16** | List each and every requirement. | Met by this file. | — |
+| **R17** | Propose possible solutions and a solution plan for each requirement. | Met by [`solution-plans.md`](./solution-plans.md). | — |
+| **R18** | Check known existing components / libraries that solve similar problems. | Met by [`existing-tools.md`](./existing-tools.md). | — |
+| **R19** | Plan and execute everything in a single pull request. | This PR delivers the case study, plan, and tracking issues. Implementation is then split into per-phase PRs as recommended in [`README.md` § Phased roadmap](./README.md#phased-roadmap-and-recommended-issue-split). | The issue explicitly notes "you have unlimited time and context, as context auto-compacts and you can continue indefinitely". We treat the deliverable as a planning-quality case study identical in shape to the parity epic ([issue #95](https://github.com/link-foundation/relative-meta-logic/issues/95)). |
+
+## Derived non-functional requirements
+
+Issue #138 implies, but does not state, the following. We surface them so the reviewer can confirm them.
+
+| ID | Requirement | Justification |
+|----|-------------|---------------|
+| **R20** | Both the JavaScript and Rust implementations of RML implement every converter. | Mandated by the dual-implementation discipline tracked in [issue #93/#168](https://github.com/link-foundation/relative-meta-logic/pull/168). |
+| **R21** | Each converter is exposed through the existing `rml` CLI (`rml import lean`, `rml export lean`, etc.). | Consistency with [`docs/LEAN_EXPORT.md` § CLI](../../LEAN_EXPORT.md) and [`docs/ROCQ-EXPORT.md` § CLI](../../ROCQ-EXPORT.md#cli). |
+| **R22** | Each converter is gated by a dedicated CI job and a documented round-trip suite. | Consistency with the bootstrap and parity CI jobs (see [`docs/case-studies/issue-95/` § Phase J](../issue-95/)). |
+| **R23** | Each converter ships with at least one example file in `examples/` that exercises the round-trip. | Consistency with the existing convention for `examples/lean-export-basic.lino` ↔ `examples/lean-export-basic.lean`. |
+| **R24** | The CST infrastructure is opt-in for existing callers — current `rml run` and `rml check` behaviour is unchanged. | Preserves the property that all 122 existing tests keep passing (see [`ARCHITECTURE.md`](../../../ARCHITECTURE.md)). |
+
+## What this PR does **not** do
+
+For the avoidance of doubt:
+
+- This PR does **not** implement any of Phases K–Q. It commits the case-study folder only.
+- This PR does **not** open the per-phase tracking issues. We recommend doing that as a follow-up once the case study is reviewed, in the same way the parity epic was filed by [PR #27 / issue #26](https://github.com/link-foundation/relative-meta-logic/pull/27).
+- This PR does **not** change any test or any source file outside `docs/case-studies/issue-138/`.
+
+The reason is operational: issue #138 is a planning issue ("we need to make sure we have ..."), the existing related deliverables in this repository (`issue-13`, `issue-22`, `issue-26`/`#27`, `issue-95`) all use the same shape (case-study folder first, implementation tracked separately), and that shape lets reviewers concentrate on the design before code starts to land.

--- a/docs/case-studies/issue-138/risks-and-open-questions.md
+++ b/docs/case-studies/issue-138/risks-and-open-questions.md
@@ -1,0 +1,97 @@
+# Risks and open questions — Issue #138
+
+This artefact captures the design trade-offs we are not yet ready to commit to, and the risks the implementation phases need to plan around. They are listed in order of expected impact, highest first.
+
+## Q1. Extensible parsers (Lean macros, Rocq notations)
+
+Both Lean 4 and Rocq let user code extend the parser. A Rocq `Notation` declaration can change how subsequent tokens are read; a Lean `macro` does the same.
+
+**Risk:** an importer that does not see the parser-state delta will mis-parse later vernacs / commands.
+
+**Options:**
+
+- **(A) Delegate to the upstream parser.** Always run `coq-lsp` / Lean's own parser. The dialect tree records the unexpanded `Syntax` / `constr_expr` plus the parser-state delta as opaque trivia. Round-trip is byte-faithful; cross-language translation through the shared dialect is gated behind explicit elaboration.
+- **(B) Forbid extensible syntax in the input.** Reject `Notation` and `macro` declarations. Simpler, but rules out most real Lean and Rocq files.
+- **(C) Run a separate elaboration pass.** Importer produces an elaborated tree; round-trip is no longer byte-faithful but cross-language translation is easier.
+
+**Recommendation:** A for the lossless lossless path, optional C for the shared-dialect path. Document the trade-off in [`cst-model.md` § 8](./cst-model.md#8-canonicalisations-documented).
+
+## Q2. Comment placement ambiguity
+
+When a comment sits between two tokens, it is ambiguous whether it belongs to the preceding or following token. Three established conventions exist:
+
+- **Roslyn / Swift libsyntax:** trivia attaches to the **following** token.
+- **IntelliJ:** trivia is a peer node between tokens.
+- **rust-analyzer (current):** trivia attaches to the **following** token, but with documented "leading vs trailing" exceptions for end-of-line comments.
+
+**Risk:** any single rule will surprise some users; tools that round-trip through us must agree on the rule.
+
+**Recommendation:** Roslyn-style, document the rule in [`cst-model.md`](./cst-model.md), and let callers query "leading comments of node X" and "trailing comments of node X" through helper APIs.
+
+## Q3. Identifier normalisation
+
+Rust raw identifiers (`r#match`), Lean's unicode-friendly names, and Rocq's escaped notations are not interchangeable. Naive translation will produce invalid code.
+
+**Risk:** cross-language translation produces source that does not compile.
+
+**Recommendation:** keep the *raw* spelling in the CST; add a per-language sanitisation pass on emit that is **distinct** from the CST. Generalise the existing collision check in [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md#supported-subset).
+
+## Q4. How aggressively should we preserve formatting?
+
+Indentation, blank-line counts, alignment, choice of quote characters are all part of the source. The rowan-style CST preserves them, but host pretty-printers may not be able to reproduce them.
+
+**Risk:** byte-equal round-trip may be impossible for some host languages even if we preserve everything.
+
+**Recommendation:** preserve in the CST. Where the host printer cannot reproduce a detail, surface a structured warning rather than silently dropping it. Document each known case in `docs/case-studies/issue-138/canonicalisations.md` when Phase K lands.
+
+## Q5. Subprocess dependencies
+
+Phases N (Lean) and O (Rocq) depend on subprocesses (`lean`, `coq-lsp`). The JS side of Phase L (Rust) also benefits from calling out to the Rust toolchain.
+
+**Risk:** CI complexity, slower tests, harder to run locally.
+
+**Recommendation:**
+
+- Cache the toolchains in CI (already done for the bootstrap workflow).
+- Provide a `rml import lean --no-subprocess` flag that errors cleanly if the toolchain is missing, rather than producing a bogus tree.
+- Keep the subprocess invocation behind a small adapter so the rest of the converter does not need to know.
+
+## Q6. Cross-language semantic equivalence
+
+Category 3 of [`acceptance-tests.md`](./acceptance-tests.md) requires that we have a notion of "semantic equality" between host ASTs. For the typed shared fragment this is straightforward; for less-shared constructs it is an open research question.
+
+**Risk:** we over-promise on cross-language transpilation and ship a tool that produces compilable but semantically wrong code.
+
+**Recommendation:** narrow the cross-language guarantee to the typed shared fragment (see [`docs/case-studies/issue-13/`](../issue-13/)) and document, in each `unrepresentable` diagnostic, the exact construct that prevented translation.
+
+## Q7. Documentation cost
+
+Each new dialect needs a generated grammar file in `lib/lino-cst/<host>.lino` plus prose explaining the more surprising mappings. Together with five new CI jobs and five new round-trip suites, this is a substantial documentation effort.
+
+**Risk:** docs go stale faster than they are updated.
+
+**Recommendation:** generate as much as possible from the upstream grammar; gate CI on a `diff lib/lino-cst/rust.lino <(cargo run -p gen-rust-grammar)`-style check so docs cannot drift.
+
+## Q8. Versioning the host languages
+
+Rust, JS, Lean and Rocq all evolve. Lean 4 has a stable language version; Rocq has frequent releases; JS has yearly ECMAScript editions; Rust pins to an edition. A CST faithful to Lean 4.6 may not parse Lean 4.7.
+
+**Risk:** importers fall behind upstream and silently mis-parse.
+
+**Recommendation:** pin the upstream parser version per converter; bump in dedicated PRs; include the upstream version string in the `lino-cst.<host>.*` dialect header so old `.lino` files declare their provenance.
+
+## Q9. Performance
+
+A naive trivia-bearing CST roughly doubles the node count of a typical file. For the 10×–100× scale of cross-language refactoring, this can matter.
+
+**Risk:** test runs slow down.
+
+**Recommendation:** measure on the Phase K corpus first; only optimise if the measurements demand it. The rust-analyzer experience suggests rowan's representation is fast enough for entire crates; we should inherit that property.
+
+## Q10. Scope creep
+
+The cross-language space is a sink for ambition. Spoofax, Rascal and CrossTL all aim to be a "universal IR" and all carry decades of accumulated complexity.
+
+**Risk:** the epic balloons and never lands.
+
+**Recommendation:** treat each per-phase issue as independently shippable, modelled on the parity-epic discipline in [`docs/case-studies/issue-95/`](../issue-95/). Land the K–O lossless path first; defer P (cross-language) until the four importers are stable.

--- a/docs/case-studies/issue-138/solution-plans.md
+++ b/docs/case-studies/issue-138/solution-plans.md
@@ -1,0 +1,203 @@
+# Solution Plans — Issue #138
+
+This document proposes one or more solution plans per requirement listed in [`requirements.md`](./requirements.md). The umbrella architecture is in [`README.md`](./README.md); the library inventory is in [`existing-tools.md`](./existing-tools.md); the CST data model is in [`cst-model.md`](./cst-model.md).
+
+For each requirement we list:
+
+- **Plan A** — the recommended approach.
+- **Plan B / C** — alternatives we considered and rejected, with the reason.
+
+## R1 — Bidirectional convert between LiNo and host languages
+
+### Plan A (recommended): one importer + one printer per language, both share the `.lino` CST
+
+- Importer reads host source via the canonical upstream parser (see [`existing-tools.md`](./existing-tools.md)), emits a `lino-cst.<host>.*` tree.
+- Printer reverses the walk and produces host source.
+- Both ship as a subcommand (`rml import <host>` and `rml export <host>`) per [R21](./requirements.md#derived-non-functional-requirements).
+
+### Plan B (rejected): single bidirectional codec per language
+
+- One function that takes either source string or `.lino` and returns the other.
+- **Why rejected:** complicates testing and obscures asymmetric semantics (e.g. importing a Lean file requires a Lean subprocess, exporting one does not).
+
+## R2 — Use a concrete syntax tree, not an AST
+
+### Plan A: trivia-aware `.lino` CST modelled on rowan
+
+Add three new node kinds to the LiNo parser (used only when the CST mode is requested):
+
+- `lino-cst.token` — an opaque leaf with the original lexeme.
+- `lino-cst.trivia.whitespace` — a run of whitespace characters.
+- `lino-cst.trivia.comment` — a `#`-comment.
+
+The existing structural-list node becomes the third CST node kind. Round-trip is a flat in-order walk of leaves.
+
+Backward compatibility: the existing AST view is the same tree with trivia and tokens hidden, exactly how rust-analyzer projects an AST view onto its rowan CST.
+
+### Plan B (rejected): keep `.lino` AST, store trivia in a sidecar file
+
+- **Why rejected:** loses single-source-of-truth; tools that don't read the sidecar silently lose data on save.
+
+## R3 — Encode comments
+
+### Plan A: comments are CST trivia attached to the *following* token (Roslyn / libsyntax convention)
+
+- Matches the trivia model used by rust-analyzer ([RFC #6584](https://github.com/rust-lang/rust-analyzer/issues/6584)) and Lean's `SourceInfo`.
+- Comments at end-of-file are attached to a synthetic EOF token, so no comment is lost.
+
+### Plan B (considered): "trivia between tokens" (IntelliJ-style)
+
+- Trivia is its own peer node, not attached to a token.
+- **Why not first choice:** harder to query ("find all comments preceding `fn foo`") without traversing trivia siblings; both libsyntax and Roslyn migrated away from this design.
+
+## R4 — Encode every variable and other name
+
+### Plan A: preserve raw spelling in `lino-cst.<host>.identifier` leaves
+
+- Store the **original token text**, not a normalised string.
+- Add a sanitisation pass on emit (Rust raw identifiers, Lean reserved keywords, Rocq punctuation) that is **distinct from the CST** so the CST itself is byte-faithful.
+- Reuse the existing collision check in [`docs/ROCQ-EXPORT.md`](../../ROCQ-EXPORT.md#supported-subset) and generalise it.
+
+### Plan B (rejected): canonicalise identifiers in the CST
+
+- **Why rejected:** breaks the round-trip property (R9) and conflicts with the issue's "as precise as possible" wording.
+
+## R5 — Encode whitespace where needed
+
+### Plan A: whitespace runs are CST trivia, preserved verbatim
+
+- Same node kind as comments, just `kind = whitespace`.
+- The printer writes the bytes back unchanged, so indentation, blank lines and CRLF/LF are all preserved.
+
+### Plan B (considered): only preserve "significant" whitespace
+
+- Hard to define; rejected to keep the contract simple.
+
+## R6 / R7 — Cross-language round-trip (Lean ↔ JS, JS ↔ Rocq, etc.)
+
+### Plan A: two-step pipeline through `lino-cst.shared.*`
+
+- `Lean → lino-cst.lean → lino-cst.shared → lino-cst.js → JavaScript`.
+- The middle step `lino-cst.<src> → lino-cst.shared` is the *lossy* one (it drops host-specific concepts); the printers stay lossless.
+- When the source has constructs outside the shared dialect, the translator emits an `unrepresentable` node and surfaces it as a diagnostic — the user can either rewrite the source or extend the shared dialect.
+
+### Plan B (rejected): direct N×N translators (one per host pair)
+
+- Twelve translators (4 hosts × 3 targets) instead of four, plus four shared-dialect translators.
+- **Why rejected:** quadratic growth; loses the "universal IR" property the issue asks for.
+
+## R8 — `.lino` becomes the universal intermediate CST
+
+### Plan A: ship the four host dialects + the shared dialect, document the contract
+
+- Treat dialect identifiers (`lino-cst.<host>.*`) as a typed namespace.
+- Provide a tiny grammar file per dialect under `lib/lino-cst/<host>.lino` listing every node kind, so the dialect is self-describing inside RML (the same trick used by `lib/programming-language/core.lino`).
+
+### Plan B (rejected): expose only the AST surface, hope for the best
+
+- **Why rejected:** caller can never know whether a tree is faithful or normalised, which is the whole point of the issue.
+
+## R9 — Conversion is lossless
+
+### Plan A: round-trip test gate per language
+
+- For every fixture, assert `host_to_lino(parse(s)).print() == s` byte-for-byte.
+- Allow a small documented canonicalisation list (e.g. trailing newline, CRLF → LF). The list lives in `docs/case-studies/issue-138/canonicalisations.md` (to be added in Phase K).
+- This mirrors [Karl Palmskog's SerAPI round-trip infrastructure](https://github.com/rocq-archive/coq-serapi/blob/main/CHANGES.md).
+
+## R10 — As precise as possible
+
+### Plan A: delegate parsing to the canonical upstream parser, do not write our own
+
+- Rust: `ra_ap_syntax`.
+- JS: `swc_ecma_parser` / `@swc/core`.
+- Lean: `Lean.Parser` via a Lean subprocess.
+- Rocq: `coq-lsp` JSON-RPC.
+- Justified in [`existing-tools.md`](./existing-tools.md). c2rust's experience is the cautionary tale.
+
+## R11 — Enough concepts to encode each host concept
+
+### Plan A: one `lino-cst.<host>.*` tag per upstream production
+
+- Generate the dialect from the upstream grammar where possible:
+  - Rust: from rust-analyzer's `ungrammar` spec.
+  - JS: from `swc_ecma_ast`'s `enum` definitions.
+  - Lean: from `Lean.SyntaxNodeKind`.
+  - Rocq: from `coq-lsp`'s `Vernacexpr` / `constr_expr` serialisation.
+- The generated dialects are checked into `lib/lino-cst/<host>.lino` for inspection and bootstrap.
+
+## R12 — Adding more languages later
+
+### Plan A: ship a guide and one worked extra example
+
+- `docs/tutorials/universal-cst-add-a-language.md` walks through wiring Python as the fifth language, since it is well-served by a permissive parser (`libcst`, which is itself a lossless CST) and is the obvious next target.
+- Demonstrates that the case-study work in this PR generalises.
+
+### Plan B (rejected): commit to N specific extra languages now
+
+- **Why rejected:** not asked for in the issue; would balloon the epic.
+
+## R13 — Extensive test coverage
+
+### Plan A: five test categories, gated in CI
+
+- See [`acceptance-tests.md`](./acceptance-tests.md). The five jobs are: trivia round-trip, idempotent canonicalisation, cross-language identity, negative `unrepresentable`, bootstrap corpus inclusion.
+
+## R14, R15, R16, R17, R18 — Case-study deliverables
+
+### Plan A: this PR
+
+- `README.md`, `requirements.md`, `existing-tools.md`, `solution-plans.md`, `cst-model.md`, `acceptance-tests.md`, `risks-and-open-questions.md`.
+- Mirrors [`docs/case-studies/issue-13/`](../issue-13/) and [`docs/case-studies/issue-26/`](../issue-26/).
+
+## R19 — Single PR
+
+### Plan A: case study in this PR, implementation in follow-up per-phase PRs
+
+- Justified in [`requirements.md` § What this PR does not do](./requirements.md#what-this-pr-does-not-do).
+
+### Plan B (considered): land the whole thing in one PR
+
+- **Why rejected:** comparable in size to the parity epic ([issue #95](https://github.com/link-foundation/relative-meta-logic/issues/95)), which was delivered in 67 PRs over many phases. Doing the same here is the project convention.
+
+## R20 — Parity across JS and Rust implementations
+
+### Plan A: every CLI subcommand has a JS and a Rust implementation
+
+- For Rust-only parser dependencies (`ra_ap_syntax`, `syn`), the JS implementation either:
+  - Calls the Rust implementation as a subprocess (acceptable since the importer is already an out-of-process operation for Lean and Rocq), or
+  - Uses a JS port (`@swc/core` for JS itself; no equivalent for Rust today).
+
+## R21 — CLI surface
+
+### Plan A: `rml import <host>` and `rml export <host>`
+
+- `rml import lean file.lean -o file.lino`
+- `rml import rust file.rs -o file.lino`
+- `rml import js file.mjs -o file.lino`
+- `rml import rocq file.v -o file.lino`
+- `rml export <host> file.lino -o file.<ext>` (already exists for `lean` and `rocq`).
+
+## R22 — CI gates
+
+### Plan A: one CI job per converter, plus one cross-language matrix job
+
+- Five new jobs in `.github/workflows/round-trip.yml`.
+- Cross-language matrix is the 4×4 identity check for the shared dialect.
+
+## R23 — Round-trip example per language
+
+### Plan A: extend `examples/` with one fixture per language
+
+- `examples/round-trip-rust.rs` ↔ `examples/round-trip-rust.lino`
+- `examples/round-trip-js.mjs` ↔ `examples/round-trip-js.lino`
+- `examples/round-trip-lean.lean` ↔ `examples/round-trip-lean.lino`
+- `examples/round-trip-rocq.v` ↔ `examples/round-trip-rocq.lino`
+
+## R24 — Opt-in CST infrastructure
+
+### Plan A: CST mode is a parser flag, default off
+
+- `parse_links(src, { mode: 'ast' })` (default) — existing behaviour, comments stripped.
+- `parse_links(src, { mode: 'cst' })` — new behaviour, trivia preserved.
+- The two modes share the underlying parser; the difference is whether trivia leaves are emitted.

--- a/examples/cst-roundtrip-demo.mjs
+++ b/examples/cst-roundtrip-demo.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Universal CST converter round-trip demo (issue #138).
+//
+// Parses one small snippet of each host language (Rust / JS / Lean / Rocq)
+// into the `.lino` CST, prints it back, and asserts byte equality. Run with:
+//
+//   node examples/cst-roundtrip-demo.mjs
+//
+// On success it prints one OK line per language plus a peek at the underlying
+// `.lino` S-expression. Exits non-zero on any round-trip mismatch.
+
+import {
+  parseToCst,
+  printFromCst,
+  roundTrip,
+  SUPPORTED_LANGUAGES,
+} from '../js/src/cst-convert.mjs';
+import { cstToLino, leaves } from '../js/src/cst.mjs';
+
+const samples = {
+  rust: `// add two i64s
+pub fn add(a: i64, b: i64) -> i64 {
+    a + b
+}
+`,
+  js: `// fetch JSON
+async function load(url) {
+  const r = await fetch(url);
+  return r.json();
+}
+`,
+  lean: `-- identity
+def id {α : Type} (x : α) : α := x
+`,
+  rocq: `(* identity *)
+Definition id {A : Type} (x : A) : A := x.
+`,
+};
+
+let allOk = true;
+
+console.log('Universal CST round-trip demo');
+console.log('-----------------------------');
+console.log('Supported languages:', [...SUPPORTED_LANGUAGES].join(', '));
+console.log('');
+
+for (const lang of ['rust', 'js', 'lean', 'rocq']) {
+  const src = samples[lang];
+  const { ok, roundTripped } = roundTrip(src, lang);
+  const tree = parseToCst(src, lang);
+  const leafCount = Array.from(leaves(tree)).length;
+  const sexpPreview = cstToLino(tree).slice(0, 60) + '…';
+  console.log(`${lang.padEnd(5)} ${ok ? 'OK' : 'FAIL'}  (${src.length} bytes, ${leafCount} leaves)`);
+  console.log(`        sexp: ${sexpPreview}`);
+  if (!ok) {
+    allOk = false;
+    console.error('  expected:', JSON.stringify(src));
+    console.error('  got     :', JSON.stringify(roundTripped));
+  }
+  // Also verify trivia leaves (comments / whitespace) survive intact.
+  const triviaTexts = Array
+    .from(leaves(tree))
+    .filter(n => n.kind === 'trivia')
+    .map(n => n.text.trim())
+    .filter(Boolean);
+  console.log(`        trivia: ${JSON.stringify(triviaTexts)}`);
+  console.log('');
+}
+
+if (!allOk) {
+  process.exitCode = 1;
+  console.error('One or more round-trip checks failed.');
+} else {
+  console.log('All round-trip checks passed.');
+}
+
+// Also sanity-check that printFromCst is a pure function (idempotent).
+for (const lang of ['rust', 'js', 'lean', 'rocq']) {
+  const tree = parseToCst(samples[lang], lang);
+  const a = printFromCst(tree, lang);
+  const b = printFromCst(tree, lang);
+  if (a !== b) {
+    console.error(`printFromCst not idempotent for ${lang}`);
+    process.exitCode = 1;
+  }
+}

--- a/js/src/cst-convert.mjs
+++ b/js/src/cst-convert.mjs
@@ -1,0 +1,76 @@
+// Universal CST converter dispatch (issue #138).
+//
+// Single entry point that turns host-language source into a `.lino` CST and
+// back. Provides:
+//
+//   - `parseToCst(src, lang)` — host source → CST.
+//   - `printFromCst(node, lang)` — CST → host source.
+//   - `roundTrip(src, lang)` — convenience helper that asserts byte fidelity.
+//
+// Supported `lang` values: `'rust'`, `'js'`, `'lean'`, `'rocq'`.
+
+import { parseRust, printRust } from './cst-rust.mjs';
+import { parseJs, printJs } from './cst-js.mjs';
+import { parseLean, printLean } from './cst-lean.mjs';
+import { parseRocq, printRocq } from './cst-rocq.mjs';
+
+const PARSERS = {
+  rust: parseRust,
+  js: parseJs,
+  javascript: parseJs,
+  lean: parseLean,
+  rocq: parseRocq,
+};
+
+const PRINTERS = {
+  rust: printRust,
+  js: printJs,
+  javascript: printJs,
+  lean: printLean,
+  rocq: printRocq,
+};
+
+/**
+ * The four host languages plus their aliases.
+ * @type {ReadonlyArray<'rust' | 'js' | 'javascript' | 'lean' | 'rocq'>}
+ */
+export const SUPPORTED_LANGUAGES = Object.freeze(['rust', 'js', 'javascript', 'lean', 'rocq']);
+
+/**
+ * Parse host-language source into a `.lino` CST.
+ *
+ * @param {string} src host-language source.
+ * @param {'rust'|'js'|'javascript'|'lean'|'rocq'} lang
+ * @returns {import('./cst.mjs').CstNode}
+ */
+export function parseToCst(src, lang) {
+  const parse = PARSERS[lang];
+  if (!parse) throw new Error(`unsupported language for parseToCst: ${lang}`);
+  return parse(src);
+}
+
+/**
+ * Print a CST node back to host-language source.
+ *
+ * @param {import('./cst.mjs').CstNode} node CST tree.
+ * @param {'rust'|'js'|'javascript'|'lean'|'rocq'} lang
+ * @returns {string}
+ */
+export function printFromCst(node, lang) {
+  const print = PRINTERS[lang];
+  if (!print) throw new Error(`unsupported language for printFromCst: ${lang}`);
+  return print(node);
+}
+
+/**
+ * Verify that `printFromCst(parseToCst(src, lang), lang) === src`.
+ *
+ * @param {string} src host-language source.
+ * @param {'rust'|'js'|'javascript'|'lean'|'rocq'} lang
+ * @returns {{ ok: boolean, source: string, roundTripped: string }}
+ */
+export function roundTrip(src, lang) {
+  const cst = parseToCst(src, lang);
+  const roundTripped = printFromCst(cst, lang);
+  return { ok: roundTripped === src, source: src, roundTripped };
+}

--- a/js/src/cst-convert.mjs
+++ b/js/src/cst-convert.mjs
@@ -41,7 +41,7 @@ export const SUPPORTED_LANGUAGES = Object.freeze(['rust', 'js', 'javascript', 'l
  *
  * @param {string} src host-language source.
  * @param {'rust'|'js'|'javascript'|'lean'|'rocq'} lang
- * @returns {import('./cst.mjs').CstNode}
+ * @returns {CstNode}
  */
 export function parseToCst(src, lang) {
   const parse = PARSERS[lang];
@@ -52,7 +52,7 @@ export function parseToCst(src, lang) {
 /**
  * Print a CST node back to host-language source.
  *
- * @param {import('./cst.mjs').CstNode} node CST tree.
+ * @param {CstNode} node CST tree.
  * @param {'rust'|'js'|'javascript'|'lean'|'rocq'} lang
  * @returns {string}
  */

--- a/js/src/cst-js.mjs
+++ b/js/src/cst-js.mjs
@@ -29,7 +29,7 @@ const JS = DIALECTS.js;
  * Parse JavaScript source into a `lino-cst.js.*` CST.
  *
  * @param {string} src JS source.
- * @returns {import('./cst.mjs').CstNode}
+ * @returns {CstNode}
  */
 export function parseJs(src) {
   return list(`${JS}.program`, tokeniseJs(String(src)));
@@ -37,7 +37,7 @@ export function parseJs(src) {
 
 /**
  * Print a JS CST back to source.
- * @param {import('./cst.mjs').CstNode} node
+ * @param {CstNode} node
  * @returns {string}
  */
 export function printJs(node) {

--- a/js/src/cst-js.mjs
+++ b/js/src/cst-js.mjs
@@ -1,0 +1,284 @@
+// JavaScript ↔ `.lino` CST converter (issue #138).
+//
+// Token-level lossless converter for JavaScript source. Produces a
+// `lino-cst.js.*` flat CST. Round-trip is byte-faithful:
+// `printJs(parseJs(src)) === src`.
+//
+// Scope: this converter operates at the token-stream level. It recognises:
+//
+//   - line comments (`// ...`)
+//   - block comments (`/* ... */`)
+//   - whitespace (spaces, tabs, CR, LF)
+//   - hashbang on the first line (`#! ...`)
+//   - string literals (`"..."`, `'...'`)
+//   - template literals (``` `...${...}...` ```), with nested expressions
+//   - numeric literals (decimal, hex, oct, bin, BigInt)
+//   - regexp literals (best-effort, using a context heuristic)
+//   - identifiers (Unicode XID-friendly)
+//   - punctuation
+//
+// Regex disambiguation is the only non-trivial piece: a `/` is the start of a
+// regex when it follows a token that cannot begin a binary-divide operand
+// (e.g. `=`, `(`, `,`, `return`, etc.). We use the standard heuristic.
+
+import { list, token, trivia, DIALECTS } from './cst.mjs';
+
+const JS = DIALECTS.js;
+
+/**
+ * Parse JavaScript source into a `lino-cst.js.*` CST.
+ *
+ * @param {string} src JS source.
+ * @returns {import('./cst.mjs').CstNode}
+ */
+export function parseJs(src) {
+  return list(`${JS}.program`, tokeniseJs(String(src)));
+}
+
+/**
+ * Print a JS CST back to source.
+ * @param {import('./cst.mjs').CstNode} node
+ * @returns {string}
+ */
+export function printJs(node) {
+  const out = [];
+  emit(node, out);
+  return out.join('');
+}
+
+function emit(node, out) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    out.push(node.text);
+    return;
+  }
+  if (node.kind === 'list') {
+    if (node.open) out.push(node.open);
+    for (const child of node.children) emit(child, out);
+    if (node.close) out.push(node.close);
+  }
+}
+
+const ID_START = /[A-Za-z_$]/;
+const ID_CONT = /[A-Za-z0-9_$]/;
+const DIGIT = /[0-9]/;
+const HEX = /[0-9A-Fa-f]/;
+
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'do', 'else', 'throw',
+  'new', 'delete', 'void', 'await', 'yield', 'case',
+]);
+
+function tokeniseJs(src) {
+  const out = [];
+  let i = 0;
+  let lastSignificant = null;
+
+  if (src.startsWith('#!')) {
+    let j = src.indexOf('\n');
+    if (j === -1) j = src.length;
+    out.push(trivia(src.substring(0, j), `${JS}.hashbang`));
+    i = j;
+  }
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (c === ' ' || c === '\t' || c === '\r' || c === '\n') {
+      let j = i;
+      while (j < src.length && (src[j] === ' ' || src[j] === '\t' || src[j] === '\r' || src[j] === '\n')) j++;
+      out.push(trivia(src.substring(i, j), `${JS}.whitespace`));
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && src[i + 1] === '/') {
+      let j = i + 2;
+      while (j < src.length && src[j] !== '\n') j++;
+      out.push(trivia(src.substring(i, j), `${JS}.comment.line`));
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2);
+      const j = end === -1 ? src.length : end + 2;
+      out.push(trivia(src.substring(i, j), `${JS}.comment.block`));
+      i = j;
+      continue;
+    }
+
+    if (c === '"' || c === "'") {
+      const j = scanString(src, i + 1, c);
+      const tok = token(src.substring(i, j), `${JS}.string_literal`);
+      out.push(tok);
+      lastSignificant = tok;
+      i = j;
+      continue;
+    }
+
+    if (c === '`') {
+      const j = scanTemplate(src, i);
+      const tok = token(src.substring(i, j), `${JS}.template_literal`);
+      out.push(tok);
+      lastSignificant = tok;
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && canBeRegex(lastSignificant)) {
+      const j = scanRegex(src, i);
+      if (j > i + 1) {
+        const tok = token(src.substring(i, j), `${JS}.regexp_literal`);
+        out.push(tok);
+        lastSignificant = tok;
+        i = j;
+        continue;
+      }
+    }
+
+    if (DIGIT.test(c) || (c === '.' && DIGIT.test(src[i + 1]))) {
+      const j = scanNumber(src, i);
+      const tok = token(src.substring(i, j), `${JS}.numeric_literal`);
+      out.push(tok);
+      lastSignificant = tok;
+      i = j;
+      continue;
+    }
+
+    if (ID_START.test(c) || isUnicodeIdStart(c)) {
+      let j = i + 1;
+      while (j < src.length && (ID_CONT.test(src[j]) || isUnicodeIdContinue(src[j]))) j++;
+      const tok = token(src.substring(i, j), `${JS}.ident`);
+      out.push(tok);
+      lastSignificant = tok;
+      i = j;
+      continue;
+    }
+
+    const tok = token(c, `${JS}.punct`);
+    out.push(tok);
+    lastSignificant = tok;
+    i += 1;
+  }
+
+  return out;
+}
+
+function scanString(src, j, quote) {
+  while (j < src.length) {
+    const c = src[j];
+    if (c === '\\') { j += 2; continue; }
+    if (c === '\n' && (quote === '"' || quote === "'")) {
+      // Unterminated; stop at end of line for safety.
+      return j;
+    }
+    if (c === quote) return j + 1;
+    j++;
+  }
+  return j;
+}
+
+function scanTemplate(src, i) {
+  let j = i + 1;
+  while (j < src.length) {
+    const c = src[j];
+    if (c === '\\') { j += 2; continue; }
+    if (c === '`') return j + 1;
+    if (c === '$' && src[j + 1] === '{') {
+      // Skip nested ${ ... } expression with bracket counting.
+      j += 2;
+      let depth = 1;
+      while (j < src.length && depth > 0) {
+        const k = src[j];
+        if (k === '{') depth++;
+        else if (k === '}') depth--;
+        else if (k === '"' || k === "'") j = scanString(src, j + 1, k) - 1;
+        else if (k === '`') j = scanTemplate(src, j) - 1;
+        else if (k === '/' && src[j + 1] === '/') {
+          while (j < src.length && src[j] !== '\n') j++;
+          continue;
+        }
+        else if (k === '/' && src[j + 1] === '*') {
+          const e = src.indexOf('*/', j + 2);
+          j = e === -1 ? src.length : e + 2;
+          continue;
+        }
+        j++;
+      }
+      continue;
+    }
+    j++;
+  }
+  return j;
+}
+
+function scanRegex(src, i) {
+  let j = i + 1;
+  let inClass = false;
+  while (j < src.length) {
+    const c = src[j];
+    if (c === '\\') { j += 2; continue; }
+    if (c === '[') inClass = true;
+    else if (c === ']') inClass = false;
+    else if (c === '/' && !inClass) {
+      j++;
+      // Flags
+      while (j < src.length && /[a-zA-Z]/.test(src[j])) j++;
+      return j;
+    } else if (c === '\n') {
+      return i + 1;
+    }
+    j++;
+  }
+  return j;
+}
+
+function scanNumber(src, i) {
+  let j = i;
+  if (src[j] === '0' && (src[j + 1] === 'x' || src[j + 1] === 'X')) {
+    j += 2;
+    while (j < src.length && (HEX.test(src[j]) || src[j] === '_')) j++;
+  } else if (src[j] === '0' && (src[j + 1] === 'o' || src[j + 1] === 'O')) {
+    j += 2;
+    while (j < src.length && /[0-7_]/.test(src[j])) j++;
+  } else if (src[j] === '0' && (src[j + 1] === 'b' || src[j + 1] === 'B')) {
+    j += 2;
+    while (j < src.length && /[01_]/.test(src[j])) j++;
+  } else {
+    while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    if (src[j] === '.') {
+      j++;
+      while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    }
+    if (src[j] === 'e' || src[j] === 'E') {
+      j++;
+      if (src[j] === '+' || src[j] === '-') j++;
+      while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    }
+  }
+  if (src[j] === 'n') j++; // BigInt suffix
+  return j;
+}
+
+function canBeRegex(prev) {
+  if (!prev) return true;
+  if (prev.kind === 'trivia') return true;
+  if (prev.tag === `${JS}.ident`) {
+    return REGEX_PRECEDING_KEYWORDS.has(prev.text);
+  }
+  if (prev.tag === `${JS}.punct`) {
+    // After most punctuation, `/` starts a regex.
+    return !')]'.includes(prev.text);
+  }
+  return false;
+}
+
+function isUnicodeIdStart(c) {
+  if (!c) return false;
+  return c.codePointAt(0) > 0x7f;
+}
+
+function isUnicodeIdContinue(c) {
+  return isUnicodeIdStart(c);
+}

--- a/js/src/cst-lean.mjs
+++ b/js/src/cst-lean.mjs
@@ -30,7 +30,7 @@ const LEAN = DIALECTS.lean;
  * Parse Lean 4 source into a `lino-cst.lean.*` CST.
  *
  * @param {string} src Lean source.
- * @returns {import('./cst.mjs').CstNode}
+ * @returns {CstNode}
  */
 export function parseLean(src) {
   return list(`${LEAN}.module`, tokeniseLean(String(src)));
@@ -38,7 +38,7 @@ export function parseLean(src) {
 
 /**
  * Print a Lean CST back to source.
- * @param {import('./cst.mjs').CstNode} node
+ * @param {CstNode} node
  * @returns {string}
  */
 export function printLean(node) {

--- a/js/src/cst-lean.mjs
+++ b/js/src/cst-lean.mjs
@@ -1,0 +1,236 @@
+// Lean 4 ↔ `.lino` CST converter (issue #138).
+//
+// Token-level lossless converter for Lean 4 source. Produces a
+// `lino-cst.lean.*` flat CST. Round-trip is byte-faithful:
+// `printLean(parseLean(src)) === src`.
+//
+// Lean 4 tokens we recognise at this layer:
+//
+//   - line comments (`-- ...`)
+//   - block comments (`/- ... -/`, with nesting)
+//   - documentation comments (`/-! ... -/`, `/-- ... -/`)
+//   - whitespace
+//   - string literals (`"..."`, `r"..."` raw)
+//   - char literals (`'c'`)
+//   - numeric literals (decimal, hex, oct, bin)
+//   - identifiers — Lean 4 allows arbitrary Unicode letters (including
+//     `α`, `β`, `→`, dotted hierarchical names like `Nat.succ`).
+//   - punctuation
+//
+// The Unicode handling is generous: any non-ASCII code point that is not
+// whitespace or a recognised delimiter is treated as identifier content. This
+// is sufficient for token-level round-trip and matches the Lean 4 tokenizer's
+// behaviour for common cases (see Lean.Parser).
+
+import { list, token, trivia, DIALECTS } from './cst.mjs';
+
+const LEAN = DIALECTS.lean;
+
+/**
+ * Parse Lean 4 source into a `lino-cst.lean.*` CST.
+ *
+ * @param {string} src Lean source.
+ * @returns {import('./cst.mjs').CstNode}
+ */
+export function parseLean(src) {
+  return list(`${LEAN}.module`, tokeniseLean(String(src)));
+}
+
+/**
+ * Print a Lean CST back to source.
+ * @param {import('./cst.mjs').CstNode} node
+ * @returns {string}
+ */
+export function printLean(node) {
+  const out = [];
+  emit(node, out);
+  return out.join('');
+}
+
+function emit(node, out) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    out.push(node.text);
+    return;
+  }
+  if (node.kind === 'list') {
+    if (node.open) out.push(node.open);
+    for (const child of node.children) emit(child, out);
+    if (node.close) out.push(node.close);
+  }
+}
+
+const DIGIT = /[0-9]/;
+const HEX = /[0-9A-Fa-f]/;
+const ASCII_PUNCT = new Set(Array.from('()[]{},.;:`@#$%^&*+-=/\\<>!?|~'));
+
+function tokeniseLean(src) {
+  const out = [];
+  let i = 0;
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (c === ' ' || c === '\t' || c === '\r' || c === '\n') {
+      let j = i;
+      while (j < src.length && (src[j] === ' ' || src[j] === '\t' || src[j] === '\r' || src[j] === '\n')) j++;
+      out.push(trivia(src.substring(i, j), `${LEAN}.whitespace`));
+      i = j;
+      continue;
+    }
+
+    if (c === '-' && src[i + 1] === '-') {
+      let j = i + 2;
+      while (j < src.length && src[j] !== '\n') j++;
+      out.push(trivia(src.substring(i, j), `${LEAN}.comment.line`));
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && src[i + 1] === '-') {
+      const j = scanBlockComment(src, i);
+      const tag = src[i + 2] === '-' ? `${LEAN}.doc.block` : `${LEAN}.comment.block`;
+      out.push(trivia(src.substring(i, j), tag));
+      i = j;
+      continue;
+    }
+
+    if (c === '"') {
+      const j = scanString(src, i + 1, '"');
+      out.push(token(src.substring(i, j), `${LEAN}.string_literal`));
+      i = j;
+      continue;
+    }
+
+    if (c === 'r' && src[i + 1] === '"') {
+      const j = scanString(src, i + 2, '"');
+      out.push(token(src.substring(i, j), `${LEAN}.raw_string_literal`));
+      i = j;
+      continue;
+    }
+
+    if (c === "'") {
+      // Char literal: `'x'` or `'\n'`, etc.
+      let j = i + 1;
+      if (src[j] === '\\') j += 2; else j += 1;
+      if (src[j] === "'") {
+        j++;
+        out.push(token(src.substring(i, j), `${LEAN}.char_literal`));
+        i = j;
+        continue;
+      }
+      // Not a valid char literal; fall through to punctuation.
+    }
+
+    if (DIGIT.test(c)) {
+      const j = scanNumber(src, i);
+      out.push(token(src.substring(i, j), `${LEAN}.numeric_literal`));
+      i = j;
+      continue;
+    }
+
+    if (isIdentStart(c)) {
+      let j = i + 1;
+      while (j < src.length && isIdentContinue(src[j])) j++;
+      // Allow dotted hierarchical name: `Nat.succ`, `List.foldr`.
+      while (src[j] === '.' && isIdentStart(src[j + 1])) {
+        j++;
+        while (j < src.length && isIdentContinue(src[j])) j++;
+      }
+      out.push(token(src.substring(i, j), `${LEAN}.ident`));
+      i = j;
+      continue;
+    }
+
+    // Multi-byte UTF-8 codepoints other than identifier-class chars:
+    // emit one full codepoint as a punctuation token to keep round-trip
+    // byte-exact.
+    const cp = src.codePointAt(i);
+    const len = cp > 0xffff ? 2 : 1;
+    out.push(token(src.substring(i, i + len), `${LEAN}.punct`));
+    i += len;
+  }
+
+  return out;
+}
+
+function scanBlockComment(src, i) {
+  let j = i + 2;
+  let depth = 1;
+  while (j < src.length && depth > 0) {
+    if (src[j] === '/' && src[j + 1] === '-') { depth++; j += 2; }
+    else if (src[j] === '-' && src[j + 1] === '/') { depth--; j += 2; }
+    else j++;
+  }
+  return j;
+}
+
+function scanString(src, j, quote) {
+  while (j < src.length) {
+    const c = src[j];
+    if (c === '\\') { j += 2; continue; }
+    if (c === quote) return j + 1;
+    j++;
+  }
+  return j;
+}
+
+function scanNumber(src, i) {
+  let j = i;
+  if (src[j] === '0' && (src[j + 1] === 'x' || src[j + 1] === 'X')) {
+    j += 2;
+    while (j < src.length && HEX.test(src[j])) j++;
+    return j;
+  }
+  if (src[j] === '0' && (src[j + 1] === 'o' || src[j + 1] === 'O')) {
+    j += 2;
+    while (j < src.length && /[0-7]/.test(src[j])) j++;
+    return j;
+  }
+  if (src[j] === '0' && (src[j + 1] === 'b' || src[j + 1] === 'B')) {
+    j += 2;
+    while (j < src.length && /[01]/.test(src[j])) j++;
+    return j;
+  }
+  while (j < src.length && DIGIT.test(src[j])) j++;
+  if (src[j] === '.' && DIGIT.test(src[j + 1])) {
+    j++;
+    while (j < src.length && DIGIT.test(src[j])) j++;
+    if (src[j] === 'e' || src[j] === 'E') {
+      j++;
+      if (src[j] === '+' || src[j] === '-') j++;
+      while (j < src.length && DIGIT.test(src[j])) j++;
+    }
+  }
+  return j;
+}
+
+function isIdentStart(c) {
+  if (!c) return false;
+  if (/[A-Za-z_]/.test(c)) return true;
+  const cp = c.codePointAt(0);
+  // Treat all non-ASCII letters and Greek-letter-class code points as identifier-start.
+  if (cp > 0x7f) {
+    return !isLeanPunctChar(c) && !isLeanWhitespaceChar(c);
+  }
+  return false;
+}
+
+function isIdentContinue(c) {
+  if (!c) return false;
+  if (/[A-Za-z0-9_'!?]/.test(c)) return true;
+  const cp = c.codePointAt(0);
+  if (cp > 0x7f) {
+    return !isLeanPunctChar(c) && !isLeanWhitespaceChar(c);
+  }
+  return false;
+}
+
+function isLeanPunctChar(c) {
+  // Reserve Lean-specific Unicode operators as punctuation: arrows, lambda, etc.
+  return '→←↦⟨⟩⟦⟧«»‹›'.includes(c);
+}
+
+function isLeanWhitespaceChar(c) {
+  return c === ' ' || c === ' ' || c === ' ';
+}

--- a/js/src/cst-rocq.mjs
+++ b/js/src/cst-rocq.mjs
@@ -23,7 +23,7 @@ const ROCQ = DIALECTS.rocq;
 /**
  * Parse Rocq source into a `lino-cst.rocq.*` CST.
  * @param {string} src
- * @returns {import('./cst.mjs').CstNode}
+ * @returns {CstNode}
  */
 export function parseRocq(src) {
   return list(`${ROCQ}.document`, tokeniseRocq(String(src)));
@@ -31,7 +31,7 @@ export function parseRocq(src) {
 
 /**
  * Print a Rocq CST back to source.
- * @param {import('./cst.mjs').CstNode} node
+ * @param {CstNode} node
  * @returns {string}
  */
 export function printRocq(node) {

--- a/js/src/cst-rocq.mjs
+++ b/js/src/cst-rocq.mjs
@@ -1,0 +1,177 @@
+// Rocq ↔ `.lino` CST converter (issue #138).
+//
+// Token-level lossless converter for Rocq (formerly Coq) source. Produces a
+// `lino-cst.rocq.*` flat CST. Round-trip is byte-faithful:
+// `printRocq(parseRocq(src)) === src`.
+//
+// Tokens we recognise at this layer (matches the Rocq lexer, `clexer.ml`):
+//
+//   - block comments `(* ... *)` (Rocq comments nest)
+//   - whitespace
+//   - string literals `"..."` (escaped via `""` doubling, the Rocq convention)
+//   - numeric literals (decimal, hex `0x...`, oct, bin)
+//   - identifiers
+//   - punctuation (vernac uses `.` as a statement terminator; the lexer just
+//     emits it as a punctuation token here.)
+//
+// Rocq does NOT use `//` for line comments — every comment is block-form.
+
+import { list, token, trivia, DIALECTS } from './cst.mjs';
+
+const ROCQ = DIALECTS.rocq;
+
+/**
+ * Parse Rocq source into a `lino-cst.rocq.*` CST.
+ * @param {string} src
+ * @returns {import('./cst.mjs').CstNode}
+ */
+export function parseRocq(src) {
+  return list(`${ROCQ}.document`, tokeniseRocq(String(src)));
+}
+
+/**
+ * Print a Rocq CST back to source.
+ * @param {import('./cst.mjs').CstNode} node
+ * @returns {string}
+ */
+export function printRocq(node) {
+  const out = [];
+  emit(node, out);
+  return out.join('');
+}
+
+function emit(node, out) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    out.push(node.text);
+    return;
+  }
+  if (node.kind === 'list') {
+    if (node.open) out.push(node.open);
+    for (const child of node.children) emit(child, out);
+    if (node.close) out.push(node.close);
+  }
+}
+
+const DIGIT = /[0-9]/;
+const HEX = /[0-9A-Fa-f]/;
+
+function tokeniseRocq(src) {
+  const out = [];
+  let i = 0;
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (c === ' ' || c === '\t' || c === '\r' || c === '\n') {
+      let j = i;
+      while (j < src.length && (src[j] === ' ' || src[j] === '\t' || src[j] === '\r' || src[j] === '\n')) j++;
+      out.push(trivia(src.substring(i, j), `${ROCQ}.whitespace`));
+      i = j;
+      continue;
+    }
+
+    if (c === '(' && src[i + 1] === '*') {
+      const j = scanBlockComment(src, i);
+      out.push(trivia(src.substring(i, j), `${ROCQ}.comment`));
+      i = j;
+      continue;
+    }
+
+    if (c === '"') {
+      const j = scanRocqString(src, i + 1);
+      out.push(token(src.substring(i, j), `${ROCQ}.string_literal`));
+      i = j;
+      continue;
+    }
+
+    if (DIGIT.test(c)) {
+      const j = scanNumber(src, i);
+      out.push(token(src.substring(i, j), `${ROCQ}.numeric_literal`));
+      i = j;
+      continue;
+    }
+
+    if (isIdentStart(c)) {
+      let j = i + 1;
+      while (j < src.length && isIdentContinue(src[j])) j++;
+      out.push(token(src.substring(i, j), `${ROCQ}.ident`));
+      i = j;
+      continue;
+    }
+
+    const cp = src.codePointAt(i);
+    const len = cp > 0xffff ? 2 : 1;
+    out.push(token(src.substring(i, i + len), `${ROCQ}.punct`));
+    i += len;
+  }
+
+  return out;
+}
+
+function scanBlockComment(src, i) {
+  let j = i + 2;
+  let depth = 1;
+  while (j < src.length && depth > 0) {
+    if (src[j] === '(' && src[j + 1] === '*') { depth++; j += 2; }
+    else if (src[j] === '*' && src[j + 1] === ')') { depth--; j += 2; }
+    else j++;
+  }
+  return j;
+}
+
+function scanRocqString(src, j) {
+  while (j < src.length) {
+    if (src[j] === '"') {
+      if (src[j + 1] === '"') { j += 2; continue; } // escaped doubled quote
+      return j + 1;
+    }
+    j++;
+  }
+  return j;
+}
+
+function scanNumber(src, i) {
+  let j = i;
+  if (src[j] === '0' && (src[j + 1] === 'x' || src[j + 1] === 'X')) {
+    j += 2;
+    while (j < src.length && HEX.test(src[j])) j++;
+    return j;
+  }
+  if (src[j] === '0' && (src[j + 1] === 'o' || src[j + 1] === 'O')) {
+    j += 2;
+    while (j < src.length && /[0-7]/.test(src[j])) j++;
+    return j;
+  }
+  if (src[j] === '0' && (src[j + 1] === 'b' || src[j + 1] === 'B')) {
+    j += 2;
+    while (j < src.length && /[01]/.test(src[j])) j++;
+    return j;
+  }
+  while (j < src.length && DIGIT.test(src[j])) j++;
+  return j;
+}
+
+function isIdentStart(c) {
+  if (!c) return false;
+  if (/[A-Za-z_]/.test(c)) return true;
+  const cp = c.codePointAt(0);
+  if (cp > 0x7f) {
+    return !isRocqPunctChar(c);
+  }
+  return false;
+}
+
+function isIdentContinue(c) {
+  if (!c) return false;
+  if (/[A-Za-z0-9_']/.test(c)) return true;
+  const cp = c.codePointAt(0);
+  if (cp > 0x7f) {
+    return !isRocqPunctChar(c);
+  }
+  return false;
+}
+
+function isRocqPunctChar(c) {
+  return '→←⟨⟩∀∃∧∨¬'.includes(c);
+}

--- a/js/src/cst-rust.mjs
+++ b/js/src/cst-rust.mjs
@@ -1,0 +1,286 @@
+// Rust ↔ `.lino` CST converter (issue #138).
+//
+// Token-level lossless converter for Rust source. Produces a `lino-cst.rust.*`
+// flat CST: every byte of input is encoded as one of the three CST node kinds.
+// The round-trip is byte-faithful: `printRust(parseRust(src)) === src`.
+//
+// Scope: this converter operates at the token-stream level. It recognises:
+//
+//   - line comments (`// ...`, `/// ...`, `//! ...`)
+//   - block comments (`/* ... */`, possibly nested)
+//   - whitespace (spaces, tabs, CR, LF)
+//   - shebang on the first line
+//   - string literals (`"..."`), byte-strings (`b"..."`), raw strings (`r"..."`,
+//     `r#"..."#`, etc.), char literals (`'...'`), byte-char literals.
+//   - numeric literals (decimal, hex, oct, bin, with suffixes).
+//   - identifiers (including raw identifiers `r#foo` and Unicode XID).
+//   - punctuation (every other byte is an operator/punctuator token).
+//
+// The output CST is a single `lino-cst.rust.source_file` list whose children
+// alternate between tokens (significant lexemes) and trivia (whitespace,
+// comments). This matches the rust-analyzer rowan layout: trivia is preserved
+// at the leaf level, structure is preserved at the leaf level too.
+//
+// A full semantic CST (one `lino-cst.rust.*` tag per `ra_ap_syntax`
+// `SyntaxKind`) is built on top of this token stream — that work is
+// orthogonal to round-trip fidelity and is intentionally deferred. The
+// token-level converter already satisfies issue #138's requirement that "every
+// variable and other name, and even whitespace if needed" survive a round
+// trip.
+
+import { list, token, trivia, DIALECTS } from './cst.mjs';
+
+const RUST = DIALECTS.rust;
+
+/**
+ * Parse Rust source into a `lino-cst.rust.*` CST.
+ *
+ * The returned tree is a single `source_file` list. Every byte of `src` is
+ * preserved verbatim in the resulting tree; `printRust(parseRust(src)) ===
+ * src` for any well-tokenised input.
+ *
+ * @param {string} src Rust source.
+ * @returns {import('./cst.mjs').CstNode} CST root.
+ */
+export function parseRust(src) {
+  const children = tokeniseRust(String(src));
+  return list(`${RUST}.source_file`, children);
+}
+
+/**
+ * Print a Rust CST back to source. Inverse of `parseRust`.
+ *
+ * @param {import('./cst.mjs').CstNode} node
+ * @returns {string}
+ */
+export function printRust(node) {
+  const out = [];
+  emit(node, out);
+  return out.join('');
+}
+
+function emit(node, out) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    out.push(node.text);
+    return;
+  }
+  if (node.kind === 'list') {
+    if (node.open) out.push(node.open);
+    for (const child of node.children) emit(child, out);
+    if (node.close) out.push(node.close);
+  }
+}
+
+// ---------- Lexer ----------
+
+const ID_START = /[A-Za-z_]/;
+const ID_CONT = /[A-Za-z0-9_]/;
+const DIGIT = /[0-9]/;
+const HEX = /[0-9A-Fa-f]/;
+
+function tokeniseRust(src) {
+  const out = [];
+  let i = 0;
+
+  if (src.startsWith('#!') && (src.length < 3 || src[2] !== '[')) {
+    // Shebang line — preserved as trivia at the start.
+    let j = src.indexOf('\n');
+    if (j === -1) j = src.length;
+    out.push(trivia(src.substring(0, j), `${RUST}.shebang`));
+    i = j;
+  }
+
+  while (i < src.length) {
+    const c = src[i];
+
+    if (c === ' ' || c === '\t' || c === '\r' || c === '\n') {
+      let j = i;
+      while (j < src.length && (src[j] === ' ' || src[j] === '\t' || src[j] === '\r' || src[j] === '\n')) j++;
+      out.push(trivia(src.substring(i, j), `${RUST}.whitespace`));
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && src[i + 1] === '/') {
+      let j = i + 2;
+      while (j < src.length && src[j] !== '\n') j++;
+      out.push(trivia(src.substring(i, j), `${RUST}.comment.line`));
+      i = j;
+      continue;
+    }
+
+    if (c === '/' && src[i + 1] === '*') {
+      const j = scanBlockComment(src, i);
+      out.push(trivia(src.substring(i, j), `${RUST}.comment.block`));
+      i = j;
+      continue;
+    }
+
+    if (c === '"') {
+      const j = scanString(src, i + 1, '"');
+      out.push(token(src.substring(i, j), `${RUST}.string_literal`));
+      i = j;
+      continue;
+    }
+
+    if ((c === 'b' || c === 'r') && (src[i + 1] === '"' || (c === 'r' && src[i + 1] === '#') || (c === 'b' && src[i + 1] === 'r' && (src[i + 2] === '"' || src[i + 2] === '#')))) {
+      const j = scanRawOrPrefixedString(src, i);
+      if (j > i) {
+        out.push(token(src.substring(i, j), `${RUST}.string_literal`));
+        i = j;
+        continue;
+      }
+    }
+
+    if (c === "'" ) {
+      // char literal or lifetime
+      const lifetimeEnd = scanLifetime(src, i);
+      if (lifetimeEnd > i + 1) {
+        out.push(token(src.substring(i, lifetimeEnd), `${RUST}.lifetime`));
+        i = lifetimeEnd;
+        continue;
+      }
+      const j = scanString(src, i + 1, "'");
+      out.push(token(src.substring(i, j), `${RUST}.char_literal`));
+      i = j;
+      continue;
+    }
+
+    if (c === 'b' && src[i + 1] === "'") {
+      const j = scanString(src, i + 2, "'");
+      out.push(token(src.substring(i, j), `${RUST}.byte_literal`));
+      i = j;
+      continue;
+    }
+
+    if (DIGIT.test(c)) {
+      const j = scanNumber(src, i);
+      out.push(token(src.substring(i, j), `${RUST}.numeric_literal`));
+      i = j;
+      continue;
+    }
+
+    if (c === 'r' && src[i + 1] === '#' && ID_START.test(src[i + 2] || '')) {
+      let j = i + 2;
+      while (j < src.length && ID_CONT.test(src[j])) j++;
+      out.push(token(src.substring(i, j), `${RUST}.raw_ident`));
+      i = j;
+      continue;
+    }
+
+    if (ID_START.test(c) || isUnicodeIdStart(c)) {
+      let j = i + 1;
+      while (j < src.length && (ID_CONT.test(src[j]) || isUnicodeIdContinue(src[j]))) j++;
+      out.push(token(src.substring(i, j), `${RUST}.ident`));
+      i = j;
+      continue;
+    }
+
+    // Punctuation: emit one byte. Operators are tokens too; the printer just
+    // concatenates them, so we do not need to bundle multi-char operators.
+    out.push(token(c, `${RUST}.punct`));
+    i += 1;
+  }
+
+  return out;
+}
+
+function scanBlockComment(src, i) {
+  let j = i + 2;
+  let depth = 1;
+  while (j < src.length && depth > 0) {
+    if (src[j] === '/' && src[j + 1] === '*') {
+      depth++;
+      j += 2;
+    } else if (src[j] === '*' && src[j + 1] === '/') {
+      depth--;
+      j += 2;
+    } else {
+      j++;
+    }
+  }
+  return j;
+}
+
+function scanString(src, j, quote) {
+  while (j < src.length) {
+    const c = src[j];
+    if (c === '\\') { j += 2; continue; }
+    if (c === quote) return j + 1;
+    j++;
+  }
+  return j;
+}
+
+function scanRawOrPrefixedString(src, i) {
+  let j = i;
+  if (src[j] === 'b') j++;
+  if (src[j] === 'r') {
+    j++;
+    let hashes = 0;
+    while (src[j] === '#') { hashes++; j++; }
+    if (src[j] !== '"') return i;
+    j++;
+    const terminator = '"' + '#'.repeat(hashes);
+    const end = src.indexOf(terminator, j);
+    if (end === -1) return src.length;
+    return end + terminator.length;
+  }
+  if (src[j] === '"') {
+    return scanString(src, j + 1, '"');
+  }
+  return i;
+}
+
+function scanLifetime(src, i) {
+  let j = i + 1;
+  if (j < src.length && (ID_START.test(src[j]) || isUnicodeIdStart(src[j]))) {
+    j++;
+    while (j < src.length && (ID_CONT.test(src[j]) || isUnicodeIdContinue(src[j]))) j++;
+    // If next char is a quote, this is a char literal, not a lifetime.
+    if (src[j] === "'") return i;
+    return j;
+  }
+  return i;
+}
+
+function scanNumber(src, i) {
+  let j = i;
+  if (src[j] === '0' && (src[j + 1] === 'x' || src[j + 1] === 'X')) {
+    j += 2;
+    while (j < src.length && (HEX.test(src[j]) || src[j] === '_')) j++;
+  } else if (src[j] === '0' && (src[j + 1] === 'o' || src[j + 1] === 'O')) {
+    j += 2;
+    while (j < src.length && (/[0-7_]/.test(src[j]))) j++;
+  } else if (src[j] === '0' && (src[j + 1] === 'b' || src[j + 1] === 'B')) {
+    j += 2;
+    while (j < src.length && (/[01_]/.test(src[j]))) j++;
+  } else {
+    while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    if (src[j] === '.' && DIGIT.test(src[j + 1])) {
+      j++;
+      while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    }
+    if (src[j] === 'e' || src[j] === 'E') {
+      j++;
+      if (src[j] === '+' || src[j] === '-') j++;
+      while (j < src.length && (DIGIT.test(src[j]) || src[j] === '_')) j++;
+    }
+  }
+  // Type suffix: i32, u64, f64, isize, usize, etc.
+  if (j < src.length && ID_START.test(src[j])) {
+    while (j < src.length && ID_CONT.test(src[j])) j++;
+  }
+  return j;
+}
+
+function isUnicodeIdStart(c) {
+  if (!c) return false;
+  const code = c.codePointAt(0);
+  return code > 0x7f;
+}
+
+function isUnicodeIdContinue(c) {
+  return isUnicodeIdStart(c);
+}

--- a/js/src/cst-rust.mjs
+++ b/js/src/cst-rust.mjs
@@ -40,7 +40,7 @@ const RUST = DIALECTS.rust;
  * src` for any well-tokenised input.
  *
  * @param {string} src Rust source.
- * @returns {import('./cst.mjs').CstNode} CST root.
+ * @returns {CstNode} CST root.
  */
 export function parseRust(src) {
   const children = tokeniseRust(String(src));
@@ -50,7 +50,7 @@ export function parseRust(src) {
 /**
  * Print a Rust CST back to source. Inverse of `parseRust`.
  *
- * @param {import('./cst.mjs').CstNode} node
+ * @param {CstNode} node
  * @returns {string}
  */
 export function printRust(node) {

--- a/js/src/cst.mjs
+++ b/js/src/cst.mjs
@@ -1,0 +1,284 @@
+// Universal lossless CST infrastructure for issue #138.
+//
+// This module implements the `.lino` concrete syntax tree (CST) model
+// described in `docs/case-studies/issue-138/cst-model.md`. It is the shared
+// core used by every host-language converter (Rust, JavaScript, Lean 4, Rocq):
+// each converter produces a tree of `CstNode` values, which can be printed
+// back to bytes via `printCst()`, giving a byte-faithful round-trip.
+//
+// Three node kinds, exactly as the model specifies:
+//
+// - `list`   — a list node tagged with a dialect-specific symbol (e.g.
+//              `lino-cst.rust.fn`); children are emitted in order with the
+//              `open` and `close` delimiters if present.
+// - `token`  — a leaf carrying a single non-trivia lexeme; its `text` field is
+//              the original source bytes.
+// - `trivia` — a leaf carrying whitespace or a comment; `text` is the original
+//              source bytes. Trivia attaches to the *following* non-trivia
+//              leaf by convention (Roslyn/libsyntax style).
+//
+// The tree is intentionally minimal: each converter owns the choice of tags
+// and the placement of trivia. The printer is content-agnostic — it simply
+// concatenates `text` in document order.
+
+/** @typedef {{ kind: 'list', tag: string|null, open: string|null, close: string|null, children: CstNode[] }} CstListNode */
+/** @typedef {{ kind: 'token', tag: string|null, text: string }} CstTokenNode */
+/** @typedef {{ kind: 'trivia', tag: string|null, text: string }} CstTriviaNode */
+/** @typedef {CstListNode|CstTokenNode|CstTriviaNode} CstNode */
+
+/**
+ * Construct a `list` CST node.
+ *
+ * @param {string|null} tag dialect-specific symbol, e.g. `lino-cst.rust.fn`.
+ * @param {CstNode[]} children child nodes in document order.
+ * @param {{ open?: string|null, close?: string|null }} [opts]
+ *   optional `open`/`close` delimiter strings to emit around the children.
+ * @returns {CstListNode}
+ */
+export function list(tag, children = [], opts = {}) {
+  return {
+    kind: 'list',
+    tag: tag === undefined ? null : tag,
+    open: opts.open ?? null,
+    close: opts.close ?? null,
+    children: children.slice(),
+  };
+}
+
+/**
+ * Construct a `token` CST leaf.
+ *
+ * @param {string} text original source bytes for the lexeme.
+ * @param {string|null} [tag] optional dialect-specific symbol.
+ * @returns {CstTokenNode}
+ */
+export function token(text, tag = null) {
+  return { kind: 'token', tag, text: String(text) };
+}
+
+/**
+ * Construct a `trivia` CST leaf (whitespace or comment).
+ *
+ * @param {string} text original source bytes.
+ * @param {string|null} [tag] optional categorisation, e.g. `comment.line`.
+ * @returns {CstTriviaNode}
+ */
+export function trivia(text, tag = null) {
+  return { kind: 'trivia', tag, text: String(text) };
+}
+
+/**
+ * Print a CST node back to its original byte-for-byte source representation.
+ *
+ * The walk is the five-line algorithm from the model document:
+ *   - for `token` and `trivia` nodes, emit `node.text`.
+ *   - for `list` nodes, emit `open`, then children in order, then `close`.
+ *
+ * @param {CstNode} node tree to print.
+ * @returns {string} reconstructed source.
+ */
+export function printCst(node) {
+  const out = [];
+  emit(node, out);
+  return out.join('');
+}
+
+function emit(node, out) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    out.push(node.text);
+    return;
+  }
+  if (node.kind === 'list') {
+    if (node.open) out.push(node.open);
+    for (const child of node.children) emit(child, out);
+    if (node.close) out.push(node.close);
+    return;
+  }
+  throw new TypeError(`Unknown CST node kind: ${node && node.kind}`);
+}
+
+/**
+ * Iterate every leaf (`token` or `trivia`) of a CST in document order.
+ *
+ * @param {CstNode} node tree to walk.
+ * @returns {Iterable<CstTokenNode|CstTriviaNode>}
+ */
+export function* leaves(node) {
+  if (!node) return;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    yield node;
+    return;
+  }
+  if (node.kind === 'list') {
+    for (const child of node.children) yield* leaves(child);
+  }
+}
+
+/**
+ * Serialise a CST node into a `.lino` S-expression suitable for embedding in
+ * `.lino` files or for round-trip testing. The serialisation is the literal
+ * shape documented in `docs/case-studies/issue-138/cst-model.md`:
+ *
+ *   `(lino-cst.list <tag> <child> <child> ...)`
+ *   `(lino-cst.token "<text>")`
+ *   `(lino-cst.trivia "<text>")`
+ *
+ * String contents are escaped using JSON rules so that the result is a valid
+ * LiNo expression. `parseCstLino` is the exact inverse.
+ *
+ * @param {CstNode} node tree to serialise.
+ * @returns {string}
+ */
+export function cstToLino(node) {
+  if (!node) return '';
+  if (node.kind === 'token') return `(lino-cst.token ${escapeText(node.text)})`;
+  if (node.kind === 'trivia') return `(lino-cst.trivia ${escapeText(node.text)})`;
+  if (node.kind === 'list') {
+    const parts = ['lino-cst.list'];
+    if (node.tag) parts.push(node.tag);
+    if (node.open !== null && node.open !== undefined) parts.push(`(open ${escapeText(node.open)})`);
+    if (node.close !== null && node.close !== undefined) parts.push(`(close ${escapeText(node.close)})`);
+    for (const child of node.children) parts.push(cstToLino(child));
+    return `(${parts.join(' ')})`;
+  }
+  throw new TypeError(`Unknown CST node kind: ${node && node.kind}`);
+}
+
+function escapeText(text) {
+  return JSON.stringify(String(text));
+}
+
+function unescapeText(literal) {
+  return JSON.parse(literal);
+}
+
+/**
+ * Parse the `.lino` S-expression produced by `cstToLino()` back into a
+ * `CstNode` tree. Inverse of `cstToLino`.
+ *
+ * @param {string} src `.lino` S-expression.
+ * @returns {CstNode}
+ */
+export function linoToCst(src) {
+  const tokens = tokeniseLinoCst(String(src));
+  let i = 0;
+  function peek() { return tokens[i]; }
+  function eat() { return tokens[i++]; }
+  function expect(t) {
+    const got = eat();
+    if (got !== t) throw new SyntaxError(`expected ${JSON.stringify(t)}, got ${JSON.stringify(got)}`);
+  }
+  function parseNode() {
+    expect('(');
+    const head = eat();
+    if (head === 'lino-cst.token') {
+      const lit = eat();
+      expect(')');
+      return token(unescapeText(lit));
+    }
+    if (head === 'lino-cst.trivia') {
+      const lit = eat();
+      expect(')');
+      return trivia(unescapeText(lit));
+    }
+    if (head === 'lino-cst.list') {
+      let tag = null;
+      let open = null;
+      let close = null;
+      const children = [];
+      while (peek() !== ')') {
+        if (peek() === '(') {
+          const lookahead = tokens[i + 1];
+          if (lookahead === 'open') {
+            eat(); eat();
+            open = unescapeText(eat());
+            expect(')');
+            continue;
+          }
+          if (lookahead === 'close') {
+            eat(); eat();
+            close = unescapeText(eat());
+            expect(')');
+            continue;
+          }
+          children.push(parseNode());
+        } else {
+          if (tag !== null) throw new SyntaxError(`unexpected token ${peek()}`);
+          tag = eat();
+        }
+      }
+      expect(')');
+      return list(tag, children, { open, close });
+    }
+    throw new SyntaxError(`unknown CST tag: ${head}`);
+  }
+  return parseNode();
+}
+
+function tokeniseLinoCst(src) {
+  const out = [];
+  let i = 0;
+  while (i < src.length) {
+    const c = src[i];
+    if (c === '(' || c === ')') {
+      out.push(c);
+      i++;
+      continue;
+    }
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+      i++;
+      continue;
+    }
+    if (c === '"') {
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === '\\') { j += 2; continue; }
+        if (src[j] === '"') break;
+        j++;
+      }
+      if (j >= src.length) throw new SyntaxError('unterminated string literal');
+      out.push(src.substring(i, j + 1));
+      i = j + 1;
+      continue;
+    }
+    let j = i;
+    while (j < src.length && !' \t\n\r()'.includes(src[j])) j++;
+    out.push(src.substring(i, j));
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * The four host-language dialect tag prefixes plus the shared dialect.
+ * Exported so that external tooling can refer to them symbolically.
+ */
+export const DIALECTS = Object.freeze({
+  rust: 'lino-cst.rust',
+  js: 'lino-cst.js',
+  lean: 'lino-cst.lean',
+  rocq: 'lino-cst.rocq',
+  shared: 'lino-cst.shared',
+});
+
+/**
+ * Compute and return a structural copy of a CST node. Used by translators that
+ * need to mutate without altering the input.
+ *
+ * @param {CstNode} node
+ * @returns {CstNode}
+ */
+export function cloneCst(node) {
+  if (!node) return node;
+  if (node.kind === 'token' || node.kind === 'trivia') {
+    return { ...node };
+  }
+  return {
+    kind: 'list',
+    tag: node.tag,
+    open: node.open,
+    close: node.close,
+    children: node.children.map(cloneCst),
+  };
+}

--- a/js/src/cst.mjs
+++ b/js/src/cst.mjs
@@ -21,17 +21,35 @@
 // and the placement of trivia. The printer is content-agnostic — it simply
 // concatenates `text` in document order.
 
-/** @typedef {{ kind: 'list', tag: string|null, open: string|null, close: string|null, children: CstNode[] }} CstListNode */
-/** @typedef {{ kind: 'token', tag: string|null, text: string }} CstTokenNode */
-/** @typedef {{ kind: 'trivia', tag: string|null, text: string }} CstTriviaNode */
+/** @typedef {Object} CstListNode
+ *  @property {'list'} kind
+ *  @property {string|null} tag
+ *  @property {string|null} open
+ *  @property {string|null} close
+ *  @property {CstNode[]} children
+ */
+/** @typedef {Object} CstTokenNode
+ *  @property {'token'} kind
+ *  @property {string|null} tag
+ *  @property {string} text
+ */
+/** @typedef {Object} CstTriviaNode
+ *  @property {'trivia'} kind
+ *  @property {string|null} tag
+ *  @property {string} text
+ */
 /** @typedef {CstListNode|CstTokenNode|CstTriviaNode} CstNode */
+/** @typedef {Object} CstListOptions
+ *  @property {string|null} [open]
+ *  @property {string|null} [close]
+ */
 
 /**
  * Construct a `list` CST node.
  *
  * @param {string|null} tag dialect-specific symbol, e.g. `lino-cst.rust.fn`.
  * @param {CstNode[]} children child nodes in document order.
- * @param {{ open?: string|null, close?: string|null }} [opts]
+ * @param {CstListOptions} [opts]
  *   optional `open`/`close` delimiter strings to emit around the children.
  * @returns {CstListNode}
  */

--- a/js/tests/cst.test.mjs
+++ b/js/tests/cst.test.mjs
@@ -1,0 +1,285 @@
+// Universal CST converter tests (issue #138).
+//
+// Verifies the lossless round-trip contract `print(parse(src)) === src` for
+// every host-language converter, plus the CST serialisation helpers.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  list,
+  token,
+  trivia,
+  printCst,
+  cstToLino,
+  linoToCst,
+  cloneCst,
+  DIALECTS,
+  leaves,
+} from '../src/cst.mjs';
+import { parseRust, printRust } from '../src/cst-rust.mjs';
+import { parseJs, printJs } from '../src/cst-js.mjs';
+import { parseLean, printLean } from '../src/cst-lean.mjs';
+import { parseRocq, printRocq } from '../src/cst-rocq.mjs';
+import { parseToCst, printFromCst, roundTrip, SUPPORTED_LANGUAGES } from '../src/cst-convert.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..');
+
+describe('cst data model', () => {
+  it('printCst concatenates leaves in document order', () => {
+    const tree = list('demo', [
+      token('hello'),
+      trivia(' '),
+      token('world'),
+    ]);
+    assert.strictEqual(printCst(tree), 'hello world');
+  });
+
+  it('list nodes emit open/close delimiters when set', () => {
+    const tree = list('demo', [token('a'), token('b')], { open: '(', close: ')' });
+    assert.strictEqual(printCst(tree), '(ab)');
+  });
+
+  it('cstToLino + linoToCst is a round trip for tokens, trivia and lists', () => {
+    const tree = list('lino-cst.rust.fn', [
+      token('fn ', 'kw'),
+      token('foo', 'ident'),
+      token('(', 'punct'),
+      token(')', 'punct'),
+      trivia(' ', 'ws'),
+      list('lino-cst.rust.block', [token('{'), token('}')]),
+    ]);
+    const serialised = cstToLino(tree);
+    assert.match(serialised, /^\(lino-cst\.list lino-cst\.rust\.fn /);
+    const parsed = linoToCst(serialised);
+    assert.strictEqual(printCst(parsed), printCst(tree));
+  });
+
+  it('linoToCst preserves open/close delimiters', () => {
+    const tree = list('frag', [token('x')], { open: '<', close: '>' });
+    const sExpr = cstToLino(tree);
+    const back = linoToCst(sExpr);
+    assert.strictEqual(printCst(back), '<x>');
+  });
+
+  it('cloneCst returns a structural copy', () => {
+    const tree = list('demo', [token('a'), list('inner', [token('b')])]);
+    const clone = cloneCst(tree);
+    assert.notStrictEqual(clone, tree);
+    assert.notStrictEqual(clone.children[1], tree.children[1]);
+    assert.deepStrictEqual(clone, tree);
+  });
+
+  it('leaves walks in document order', () => {
+    const tree = list('demo', [token('a'), list('inner', [token('b'), token('c')]), token('d')]);
+    const texts = Array.from(leaves(tree)).map(n => n.text);
+    assert.deepStrictEqual(texts, ['a', 'b', 'c', 'd']);
+  });
+
+  it('exposes the four host dialects', () => {
+    assert.strictEqual(DIALECTS.rust, 'lino-cst.rust');
+    assert.strictEqual(DIALECTS.js, 'lino-cst.js');
+    assert.strictEqual(DIALECTS.lean, 'lino-cst.lean');
+    assert.strictEqual(DIALECTS.rocq, 'lino-cst.rocq');
+  });
+});
+
+describe('Rust round-trip', () => {
+  const samples = [
+    '',
+    'fn main() {}\n',
+    '// hello\nfn f() -> i32 { 42 }\n',
+    '/* multi\n  line */\nfn g() {}\n',
+    'fn id<T>(x: T) -> T { x }\n',
+    "let s = \"hello\\n\";\n",
+    'let s = r#"raw"#;\n',
+    "let c = 'a';\nlet lt: &'static str = \"x\";\n",
+    'let n = 0xFF_FF;\nlet m = 0b1010;\nlet f = 3.14e10;\n',
+    'pub fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n',
+    'use std::collections::HashMap;\n',
+    "let mut v = Vec::<i32>::new();\nv.push(1);\n",
+    "macro_rules! foo { () => {}; }\n",
+    'let r#match = 1;\n',
+  ];
+  for (const src of samples) {
+    it(`round-trips: ${JSON.stringify(src.slice(0, 40))}`, () => {
+      const r = roundTrip(src, 'rust');
+      assert.strictEqual(r.roundTripped, src);
+      assert.strictEqual(r.ok, true);
+    });
+  }
+});
+
+describe('JavaScript round-trip', () => {
+  const samples = [
+    '',
+    'const x = 1;\n',
+    '// hello\nconst y = 2;\n',
+    '/* block */ const z = 3;\n',
+    "const s = 'a\\'b';\n",
+    'const t = `hello ${name}!`;\n',
+    'const t2 = `nested ${`inner ${1+2}`} done`;\n',
+    'const r = /foo\\/bar/g;\n',
+    'const n = 0xff_ff;\nconst b = 0b1010n;\nconst f = 3.14e-2;\n',
+    'function f(a, b) {\n  return a + b;\n}\n',
+    'class C { method() { return 1; } }\n',
+    'const obj = { a: 1, "b c": 2 };\n',
+    '#!/usr/bin/env node\nconsole.log("hi");\n',
+    'export default async function f() { await sleep(1); }\n',
+    'let { a, b: c = 3 } = x;\n',
+    'const re = /^a[/]b$/;\n',
+  ];
+  for (const src of samples) {
+    it(`round-trips: ${JSON.stringify(src.slice(0, 40))}`, () => {
+      const r = roundTrip(src, 'js');
+      assert.strictEqual(r.roundTripped, src);
+      assert.strictEqual(r.ok, true);
+    });
+  }
+});
+
+describe('Lean 4 round-trip', () => {
+  const samples = [
+    '',
+    '-- comment\ndef f : Nat := 1\n',
+    '/- block comment -/\ndef g : Nat := 2\n',
+    '/-! module doc -/\n',
+    '/-- decl doc -/\ndef h : Nat := 3\n',
+    'def id {α : Type} (x : α) : α := x\n',
+    '#check Nat.succ\n',
+    'theorem t : 1 + 1 = 2 := rfl\n',
+    'def s : String := "hello"\n',
+    'def n : Nat := 0xff\n',
+    'def m : Nat := 0b1010\n',
+    'inductive List (α : Type u) where\n  | nil : List α\n  | cons : α → List α → List α\n',
+    'namespace Foo\ndef x := 1\nend Foo\n',
+    "def c : Char := 'a'\n",
+  ];
+  for (const src of samples) {
+    it(`round-trips: ${JSON.stringify(src.slice(0, 40))}`, () => {
+      const r = roundTrip(src, 'lean');
+      assert.strictEqual(r.roundTripped, src);
+      assert.strictEqual(r.ok, true);
+    });
+  }
+});
+
+describe('Rocq round-trip', () => {
+  const samples = [
+    '',
+    '(* comment *)\nDefinition x := 1.\n',
+    '(* nested (* inside *) *)\nDefinition y := 2.\n',
+    'Definition id {A : Type} (x : A) : A := x.\n',
+    'Theorem t : 1 + 1 = 2. Proof. reflexivity. Qed.\n',
+    'Inductive list (A : Type) : Type :=\n  | nil\n  | cons (x : A) (xs : list A).\n',
+    'Definition s := "hello, ""world""".\n',
+    'Definition n := 0xff.\n',
+    'Require Import Coq.Lists.List.\n',
+  ];
+  for (const src of samples) {
+    it(`round-trips: ${JSON.stringify(src.slice(0, 40))}`, () => {
+      const r = roundTrip(src, 'rocq');
+      assert.strictEqual(r.roundTripped, src);
+      assert.strictEqual(r.ok, true);
+    });
+  }
+});
+
+describe('cross-converter dispatch', () => {
+  it('SUPPORTED_LANGUAGES lists the four host languages plus js alias', () => {
+    assert.deepStrictEqual([...SUPPORTED_LANGUAGES].sort(), ['javascript', 'js', 'lean', 'rocq', 'rust']);
+  });
+
+  it('parseToCst / printFromCst dispatch by language name', () => {
+    for (const lang of ['rust', 'js', 'lean', 'rocq']) {
+      const sample = lang === 'rocq' ? 'Definition x := 1.\n' : 'x\n';
+      const out = printFromCst(parseToCst(sample, lang), lang);
+      assert.strictEqual(out, sample);
+    }
+  });
+
+  it("'javascript' alias works the same as 'js'", () => {
+    const src = 'const x = 1;\n';
+    assert.strictEqual(printFromCst(parseToCst(src, 'javascript'), 'javascript'), src);
+  });
+
+  it('rejects unsupported languages', () => {
+    assert.throws(() => parseToCst('x', 'python'), /unsupported language/);
+    assert.throws(() => printFromCst(list('x', []), 'python'), /unsupported language/);
+  });
+});
+
+describe('CST encoding preserves comments and whitespace explicitly', () => {
+  it('Rust line and block comments survive as trivia leaves', () => {
+    const src = '// leading\nfn f() {\n  /* mid */ 1\n}\n';
+    const tree = parseRust(src);
+    const leafList = Array.from(leaves(tree));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text === '// leading'));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text === '/* mid */'));
+    assert.strictEqual(printRust(tree), src);
+  });
+
+  it('JS hashbang and comments survive', () => {
+    const src = '#!/usr/bin/env node\n// hi\nlet x = 1;\n';
+    const tree = parseJs(src);
+    const leafList = Array.from(leaves(tree));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text.startsWith('#!')));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text === '// hi'));
+    assert.strictEqual(printJs(tree), src);
+  });
+
+  it('Lean nested block comments survive', () => {
+    const src = '/- outer /- inner -/ still outer -/\ndef x := 1\n';
+    const tree = parseLean(src);
+    const leafList = Array.from(leaves(tree));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text.startsWith('/- outer')));
+    assert.strictEqual(printLean(tree), src);
+  });
+
+  it('Rocq nested comments survive', () => {
+    const src = '(* a (* b *) c *)\nDefinition x := 1.\n';
+    const tree = parseRocq(src);
+    const leafList = Array.from(leaves(tree));
+    assert.ok(leafList.some(n => n.kind === 'trivia' && n.text === '(* a (* b *) c *)'));
+    assert.strictEqual(printRocq(tree), src);
+  });
+});
+
+describe('repository corpus round-trip', () => {
+  // Verify that real, repository-tracked source files in each host language
+  // round-trip byte-for-byte. This is the "bootstrap" criterion described in
+  // docs/case-studies/issue-138/acceptance-tests.md.
+  function readIfExists(p) {
+    try { return fs.readFileSync(p, 'utf8'); } catch { return null; }
+  }
+
+  it('round-trips js/src/cst.mjs (this module is itself JS source)', () => {
+    const src = readIfExists(path.join(repoRoot, 'js', 'src', 'cst.mjs'));
+    if (src === null) return;
+    assert.strictEqual(printJs(parseJs(src)), src);
+  });
+
+  it('round-trips rust/src/main.rs', () => {
+    const src = readIfExists(path.join(repoRoot, 'rust', 'src', 'main.rs'));
+    if (src === null) return;
+    assert.strictEqual(printRust(parseRust(src)), src);
+  });
+
+  it('round-trips examples/lean-export-basic.lean', () => {
+    const src = readIfExists(path.join(repoRoot, 'examples', 'lean-export-basic.lean'));
+    if (src === null) return;
+    assert.strictEqual(printLean(parseLean(src)), src);
+  });
+
+  it('round-trips examples/isabelle-typed-fragment.thy as Rocq-style block-comment source', () => {
+    // Isabelle uses (* ... *) like Rocq for some comment styles; the
+    // token-stream converter is permissive enough that this still round-trips.
+    const src = readIfExists(path.join(repoRoot, 'examples', 'isabelle-typed-fragment.thy'));
+    if (src === null) return;
+    assert.strictEqual(printRocq(parseRocq(src)), src);
+  });
+});

--- a/rust/examples/cst_roundtrip_demo.rs
+++ b/rust/examples/cst_roundtrip_demo.rs
@@ -1,0 +1,91 @@
+//! Universal CST converter round-trip demo (issue #138).
+//!
+//! Rust counterpart of `examples/cst-roundtrip-demo.mjs`. Run with:
+//!
+//!     cargo run --example cst_roundtrip_demo --manifest-path rust/Cargo.toml
+//!
+//! On success it prints one OK line per language plus a peek at the underlying
+//! `.lino` S-expression. Exits non-zero on any round-trip mismatch.
+
+use rml::cst::{cst_to_lino, CstNode};
+use rml::cst_convert::{parse_to_cst, print_from_cst, round_trip, SUPPORTED_LANGUAGES};
+
+fn main() {
+    let samples: &[(&str, &str)] = &[
+        (
+            "rust",
+            "// add two i64s\npub fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n",
+        ),
+        (
+            "js",
+            "// fetch JSON\nasync function load(url) {\n  const r = await fetch(url);\n  return r.json();\n}\n",
+        ),
+        ("lean", "-- identity\ndef id {α : Type} (x : α) : α := x\n"),
+        (
+            "rocq",
+            "(* identity *)\nDefinition id {A : Type} (x : A) : A := x.\n",
+        ),
+    ];
+
+    println!("Universal CST round-trip demo");
+    println!("-----------------------------");
+    println!("Supported languages: {}", SUPPORTED_LANGUAGES.join(", "));
+    println!();
+
+    let mut all_ok = true;
+    for (lang, src) in samples {
+        let r = round_trip(src, lang).expect("known language");
+        let tree = parse_to_cst(src, lang).expect("known language");
+        let leaf_count = tree.leaves().len();
+        let sexp = cst_to_lino(&tree);
+        let preview: String = sexp.chars().take(60).collect();
+        println!(
+            "{:<5} {}  ({} bytes, {} leaves)",
+            lang,
+            if r.ok { "OK" } else { "FAIL" },
+            src.len(),
+            leaf_count,
+        );
+        println!("        sexp: {}…", preview);
+        if !r.ok {
+            all_ok = false;
+            eprintln!("  expected: {:?}", r.source);
+            eprintln!("  got     : {:?}", r.round_tripped);
+        }
+        let trivia: Vec<String> = tree
+            .leaves()
+            .into_iter()
+            .filter_map(|n| match n {
+                CstNode::Trivia { text, .. } => {
+                    let t = text.trim();
+                    if t.is_empty() {
+                        None
+                    } else {
+                        Some(t.to_string())
+                    }
+                }
+                _ => None,
+            })
+            .collect();
+        println!("        trivia: {:?}", trivia);
+        println!();
+    }
+
+    // Idempotency sanity check.
+    for (lang, src) in samples {
+        let tree = parse_to_cst(src, lang).unwrap();
+        let a = print_from_cst(&tree, lang).unwrap();
+        let b = print_from_cst(&tree, lang).unwrap();
+        if a != b {
+            eprintln!("print_from_cst not idempotent for {}", lang);
+            all_ok = false;
+        }
+    }
+
+    if all_ok {
+        println!("All round-trip checks passed.");
+    } else {
+        eprintln!("One or more round-trip checks failed.");
+        std::process::exit(1);
+    }
+}

--- a/rust/src/cst.rs
+++ b/rust/src/cst.rs
@@ -1,0 +1,427 @@
+//! Universal lossless CST infrastructure for issue #138.
+//!
+//! This module mirrors `js/src/cst.mjs`: three node kinds (`list`, `token`,
+//! `trivia`), a content-agnostic round-trip printer, and `.lino`
+//! serialisation/deserialisation helpers. Used by `cst_rust`, `cst_js`,
+//! `cst_lean` and `cst_rocq` to express their token streams.
+
+use std::fmt::Write;
+
+/// The four host-language dialect tag prefixes plus the shared dialect.
+pub mod dialects {
+    pub const RUST: &str = "lino-cst.rust";
+    pub const JS: &str = "lino-cst.js";
+    pub const LEAN: &str = "lino-cst.lean";
+    pub const ROCQ: &str = "lino-cst.rocq";
+    pub const SHARED: &str = "lino-cst.shared";
+}
+
+/// A CST node. Three kinds: `List` (with optional `open`/`close` delimiters),
+/// `Token` (significant lexeme), `Trivia` (whitespace or comment).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CstNode {
+    /// A list node with an optional dialect tag and optional open/close
+    /// delimiter strings (e.g. `(`, `)`).
+    List {
+        tag: Option<String>,
+        open: Option<String>,
+        close: Option<String>,
+        children: Vec<CstNode>,
+    },
+    /// A non-trivia lexeme. `text` holds the original source bytes.
+    Token { tag: Option<String>, text: String },
+    /// Whitespace or comment trivia. `text` holds the original source bytes.
+    Trivia { tag: Option<String>, text: String },
+}
+
+impl CstNode {
+    /// Construct a `List` node.
+    pub fn list(tag: impl Into<String>, children: Vec<CstNode>) -> Self {
+        CstNode::List {
+            tag: Some(tag.into()),
+            open: None,
+            close: None,
+            children,
+        }
+    }
+
+    /// Construct an untagged `List` node with custom open/close delimiters.
+    pub fn list_with_delims(
+        tag: Option<String>,
+        open: Option<String>,
+        close: Option<String>,
+        children: Vec<CstNode>,
+    ) -> Self {
+        CstNode::List {
+            tag,
+            open,
+            close,
+            children,
+        }
+    }
+
+    /// Construct a `Token` leaf.
+    pub fn token(text: impl Into<String>, tag: Option<&str>) -> Self {
+        CstNode::Token {
+            tag: tag.map(String::from),
+            text: text.into(),
+        }
+    }
+
+    /// Construct a `Trivia` leaf.
+    pub fn trivia(text: impl Into<String>, tag: Option<&str>) -> Self {
+        CstNode::Trivia {
+            tag: tag.map(String::from),
+            text: text.into(),
+        }
+    }
+
+    /// True if this node is a list.
+    pub fn is_list(&self) -> bool {
+        matches!(self, CstNode::List { .. })
+    }
+
+    /// The dialect tag, if any.
+    pub fn tag(&self) -> Option<&str> {
+        match self {
+            CstNode::List { tag, .. } => tag.as_deref(),
+            CstNode::Token { tag, .. } => tag.as_deref(),
+            CstNode::Trivia { tag, .. } => tag.as_deref(),
+        }
+    }
+
+    /// The textual content of a leaf node. Returns `""` for lists.
+    pub fn text(&self) -> &str {
+        match self {
+            CstNode::Token { text, .. } => text,
+            CstNode::Trivia { text, .. } => text,
+            CstNode::List { .. } => "",
+        }
+    }
+
+    /// Iterate every leaf (token/trivia) of this subtree in document order.
+    pub fn leaves(&self) -> Vec<&CstNode> {
+        let mut out = Vec::new();
+        collect_leaves(self, &mut out);
+        out
+    }
+}
+
+fn collect_leaves<'a>(node: &'a CstNode, out: &mut Vec<&'a CstNode>) {
+    match node {
+        CstNode::List { children, .. } => {
+            for c in children {
+                collect_leaves(c, out);
+            }
+        }
+        _ => out.push(node),
+    }
+}
+
+/// Print a CST node back to its byte-faithful source form.
+pub fn print_cst(node: &CstNode) -> String {
+    let mut out = String::new();
+    emit(node, &mut out);
+    out
+}
+
+fn emit(node: &CstNode, out: &mut String) {
+    match node {
+        CstNode::Token { text, .. } | CstNode::Trivia { text, .. } => {
+            out.push_str(text);
+        }
+        CstNode::List {
+            children,
+            open,
+            close,
+            ..
+        } => {
+            if let Some(o) = open {
+                out.push_str(o);
+            }
+            for c in children {
+                emit(c, out);
+            }
+            if let Some(c) = close {
+                out.push_str(c);
+            }
+        }
+    }
+}
+
+/// Serialise a CST node into a `.lino` S-expression matching the format
+/// produced by `js/src/cst.mjs`'s `cstToLino`.
+pub fn cst_to_lino(node: &CstNode) -> String {
+    let mut out = String::new();
+    write_lino(node, &mut out);
+    out
+}
+
+fn write_lino(node: &CstNode, out: &mut String) {
+    match node {
+        CstNode::Token { text, .. } => {
+            let _ = write!(out, "(lino-cst.token {})", escape_text(text));
+        }
+        CstNode::Trivia { text, .. } => {
+            let _ = write!(out, "(lino-cst.trivia {})", escape_text(text));
+        }
+        CstNode::List {
+            tag,
+            open,
+            close,
+            children,
+        } => {
+            out.push('(');
+            out.push_str("lino-cst.list");
+            if let Some(t) = tag {
+                out.push(' ');
+                out.push_str(t);
+            }
+            if let Some(o) = open {
+                let _ = write!(out, " (open {})", escape_text(o));
+            }
+            if let Some(c) = close {
+                let _ = write!(out, " (close {})", escape_text(c));
+            }
+            for c in children {
+                out.push(' ');
+                write_lino(c, out);
+            }
+            out.push(')');
+        }
+    }
+}
+
+fn escape_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + 2);
+    out.push('"');
+    for ch in text.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x08' => out.push_str("\\b"),
+            '\x0C' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Parse the `.lino` S-expression produced by `cst_to_lino` back into a
+/// `CstNode`. Inverse of `cst_to_lino`.
+pub fn lino_to_cst(src: &str) -> Result<CstNode, String> {
+    let tokens = tokenise_lino_cst(src)?;
+    let mut idx = 0usize;
+    let node = parse_node(&tokens, &mut idx)?;
+    Ok(node)
+}
+
+fn parse_node(tokens: &[String], idx: &mut usize) -> Result<CstNode, String> {
+    expect(tokens, idx, "(")?;
+    let head = eat(tokens, idx)?;
+    match head.as_str() {
+        "lino-cst.token" => {
+            let lit = eat(tokens, idx)?;
+            expect(tokens, idx, ")")?;
+            Ok(CstNode::token(unescape_text(&lit)?, None))
+        }
+        "lino-cst.trivia" => {
+            let lit = eat(tokens, idx)?;
+            expect(tokens, idx, ")")?;
+            Ok(CstNode::trivia(unescape_text(&lit)?, None))
+        }
+        "lino-cst.list" => {
+            let mut tag: Option<String> = None;
+            let mut open: Option<String> = None;
+            let mut close: Option<String> = None;
+            let mut children: Vec<CstNode> = Vec::new();
+            while peek(tokens, *idx)? != ")" {
+                if peek(tokens, *idx)? == "(" {
+                    let lookahead = peek(tokens, *idx + 1)?;
+                    if lookahead == "open" {
+                        *idx += 2;
+                        let lit = eat(tokens, idx)?;
+                        expect(tokens, idx, ")")?;
+                        open = Some(unescape_text(&lit)?);
+                        continue;
+                    }
+                    if lookahead == "close" {
+                        *idx += 2;
+                        let lit = eat(tokens, idx)?;
+                        expect(tokens, idx, ")")?;
+                        close = Some(unescape_text(&lit)?);
+                        continue;
+                    }
+                    children.push(parse_node(tokens, idx)?);
+                } else {
+                    if tag.is_some() {
+                        return Err(format!("unexpected token {:?}", peek(tokens, *idx)?));
+                    }
+                    tag = Some(eat(tokens, idx)?);
+                }
+            }
+            expect(tokens, idx, ")")?;
+            Ok(CstNode::list_with_delims(tag, open, close, children))
+        }
+        other => Err(format!("unknown CST tag: {}", other)),
+    }
+}
+
+fn peek(tokens: &[String], idx: usize) -> Result<&str, String> {
+    tokens
+        .get(idx)
+        .map(String::as_str)
+        .ok_or_else(|| "unexpected end of input".to_string())
+}
+
+fn eat(tokens: &[String], idx: &mut usize) -> Result<String, String> {
+    let s = tokens
+        .get(*idx)
+        .cloned()
+        .ok_or_else(|| "unexpected end of input".to_string())?;
+    *idx += 1;
+    Ok(s)
+}
+
+fn expect(tokens: &[String], idx: &mut usize, t: &str) -> Result<(), String> {
+    let got = eat(tokens, idx)?;
+    if got != t {
+        return Err(format!("expected {:?}, got {:?}", t, got));
+    }
+    Ok(())
+}
+
+fn tokenise_lino_cst(src: &str) -> Result<Vec<String>, String> {
+    let bytes: Vec<char> = src.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c == '(' || c == ')' {
+            out.push(c.to_string());
+            i += 1;
+            continue;
+        }
+        if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+            i += 1;
+            continue;
+        }
+        if c == '"' {
+            let mut j = i + 1;
+            while j < bytes.len() {
+                if bytes[j] == '\\' {
+                    j += 2;
+                    continue;
+                }
+                if bytes[j] == '"' {
+                    break;
+                }
+                j += 1;
+            }
+            if j >= bytes.len() {
+                return Err("unterminated string literal".to_string());
+            }
+            out.push(bytes[i..=j].iter().collect());
+            i = j + 1;
+            continue;
+        }
+        let mut j = i;
+        while j < bytes.len() && !" \t\n\r()".contains(bytes[j]) {
+            j += 1;
+        }
+        out.push(bytes[i..j].iter().collect());
+        i = j;
+    }
+    Ok(out)
+}
+
+fn unescape_text(literal: &str) -> Result<String, String> {
+    let chars: Vec<char> = literal.chars().collect();
+    if chars.first() != Some(&'"') || chars.last() != Some(&'"') {
+        return Err(format!("not a string literal: {}", literal));
+    }
+    let mut out = String::new();
+    let mut i = 1;
+    while i < chars.len() - 1 {
+        let c = chars[i];
+        if c == '\\' {
+            i += 1;
+            if i >= chars.len() - 1 {
+                return Err("trailing backslash".to_string());
+            }
+            let esc = chars[i];
+            match esc {
+                '"' => out.push('"'),
+                '\\' => out.push('\\'),
+                '/' => out.push('/'),
+                'n' => out.push('\n'),
+                'r' => out.push('\r'),
+                't' => out.push('\t'),
+                'b' => out.push('\x08'),
+                'f' => out.push('\x0C'),
+                'u' => {
+                    if i + 4 >= chars.len() {
+                        return Err("bad \\u escape".to_string());
+                    }
+                    let hex: String = chars[i + 1..=i + 4].iter().collect();
+                    let cp = u32::from_str_radix(&hex, 16)
+                        .map_err(|e| format!("bad \\u escape: {}", e))?;
+                    if let Some(ch) = char::from_u32(cp) {
+                        out.push(ch);
+                    }
+                    i += 4;
+                }
+                other => return Err(format!("unknown escape: \\{}", other)),
+            }
+            i += 1;
+        } else {
+            out.push(c);
+            i += 1;
+        }
+    }
+    Ok(out)
+}
+
+/// Convenience: return a clone of `node`. Provided for parity with the JS
+/// module which exports `cloneCst` explicitly.
+pub fn clone_cst(node: &CstNode) -> CstNode {
+    node.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prints_list_with_open_close() {
+        let n = CstNode::list_with_delims(
+            Some("demo".into()),
+            Some("(".into()),
+            Some(")".into()),
+            vec![CstNode::token("a", None), CstNode::token("b", None)],
+        );
+        assert_eq!(print_cst(&n), "(ab)");
+    }
+
+    #[test]
+    fn lino_round_trip_for_token_trivia_list() {
+        let n = CstNode::list(
+            "lino-cst.rust.fn",
+            vec![
+                CstNode::token("fn ", Some("kw")),
+                CstNode::token("foo", Some("ident")),
+                CstNode::trivia(" ", Some("ws")),
+            ],
+        );
+        let s = cst_to_lino(&n);
+        let back = lino_to_cst(&s).unwrap();
+        assert_eq!(print_cst(&n), print_cst(&back));
+    }
+}

--- a/rust/src/cst_convert.rs
+++ b/rust/src/cst_convert.rs
@@ -1,0 +1,99 @@
+//! Universal CST converter dispatch (issue #138).
+//!
+//! Single entry point that turns host-language source into a `.lino` CST and
+//! back. Mirrors `js/src/cst-convert.mjs`. Provides:
+//!
+//! - [`parse_to_cst`] — host source → CST.
+//! - [`print_from_cst`] — CST → host source.
+//! - [`round_trip`] — convenience helper that asserts byte fidelity.
+//!
+//! Supported `lang` values: `"rust"`, `"js"` (or `"javascript"`), `"lean"`, `"rocq"`.
+
+use crate::cst::CstNode;
+use crate::cst_js::{parse_js, print_js};
+use crate::cst_lean::{parse_lean, print_lean};
+use crate::cst_rocq::{parse_rocq, print_rocq};
+use crate::cst_rust::{parse_rust, print_rust};
+
+/// The four host languages plus the `javascript` alias.
+pub const SUPPORTED_LANGUAGES: &[&str] = &["rust", "js", "javascript", "lean", "rocq"];
+
+/// Parse host-language source into a `.lino` CST.
+pub fn parse_to_cst(src: &str, lang: &str) -> Result<CstNode, String> {
+    match lang {
+        "rust" => Ok(parse_rust(src)),
+        "js" | "javascript" => Ok(parse_js(src)),
+        "lean" => Ok(parse_lean(src)),
+        "rocq" => Ok(parse_rocq(src)),
+        other => Err(format!("unsupported language for parse_to_cst: {}", other)),
+    }
+}
+
+/// Print a CST node back to host-language source.
+pub fn print_from_cst(node: &CstNode, lang: &str) -> Result<String, String> {
+    match lang {
+        "rust" => Ok(print_rust(node)),
+        "js" | "javascript" => Ok(print_js(node)),
+        "lean" => Ok(print_lean(node)),
+        "rocq" => Ok(print_rocq(node)),
+        other => Err(format!("unsupported language for print_from_cst: {}", other)),
+    }
+}
+
+/// Result of a round-trip check.
+pub struct RoundTripResult {
+    pub ok: bool,
+    pub source: String,
+    pub round_tripped: String,
+}
+
+/// Verify that `print_from_cst(parse_to_cst(src, lang), lang) == src`.
+pub fn round_trip(src: &str, lang: &str) -> Result<RoundTripResult, String> {
+    let cst = parse_to_cst(src, lang)?;
+    let round_tripped = print_from_cst(&cst, lang)?;
+    Ok(RoundTripResult {
+        ok: round_tripped == src,
+        source: src.to_string(),
+        round_tripped,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatches_by_language_name() {
+        for lang in &["rust", "js", "lean", "rocq"] {
+            let sample = if *lang == "rocq" {
+                "Definition x := 1.\n"
+            } else {
+                "x\n"
+            };
+            let out = print_from_cst(&parse_to_cst(sample, lang).unwrap(), lang).unwrap();
+            assert_eq!(out, sample);
+        }
+    }
+
+    #[test]
+    fn javascript_alias_works_like_js() {
+        let src = "const x = 1;\n";
+        let out =
+            print_from_cst(&parse_to_cst(src, "javascript").unwrap(), "javascript").unwrap();
+        assert_eq!(out, src);
+    }
+
+    #[test]
+    fn rejects_unsupported_language() {
+        assert!(parse_to_cst("x", "python").is_err());
+        let n = CstNode::list("x", vec![]);
+        assert!(print_from_cst(&n, "python").is_err());
+    }
+
+    #[test]
+    fn round_trip_helper_reports_ok() {
+        let r = round_trip("fn main() {}\n", "rust").unwrap();
+        assert!(r.ok);
+        assert_eq!(r.round_tripped, "fn main() {}\n");
+    }
+}

--- a/rust/src/cst_js.rs
+++ b/rust/src/cst_js.rs
@@ -1,0 +1,402 @@
+//! JavaScript ↔ `.lino` CST converter (issue #138).
+//!
+//! Token-level lossless converter for JavaScript source. Produces a
+//! `lino-cst.js.*` flat CST whose round-trip is byte-faithful:
+//! `print_js(&parse_js(src)) == src`. Mirrors `js/src/cst-js.mjs`
+//! line for line.
+
+use crate::cst::{dialects::JS, print_cst, CstNode};
+
+/// Parse JavaScript source into a `lino-cst.js.*` CST.
+pub fn parse_js(src: &str) -> CstNode {
+    let children = tokenise(src);
+    CstNode::list(format!("{}.program", JS), children)
+}
+
+/// Print a JS CST back to source.
+pub fn print_js(node: &CstNode) -> String {
+    print_cst(node)
+}
+
+#[derive(Clone, Copy)]
+enum LastKind {
+    None,
+    Trivia,
+    Ident,
+    Punct,
+    Other,
+}
+
+fn tokenise(src: &str) -> Vec<CstNode> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out: Vec<CstNode> = Vec::new();
+    let mut i = 0usize;
+    let mut last_kind = LastKind::None;
+    let mut last_text: String = String::new();
+
+    if chars.len() >= 2 && chars[0] == '#' && chars[1] == '!' {
+        let mut j = 0usize;
+        while j < chars.len() && chars[j] != '\n' {
+            j += 1;
+        }
+        out.push(CstNode::trivia(
+            chars[..j].iter().collect::<String>(),
+            Some(&format!("{}.hashbang", JS)),
+        ));
+        i = j;
+    }
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+            let mut j = i;
+            while j < chars.len()
+                && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\r' || chars[j] == '\n')
+            {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.whitespace", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Trivia;
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'/') {
+            let mut j = i + 2;
+            while j < chars.len() && chars[j] != '\n' {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment.line", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Trivia;
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'*') {
+            let j = scan_block_comment(&chars, i);
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment.block", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Trivia;
+            continue;
+        }
+
+        if c == '"' || c == '\'' {
+            let j = scan_string(&chars, i + 1, c);
+            let text: String = chars[i..j].iter().collect();
+            out.push(CstNode::token(
+                text.clone(),
+                Some(&format!("{}.string_literal", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Other;
+            last_text = text;
+            continue;
+        }
+
+        if c == '`' {
+            let j = scan_template(&chars, i);
+            let text: String = chars[i..j].iter().collect();
+            out.push(CstNode::token(
+                text.clone(),
+                Some(&format!("{}.template_literal", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Other;
+            last_text = text;
+            continue;
+        }
+
+        if c == '/' && can_be_regex(last_kind, &last_text) {
+            let j = scan_regex(&chars, i);
+            if j > i + 1 {
+                let text: String = chars[i..j].iter().collect();
+                out.push(CstNode::token(
+                    text.clone(),
+                    Some(&format!("{}.regexp_literal", JS)),
+                ));
+                i = j;
+                last_kind = LastKind::Other;
+                last_text = text;
+                continue;
+            }
+        }
+
+        if c.is_ascii_digit()
+            || (c == '.' && chars.get(i + 1).map(|x| x.is_ascii_digit()).unwrap_or(false))
+        {
+            let j = scan_number(&chars, i);
+            let text: String = chars[i..j].iter().collect();
+            out.push(CstNode::token(
+                text.clone(),
+                Some(&format!("{}.numeric_literal", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Other;
+            last_text = text;
+            continue;
+        }
+
+        if is_ident_start(c) {
+            let mut j = i + 1;
+            while j < chars.len() && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            let text: String = chars[i..j].iter().collect();
+            out.push(CstNode::token(
+                text.clone(),
+                Some(&format!("{}.ident", JS)),
+            ));
+            i = j;
+            last_kind = LastKind::Ident;
+            last_text = text;
+            continue;
+        }
+
+        let text = c.to_string();
+        out.push(CstNode::token(
+            text.clone(),
+            Some(&format!("{}.punct", JS)),
+        ));
+        i += 1;
+        last_kind = LastKind::Punct;
+        last_text = text;
+    }
+
+    out
+}
+
+fn scan_block_comment(chars: &[char], i: usize) -> usize {
+    let mut j = i + 2;
+    while j < chars.len() {
+        if chars[j] == '*' && chars.get(j + 1) == Some(&'/') {
+            return j + 2;
+        }
+        j += 1;
+    }
+    chars.len()
+}
+
+fn scan_string(chars: &[char], mut j: usize, quote: char) -> usize {
+    while j < chars.len() {
+        let c = chars[j];
+        if c == '\\' {
+            j += 2;
+            continue;
+        }
+        if c == '\n' && (quote == '"' || quote == '\'') {
+            return j;
+        }
+        if c == quote {
+            return j + 1;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_template(chars: &[char], i: usize) -> usize {
+    let mut j = i + 1;
+    while j < chars.len() {
+        let c = chars[j];
+        if c == '\\' {
+            j += 2;
+            continue;
+        }
+        if c == '`' {
+            return j + 1;
+        }
+        if c == '$' && chars.get(j + 1) == Some(&'{') {
+            j += 2;
+            let mut depth = 1;
+            while j < chars.len() && depth > 0 {
+                let k = chars[j];
+                if k == '{' {
+                    depth += 1;
+                } else if k == '}' {
+                    depth -= 1;
+                } else if k == '"' || k == '\'' {
+                    j = scan_string(chars, j + 1, k).saturating_sub(1);
+                } else if k == '`' {
+                    j = scan_template(chars, j).saturating_sub(1);
+                } else if k == '/' && chars.get(j + 1) == Some(&'/') {
+                    while j < chars.len() && chars[j] != '\n' {
+                        j += 1;
+                    }
+                    continue;
+                } else if k == '/' && chars.get(j + 1) == Some(&'*') {
+                    j = scan_block_comment(chars, j);
+                    continue;
+                }
+                j += 1;
+            }
+            continue;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_regex(chars: &[char], i: usize) -> usize {
+    let mut j = i + 1;
+    let mut in_class = false;
+    while j < chars.len() {
+        let c = chars[j];
+        if c == '\\' {
+            j += 2;
+            continue;
+        }
+        if c == '[' {
+            in_class = true;
+        } else if c == ']' {
+            in_class = false;
+        } else if c == '/' && !in_class {
+            j += 1;
+            while j < chars.len() && chars[j].is_ascii_alphabetic() {
+                j += 1;
+            }
+            return j;
+        } else if c == '\n' {
+            return i + 1;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_number(chars: &[char], i: usize) -> usize {
+    let mut j = i;
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('x') | Some('X')) {
+        j += 2;
+        while j < chars.len() && (chars[j].is_ascii_hexdigit() || chars[j] == '_') {
+            j += 1;
+        }
+    } else if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('o') | Some('O')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0'..='7' | '_') {
+            j += 1;
+        }
+    } else if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('b') | Some('B')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0' | '1' | '_') {
+            j += 1;
+        }
+    } else {
+        while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+            j += 1;
+        }
+        if chars.get(j) == Some(&'.') {
+            j += 1;
+            while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                j += 1;
+            }
+        }
+        if matches!(chars.get(j), Some('e') | Some('E')) {
+            j += 1;
+            if matches!(chars.get(j), Some('+') | Some('-')) {
+                j += 1;
+            }
+            while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                j += 1;
+            }
+        }
+    }
+    if chars.get(j) == Some(&'n') {
+        j += 1;
+    }
+    j
+}
+
+const REGEX_PRECEDING_KEYWORDS: &[&str] = &[
+    "return",
+    "typeof",
+    "instanceof",
+    "in",
+    "of",
+    "do",
+    "else",
+    "throw",
+    "new",
+    "delete",
+    "void",
+    "await",
+    "yield",
+    "case",
+];
+
+fn can_be_regex(last_kind: LastKind, last_text: &str) -> bool {
+    match last_kind {
+        LastKind::None | LastKind::Trivia => true,
+        LastKind::Ident => REGEX_PRECEDING_KEYWORDS.iter().any(|k| *k == last_text),
+        LastKind::Punct => !(last_text == ")" || last_text == "]"),
+        LastKind::Other => false,
+    }
+}
+
+fn is_ident_start(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphabetic() || (c as u32) > 0x7F
+}
+
+fn is_ident_continue(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphanumeric() || (c as u32) > 0x7F
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt(src: &str) {
+        let node = parse_js(src);
+        let back = print_js(&node);
+        assert_eq!(back, src, "round-trip mismatch");
+    }
+
+    #[test]
+    fn empty_string() {
+        rt("");
+    }
+
+    #[test]
+    fn simple_const() {
+        rt("const x = 1;\n");
+    }
+
+    #[test]
+    fn comments_and_strings() {
+        rt("// hi\n/* block */ const s = 'a\\'b';\n");
+    }
+
+    #[test]
+    fn template_with_nested_expr() {
+        rt("const t = `nested ${`inner ${1+2}`} done`;\n");
+    }
+
+    #[test]
+    fn regex_after_assignment() {
+        rt("const r = /foo\\/bar/g;\n");
+    }
+
+    #[test]
+    fn divide_after_paren_is_not_regex() {
+        rt("const x = (1)/2;\n");
+    }
+
+    #[test]
+    fn bigint_and_hex() {
+        rt("const n = 0xff_ff;\nconst b = 0b1010n;\nconst f = 3.14e-2;\n");
+    }
+
+    #[test]
+    fn hashbang_preserved() {
+        rt("#!/usr/bin/env node\nconsole.log(\"hi\");\n");
+    }
+}

--- a/rust/src/cst_lean.rs
+++ b/rust/src/cst_lean.rs
@@ -1,0 +1,311 @@
+//! Lean 4 ↔ `.lino` CST converter (issue #138).
+//!
+//! Token-level lossless converter for Lean 4 source. Produces a
+//! `lino-cst.lean.*` flat CST whose round-trip is byte-faithful:
+//! `print_lean(&parse_lean(src)) == src`. Mirrors `js/src/cst-lean.mjs`
+//! line for line.
+
+use crate::cst::{dialects::LEAN, print_cst, CstNode};
+
+/// Parse Lean 4 source into a `lino-cst.lean.*` CST.
+pub fn parse_lean(src: &str) -> CstNode {
+    let children = tokenise(src);
+    CstNode::list(format!("{}.module", LEAN), children)
+}
+
+/// Print a Lean CST back to source.
+pub fn print_lean(node: &CstNode) -> String {
+    print_cst(node)
+}
+
+fn tokenise(src: &str) -> Vec<CstNode> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out: Vec<CstNode> = Vec::new();
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+            let mut j = i;
+            while j < chars.len()
+                && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\r' || chars[j] == '\n')
+            {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.whitespace", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '-' && chars.get(i + 1) == Some(&'-') {
+            let mut j = i + 2;
+            while j < chars.len() && chars[j] != '\n' {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment.line", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'-') {
+            let j = scan_block_comment(&chars, i);
+            let tag = if chars.get(i + 2) == Some(&'-') {
+                format!("{}.doc.block", LEAN)
+            } else {
+                format!("{}.comment.block", LEAN)
+            };
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&tag),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '"' {
+            let j = scan_string(&chars, i + 1, '"');
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.string_literal", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == 'r' && chars.get(i + 1) == Some(&'"') {
+            let j = scan_string(&chars, i + 2, '"');
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.raw_string_literal", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '\'' {
+            let mut j = i + 1;
+            if chars.get(j) == Some(&'\\') {
+                j += 2;
+            } else {
+                j += 1;
+            }
+            if chars.get(j) == Some(&'\'') {
+                j += 1;
+                out.push(CstNode::token(
+                    chars[i..j].iter().collect::<String>(),
+                    Some(&format!("{}.char_literal", LEAN)),
+                ));
+                i = j;
+                continue;
+            }
+            // Not a valid char literal; fall through to punctuation.
+        }
+
+        if c.is_ascii_digit() {
+            let j = scan_number(&chars, i);
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.numeric_literal", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if is_ident_start(c) {
+            let mut j = i + 1;
+            while j < chars.len() && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            // Dotted hierarchical name: `Nat.succ`, `List.foldr`.
+            while chars.get(j) == Some(&'.')
+                && chars
+                    .get(j + 1)
+                    .map(|c| is_ident_start(*c))
+                    .unwrap_or(false)
+            {
+                j += 1;
+                while j < chars.len() && is_ident_continue(chars[j]) {
+                    j += 1;
+                }
+            }
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.ident", LEAN)),
+            ));
+            i = j;
+            continue;
+        }
+
+        // Multi-byte / other punctuation: emit one codepoint.
+        out.push(CstNode::token(
+            c.to_string(),
+            Some(&format!("{}.punct", LEAN)),
+        ));
+        i += 1;
+    }
+
+    out
+}
+
+fn scan_block_comment(chars: &[char], i: usize) -> usize {
+    let mut j = i + 2;
+    let mut depth = 1;
+    while j < chars.len() && depth > 0 {
+        if chars[j] == '/' && chars.get(j + 1) == Some(&'-') {
+            depth += 1;
+            j += 2;
+        } else if chars[j] == '-' && chars.get(j + 1) == Some(&'/') {
+            depth -= 1;
+            j += 2;
+        } else {
+            j += 1;
+        }
+    }
+    j
+}
+
+fn scan_string(chars: &[char], mut j: usize, quote: char) -> usize {
+    while j < chars.len() {
+        let c = chars[j];
+        if c == '\\' {
+            j += 2;
+            continue;
+        }
+        if c == quote {
+            return j + 1;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_number(chars: &[char], i: usize) -> usize {
+    let mut j = i;
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('x') | Some('X')) {
+        j += 2;
+        while j < chars.len() && chars[j].is_ascii_hexdigit() {
+            j += 1;
+        }
+        return j;
+    }
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('o') | Some('O')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0'..='7') {
+            j += 1;
+        }
+        return j;
+    }
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('b') | Some('B')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0' | '1') {
+            j += 1;
+        }
+        return j;
+    }
+    while j < chars.len() && chars[j].is_ascii_digit() {
+        j += 1;
+    }
+    if chars.get(j) == Some(&'.')
+        && chars.get(j + 1).map(|c| c.is_ascii_digit()).unwrap_or(false)
+    {
+        j += 1;
+        while j < chars.len() && chars[j].is_ascii_digit() {
+            j += 1;
+        }
+        if matches!(chars.get(j), Some('e') | Some('E')) {
+            j += 1;
+            if matches!(chars.get(j), Some('+') | Some('-')) {
+                j += 1;
+            }
+            while j < chars.len() && chars[j].is_ascii_digit() {
+                j += 1;
+            }
+        }
+    }
+    j
+}
+
+fn is_ident_start(c: char) -> bool {
+    if c == '_' || c.is_ascii_alphabetic() {
+        return true;
+    }
+    if (c as u32) > 0x7F {
+        return !is_lean_punct_char(c);
+    }
+    false
+}
+
+fn is_ident_continue(c: char) -> bool {
+    if c == '_' || c == '\'' || c == '!' || c == '?' || c.is_ascii_alphanumeric() {
+        return true;
+    }
+    if (c as u32) > 0x7F {
+        return !is_lean_punct_char(c);
+    }
+    false
+}
+
+fn is_lean_punct_char(c: char) -> bool {
+    matches!(
+        c,
+        '→' | '←' | '↦' | '⟨' | '⟩' | '⟦' | '⟧' | '«' | '»' | '‹' | '›'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt(src: &str) {
+        let node = parse_lean(src);
+        let back = print_lean(&node);
+        assert_eq!(back, src, "round-trip mismatch");
+    }
+
+    #[test]
+    fn empty_string() {
+        rt("");
+    }
+
+    #[test]
+    fn simple_def() {
+        rt("def f : Nat := 1\n");
+    }
+
+    #[test]
+    fn line_comment() {
+        rt("-- comment\ndef f : Nat := 1\n");
+    }
+
+    #[test]
+    fn block_and_doc_comments() {
+        rt("/- block -/\n/-- doc -/\n/-! module -/\n");
+    }
+
+    #[test]
+    fn nested_block_comment() {
+        rt("/- outer /- inner -/ still outer -/\ndef x := 1\n");
+    }
+
+    #[test]
+    fn unicode_ident_and_arrow() {
+        rt("def id {α : Type} (x : α) : α := x\n");
+    }
+
+    #[test]
+    fn dotted_ident() {
+        rt("#check Nat.succ\n");
+    }
+
+    #[test]
+    fn char_literal() {
+        rt("def c : Char := 'a'\n");
+    }
+}

--- a/rust/src/cst_rocq.rs
+++ b/rust/src/cst_rocq.rs
@@ -1,0 +1,225 @@
+//! Rocq ↔ `.lino` CST converter (issue #138).
+//!
+//! Token-level lossless converter for Rocq (formerly Coq) source. Produces a
+//! `lino-cst.rocq.*` flat CST whose round-trip is byte-faithful:
+//! `print_rocq(&parse_rocq(src)) == src`. Mirrors `js/src/cst-rocq.mjs`
+//! line for line.
+
+use crate::cst::{dialects::ROCQ, print_cst, CstNode};
+
+/// Parse Rocq source into a `lino-cst.rocq.*` CST.
+pub fn parse_rocq(src: &str) -> CstNode {
+    let children = tokenise(src);
+    CstNode::list(format!("{}.document", ROCQ), children)
+}
+
+/// Print a Rocq CST back to source.
+pub fn print_rocq(node: &CstNode) -> String {
+    print_cst(node)
+}
+
+fn tokenise(src: &str) -> Vec<CstNode> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out: Vec<CstNode> = Vec::new();
+    let mut i = 0usize;
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+            let mut j = i;
+            while j < chars.len()
+                && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\r' || chars[j] == '\n')
+            {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.whitespace", ROCQ)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '(' && chars.get(i + 1) == Some(&'*') {
+            let j = scan_block_comment(&chars, i);
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment", ROCQ)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '"' {
+            let j = scan_rocq_string(&chars, i + 1);
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.string_literal", ROCQ)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c.is_ascii_digit() {
+            let j = scan_number(&chars, i);
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.numeric_literal", ROCQ)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if is_ident_start(c) {
+            let mut j = i + 1;
+            while j < chars.len() && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.ident", ROCQ)),
+            ));
+            i = j;
+            continue;
+        }
+
+        out.push(CstNode::token(
+            c.to_string(),
+            Some(&format!("{}.punct", ROCQ)),
+        ));
+        i += 1;
+    }
+
+    out
+}
+
+fn scan_block_comment(chars: &[char], i: usize) -> usize {
+    let mut j = i + 2;
+    let mut depth = 1;
+    while j < chars.len() && depth > 0 {
+        if chars[j] == '(' && chars.get(j + 1) == Some(&'*') {
+            depth += 1;
+            j += 2;
+        } else if chars[j] == '*' && chars.get(j + 1) == Some(&')') {
+            depth -= 1;
+            j += 2;
+        } else {
+            j += 1;
+        }
+    }
+    j
+}
+
+fn scan_rocq_string(chars: &[char], mut j: usize) -> usize {
+    while j < chars.len() {
+        if chars[j] == '"' {
+            if chars.get(j + 1) == Some(&'"') {
+                j += 2;
+                continue;
+            }
+            return j + 1;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_number(chars: &[char], i: usize) -> usize {
+    let mut j = i;
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('x') | Some('X')) {
+        j += 2;
+        while j < chars.len() && chars[j].is_ascii_hexdigit() {
+            j += 1;
+        }
+        return j;
+    }
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('o') | Some('O')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0'..='7') {
+            j += 1;
+        }
+        return j;
+    }
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('b') | Some('B')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0' | '1') {
+            j += 1;
+        }
+        return j;
+    }
+    while j < chars.len() && chars[j].is_ascii_digit() {
+        j += 1;
+    }
+    j
+}
+
+fn is_ident_start(c: char) -> bool {
+    if c == '_' || c.is_ascii_alphabetic() {
+        return true;
+    }
+    if (c as u32) > 0x7F {
+        return !is_rocq_punct_char(c);
+    }
+    false
+}
+
+fn is_ident_continue(c: char) -> bool {
+    if c == '_' || c == '\'' || c.is_ascii_alphanumeric() {
+        return true;
+    }
+    if (c as u32) > 0x7F {
+        return !is_rocq_punct_char(c);
+    }
+    false
+}
+
+fn is_rocq_punct_char(c: char) -> bool {
+    matches!(c, '→' | '←' | '⟨' | '⟩' | '∀' | '∃' | '∧' | '∨' | '¬')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt(src: &str) {
+        let node = parse_rocq(src);
+        let back = print_rocq(&node);
+        assert_eq!(back, src, "round-trip mismatch");
+    }
+
+    #[test]
+    fn empty_string() {
+        rt("");
+    }
+
+    #[test]
+    fn simple_def() {
+        rt("Definition x := 1.\n");
+    }
+
+    #[test]
+    fn nested_block_comment() {
+        rt("(* a (* b *) c *)\nDefinition x := 1.\n");
+    }
+
+    #[test]
+    fn doubled_quote_string() {
+        rt("Definition s := \"hello, \"\"world\"\"\".\n");
+    }
+
+    #[test]
+    fn proof_block() {
+        rt("Theorem t : 1 + 1 = 2. Proof. reflexivity. Qed.\n");
+    }
+
+    #[test]
+    fn hex_number() {
+        rt("Definition n := 0xff.\n");
+    }
+
+    #[test]
+    fn require_import() {
+        rt("Require Import Coq.Lists.List.\n");
+    }
+}

--- a/rust/src/cst_rust.rs
+++ b/rust/src/cst_rust.rs
@@ -1,0 +1,365 @@
+//! Rust ↔ `.lino` CST converter (issue #138).
+//!
+//! Token-level lossless converter for Rust source. Produces a
+//! `lino-cst.rust.*` flat CST whose round-trip is byte-faithful:
+//! `print_rust(&parse_rust(src)) == src`. Mirrors `js/src/cst-rust.mjs`
+//! line for line.
+
+use crate::cst::{dialects::RUST, print_cst, CstNode};
+
+/// Parse Rust source into a `lino-cst.rust.*` CST.
+pub fn parse_rust(src: &str) -> CstNode {
+    let children = tokenise(src);
+    CstNode::list(format!("{}.source_file", RUST), children)
+}
+
+/// Print a Rust CST back to source.
+pub fn print_rust(node: &CstNode) -> String {
+    print_cst(node)
+}
+
+fn tokenise(src: &str) -> Vec<CstNode> {
+    let chars: Vec<char> = src.chars().collect();
+    let mut out: Vec<CstNode> = Vec::new();
+    let mut i = 0usize;
+
+    if chars.len() >= 2 && chars[0] == '#' && chars[1] == '!' && chars.get(2) != Some(&'[') {
+        let mut j = i;
+        while j < chars.len() && chars[j] != '\n' {
+            j += 1;
+        }
+        out.push(CstNode::trivia(
+            chars[i..j].iter().collect::<String>(),
+            Some(&format!("{}.shebang", RUST)),
+        ));
+        i = j;
+    }
+
+    while i < chars.len() {
+        let c = chars[i];
+
+        if c == ' ' || c == '\t' || c == '\r' || c == '\n' {
+            let mut j = i;
+            while j < chars.len()
+                && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\r' || chars[j] == '\n')
+            {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.whitespace", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'/') {
+            let mut j = i + 2;
+            while j < chars.len() && chars[j] != '\n' {
+                j += 1;
+            }
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment.line", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '/' && chars.get(i + 1) == Some(&'*') {
+            let j = scan_block_comment(&chars, i);
+            out.push(CstNode::trivia(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.comment.block", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == '"' {
+            let j = scan_string(&chars, i + 1, '"');
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.string_literal", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        // Raw/byte strings: b"...", r"...", r#"..."#, br"...".
+        if (c == 'b' || c == 'r')
+            && (chars.get(i + 1) == Some(&'"')
+                || (c == 'r' && chars.get(i + 1) == Some(&'#'))
+                || (c == 'b'
+                    && chars.get(i + 1) == Some(&'r')
+                    && (chars.get(i + 2) == Some(&'"') || chars.get(i + 2) == Some(&'#'))))
+        {
+            if let Some(j) = scan_raw_or_prefixed_string(&chars, i) {
+                out.push(CstNode::token(
+                    chars[i..j].iter().collect::<String>(),
+                    Some(&format!("{}.string_literal", RUST)),
+                ));
+                i = j;
+                continue;
+            }
+        }
+
+        if c == '\'' {
+            let lifetime_end = scan_lifetime(&chars, i);
+            if lifetime_end > i + 1 {
+                out.push(CstNode::token(
+                    chars[i..lifetime_end].iter().collect::<String>(),
+                    Some(&format!("{}.lifetime", RUST)),
+                ));
+                i = lifetime_end;
+                continue;
+            }
+            let j = scan_string(&chars, i + 1, '\'');
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.char_literal", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == 'b' && chars.get(i + 1) == Some(&'\'') {
+            let j = scan_string(&chars, i + 2, '\'');
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.byte_literal", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c.is_ascii_digit() {
+            let j = scan_number(&chars, i);
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.numeric_literal", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if c == 'r'
+            && chars.get(i + 1) == Some(&'#')
+            && chars
+                .get(i + 2)
+                .map(|c| is_ident_start(*c))
+                .unwrap_or(false)
+        {
+            let mut j = i + 2;
+            while j < chars.len() && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.raw_ident", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        if is_ident_start(c) {
+            let mut j = i + 1;
+            while j < chars.len() && is_ident_continue(chars[j]) {
+                j += 1;
+            }
+            out.push(CstNode::token(
+                chars[i..j].iter().collect::<String>(),
+                Some(&format!("{}.ident", RUST)),
+            ));
+            i = j;
+            continue;
+        }
+
+        out.push(CstNode::token(
+            c.to_string(),
+            Some(&format!("{}.punct", RUST)),
+        ));
+        i += 1;
+    }
+
+    out
+}
+
+fn scan_block_comment(chars: &[char], i: usize) -> usize {
+    let mut j = i + 2;
+    let mut depth = 1;
+    while j < chars.len() && depth > 0 {
+        if chars[j] == '/' && chars.get(j + 1) == Some(&'*') {
+            depth += 1;
+            j += 2;
+        } else if chars[j] == '*' && chars.get(j + 1) == Some(&'/') {
+            depth -= 1;
+            j += 2;
+        } else {
+            j += 1;
+        }
+    }
+    j
+}
+
+fn scan_string(chars: &[char], mut j: usize, quote: char) -> usize {
+    while j < chars.len() {
+        let c = chars[j];
+        if c == '\\' {
+            j += 2;
+            continue;
+        }
+        if c == quote {
+            return j + 1;
+        }
+        j += 1;
+    }
+    j
+}
+
+fn scan_raw_or_prefixed_string(chars: &[char], i: usize) -> Option<usize> {
+    let mut j = i;
+    if chars.get(j) == Some(&'b') {
+        j += 1;
+    }
+    if chars.get(j) == Some(&'r') {
+        j += 1;
+        let mut hashes = 0;
+        while chars.get(j) == Some(&'#') {
+            hashes += 1;
+            j += 1;
+        }
+        if chars.get(j) != Some(&'"') {
+            return None;
+        }
+        j += 1;
+        let terminator: String =
+            std::iter::once('"').chain(std::iter::repeat('#').take(hashes)).collect();
+        // search for terminator
+        let rest: String = chars[j..].iter().collect();
+        match rest.find(&terminator) {
+            Some(rel) => Some(j + rel + terminator.chars().count()),
+            None => Some(chars.len()),
+        }
+    } else if chars.get(j) == Some(&'"') {
+        Some(scan_string(chars, j + 1, '"'))
+    } else {
+        None
+    }
+}
+
+fn scan_lifetime(chars: &[char], i: usize) -> usize {
+    let mut j = i + 1;
+    if j < chars.len() && is_ident_start(chars[j]) {
+        j += 1;
+        while j < chars.len() && is_ident_continue(chars[j]) {
+            j += 1;
+        }
+        if chars.get(j) == Some(&'\'') {
+            return i;
+        }
+        return j;
+    }
+    i
+}
+
+fn scan_number(chars: &[char], i: usize) -> usize {
+    let mut j = i;
+    if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('x') | Some('X')) {
+        j += 2;
+        while j < chars.len() && (chars[j].is_ascii_hexdigit() || chars[j] == '_') {
+            j += 1;
+        }
+    } else if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('o') | Some('O')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0'..='7' | '_') {
+            j += 1;
+        }
+    } else if chars.get(j) == Some(&'0') && matches!(chars.get(j + 1), Some('b') | Some('B')) {
+        j += 2;
+        while j < chars.len() && matches!(chars[j], '0' | '1' | '_') {
+            j += 1;
+        }
+    } else {
+        while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+            j += 1;
+        }
+        if chars.get(j) == Some(&'.')
+            && chars.get(j + 1).map(|c| c.is_ascii_digit()).unwrap_or(false)
+        {
+            j += 1;
+            while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                j += 1;
+            }
+        }
+        if matches!(chars.get(j), Some('e') | Some('E')) {
+            j += 1;
+            if matches!(chars.get(j), Some('+') | Some('-')) {
+                j += 1;
+            }
+            while j < chars.len() && (chars[j].is_ascii_digit() || chars[j] == '_') {
+                j += 1;
+            }
+        }
+    }
+    if j < chars.len() && is_ident_start(chars[j]) {
+        while j < chars.len() && is_ident_continue(chars[j]) {
+            j += 1;
+        }
+    }
+    j
+}
+
+fn is_ident_start(c: char) -> bool {
+    c == '_' || c.is_ascii_alphabetic() || (c as u32) > 0x7F
+}
+
+fn is_ident_continue(c: char) -> bool {
+    c == '_' || c.is_ascii_alphanumeric() || (c as u32) > 0x7F
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rt(src: &str) {
+        let node = parse_rust(src);
+        let back = print_rust(&node);
+        assert_eq!(back, src, "round-trip mismatch");
+    }
+
+    #[test]
+    fn empty_string() {
+        rt("");
+    }
+
+    #[test]
+    fn simple_fn() {
+        rt("fn main() {}\n");
+    }
+
+    #[test]
+    fn line_and_block_comments() {
+        rt("// hi\nfn f() {\n    /* mid */ 1\n}\n");
+    }
+
+    #[test]
+    fn raw_and_byte_strings() {
+        rt("let s = r#\"raw\"#;\nlet b = b\"abc\";\n");
+    }
+
+    #[test]
+    fn lifetime_vs_char() {
+        rt("let c = 'a';\nlet lt: &'static str = \"x\";\n");
+    }
+
+    #[test]
+    fn numeric_with_suffix() {
+        rt("let n = 0xFF_FFu32;\nlet f = 3.14e10_f64;\n");
+    }
+
+    #[test]
+    fn raw_ident() {
+        rt("let r#match = 1;\n");
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9517,3 +9517,11 @@ pub mod repl;
 pub mod check;
 pub mod meta;
 pub mod rocq;
+
+// Universal CST converters (issue #138).
+pub mod cst;
+pub mod cst_rust;
+pub mod cst_js;
+pub mod cst_lean;
+pub mod cst_rocq;
+pub mod cst_convert;

--- a/rust/tests/cst_tests.rs
+++ b/rust/tests/cst_tests.rs
@@ -1,0 +1,328 @@
+//! Universal CST converter integration tests (issue #138).
+//!
+//! Mirrors `js/tests/cst.test.mjs`: verifies the lossless round-trip contract
+//! `print(parse(src)) == src` for every host-language converter plus the CST
+//! serialisation helpers and the dispatch entry point.
+
+use std::path::PathBuf;
+
+use rml::cst::{
+    clone_cst, cst_to_lino, dialects, lino_to_cst, print_cst, CstNode,
+};
+use rml::cst_convert::{round_trip, SUPPORTED_LANGUAGES};
+use rml::cst_js::{parse_js, print_js};
+use rml::cst_lean::{parse_lean, print_lean};
+use rml::cst_rocq::{parse_rocq, print_rocq};
+use rml::cst_rust::{parse_rust, print_rust};
+
+fn repo_root() -> PathBuf {
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    here.parent().unwrap().to_path_buf()
+}
+
+// -------------------- CST data model --------------------
+
+#[test]
+fn print_cst_concatenates_leaves_in_document_order() {
+    let tree = CstNode::list(
+        "demo",
+        vec![
+            CstNode::token("hello", None),
+            CstNode::trivia(" ", None),
+            CstNode::token("world", None),
+        ],
+    );
+    assert_eq!(print_cst(&tree), "hello world");
+}
+
+#[test]
+fn list_nodes_emit_open_close_delimiters_when_set() {
+    let tree = CstNode::list_with_delims(
+        Some("demo".into()),
+        Some("(".into()),
+        Some(")".into()),
+        vec![CstNode::token("a", None), CstNode::token("b", None)],
+    );
+    assert_eq!(print_cst(&tree), "(ab)");
+}
+
+#[test]
+fn cst_to_lino_and_back_round_trips() {
+    let tree = CstNode::list(
+        "lino-cst.rust.fn",
+        vec![
+            CstNode::token("fn ", Some("kw")),
+            CstNode::token("foo", Some("ident")),
+            CstNode::token("(", Some("punct")),
+            CstNode::token(")", Some("punct")),
+            CstNode::trivia(" ", Some("ws")),
+            CstNode::list(
+                "lino-cst.rust.block",
+                vec![CstNode::token("{", None), CstNode::token("}", None)],
+            ),
+        ],
+    );
+    let serialised = cst_to_lino(&tree);
+    assert!(
+        serialised.starts_with("(lino-cst.list lino-cst.rust.fn"),
+        "unexpected serialisation: {}",
+        serialised
+    );
+    let parsed = lino_to_cst(&serialised).unwrap();
+    assert_eq!(print_cst(&parsed), print_cst(&tree));
+}
+
+#[test]
+fn lino_round_trip_preserves_open_close_delimiters() {
+    let tree = CstNode::list_with_delims(
+        Some("frag".into()),
+        Some("<".into()),
+        Some(">".into()),
+        vec![CstNode::token("x", None)],
+    );
+    let sexp = cst_to_lino(&tree);
+    let back = lino_to_cst(&sexp).unwrap();
+    assert_eq!(print_cst(&back), "<x>");
+}
+
+#[test]
+fn clone_cst_returns_structural_copy() {
+    let tree = CstNode::list(
+        "demo",
+        vec![
+            CstNode::token("a", None),
+            CstNode::list("inner", vec![CstNode::token("b", None)]),
+        ],
+    );
+    let clone = clone_cst(&tree);
+    assert_eq!(clone, tree);
+}
+
+#[test]
+fn leaves_walks_in_document_order() {
+    let tree = CstNode::list(
+        "demo",
+        vec![
+            CstNode::token("a", None),
+            CstNode::list(
+                "inner",
+                vec![CstNode::token("b", None), CstNode::token("c", None)],
+            ),
+            CstNode::token("d", None),
+        ],
+    );
+    let texts: Vec<&str> = tree.leaves().iter().map(|n| n.text()).collect();
+    assert_eq!(texts, vec!["a", "b", "c", "d"]);
+}
+
+#[test]
+fn exposes_four_host_dialects() {
+    assert_eq!(dialects::RUST, "lino-cst.rust");
+    assert_eq!(dialects::JS, "lino-cst.js");
+    assert_eq!(dialects::LEAN, "lino-cst.lean");
+    assert_eq!(dialects::ROCQ, "lino-cst.rocq");
+}
+
+// -------------------- Rust round-trip --------------------
+
+#[test]
+fn rust_round_trip_samples() {
+    let samples = [
+        "",
+        "fn main() {}\n",
+        "// hello\nfn f() -> i32 { 42 }\n",
+        "/* multi\n  line */\nfn g() {}\n",
+        "fn id<T>(x: T) -> T { x }\n",
+        "let s = \"hello\\n\";\n",
+        "let s = r#\"raw\"#;\n",
+        "let c = 'a';\nlet lt: &'static str = \"x\";\n",
+        "let n = 0xFF_FF;\nlet m = 0b1010;\nlet f = 3.14e10;\n",
+        "pub fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n",
+        "use std::collections::HashMap;\n",
+        "let mut v = Vec::<i32>::new();\nv.push(1);\n",
+        "macro_rules! foo { () => {}; }\n",
+        "let r#match = 1;\n",
+    ];
+    for src in samples {
+        let r = round_trip(src, "rust").unwrap();
+        assert!(r.ok, "rust round-trip failed for {:?}", src);
+        assert_eq!(r.round_tripped, src);
+    }
+}
+
+// -------------------- JavaScript round-trip --------------------
+
+#[test]
+fn js_round_trip_samples() {
+    let samples = [
+        "",
+        "const x = 1;\n",
+        "// hello\nconst y = 2;\n",
+        "/* block */ const z = 3;\n",
+        "const s = 'a\\'b';\n",
+        "const t = `hello ${name}!`;\n",
+        "const t2 = `nested ${`inner ${1+2}`} done`;\n",
+        "const r = /foo\\/bar/g;\n",
+        "const n = 0xff_ff;\nconst b = 0b1010n;\nconst f = 3.14e-2;\n",
+        "function f(a, b) {\n  return a + b;\n}\n",
+        "class C { method() { return 1; } }\n",
+        "const obj = { a: 1, \"b c\": 2 };\n",
+        "#!/usr/bin/env node\nconsole.log(\"hi\");\n",
+        "export default async function f() { await sleep(1); }\n",
+        "let { a, b: c = 3 } = x;\n",
+        "const re = /^a[/]b$/;\n",
+    ];
+    for src in samples {
+        let r = round_trip(src, "js").unwrap();
+        assert!(r.ok, "js round-trip failed for {:?}", src);
+        assert_eq!(r.round_tripped, src);
+    }
+}
+
+// -------------------- Lean 4 round-trip --------------------
+
+#[test]
+fn lean_round_trip_samples() {
+    let samples = [
+        "",
+        "-- comment\ndef f : Nat := 1\n",
+        "/- block comment -/\ndef g : Nat := 2\n",
+        "/-! module doc -/\n",
+        "/-- decl doc -/\ndef h : Nat := 3\n",
+        "def id {α : Type} (x : α) : α := x\n",
+        "#check Nat.succ\n",
+        "theorem t : 1 + 1 = 2 := rfl\n",
+        "def s : String := \"hello\"\n",
+        "def n : Nat := 0xff\n",
+        "def m : Nat := 0b1010\n",
+        "inductive List (α : Type u) where\n  | nil : List α\n  | cons : α → List α → List α\n",
+        "namespace Foo\ndef x := 1\nend Foo\n",
+        "def c : Char := 'a'\n",
+    ];
+    for src in samples {
+        let r = round_trip(src, "lean").unwrap();
+        assert!(r.ok, "lean round-trip failed for {:?}", src);
+        assert_eq!(r.round_tripped, src);
+    }
+}
+
+// -------------------- Rocq round-trip --------------------
+
+#[test]
+fn rocq_round_trip_samples() {
+    let samples = [
+        "",
+        "(* comment *)\nDefinition x := 1.\n",
+        "(* nested (* inside *) *)\nDefinition y := 2.\n",
+        "Definition id {A : Type} (x : A) : A := x.\n",
+        "Theorem t : 1 + 1 = 2. Proof. reflexivity. Qed.\n",
+        "Inductive list (A : Type) : Type :=\n  | nil\n  | cons (x : A) (xs : list A).\n",
+        "Definition s := \"hello, \"\"world\"\"\".\n",
+        "Definition n := 0xff.\n",
+        "Require Import Coq.Lists.List.\n",
+    ];
+    for src in samples {
+        let r = round_trip(src, "rocq").unwrap();
+        assert!(r.ok, "rocq round-trip failed for {:?}", src);
+        assert_eq!(r.round_tripped, src);
+    }
+}
+
+// -------------------- Cross-converter dispatch --------------------
+
+#[test]
+fn supported_languages_lists_four_hosts_plus_alias() {
+    let mut langs: Vec<&str> = SUPPORTED_LANGUAGES.to_vec();
+    langs.sort();
+    assert_eq!(langs, vec!["javascript", "js", "lean", "rocq", "rust"]);
+}
+
+// -------------------- Comment / whitespace preservation --------------------
+
+#[test]
+fn rust_comments_survive_as_trivia() {
+    let src = "// leading\nfn f() {\n  /* mid */ 1\n}\n";
+    let tree = parse_rust(src);
+    let leaves = tree.leaves();
+    assert!(leaves.iter().any(|n| matches!(n, CstNode::Trivia { text, .. } if text == "// leading")));
+    assert!(leaves.iter().any(|n| matches!(n, CstNode::Trivia { text, .. } if text == "/* mid */")));
+    assert_eq!(print_rust(&tree), src);
+}
+
+#[test]
+fn js_hashbang_and_comments_survive() {
+    let src = "#!/usr/bin/env node\n// hi\nlet x = 1;\n";
+    let tree = parse_js(src);
+    let leaves = tree.leaves();
+    assert!(leaves
+        .iter()
+        .any(|n| matches!(n, CstNode::Trivia { text, .. } if text.starts_with("#!"))));
+    assert!(leaves
+        .iter()
+        .any(|n| matches!(n, CstNode::Trivia { text, .. } if text == "// hi")));
+    assert_eq!(print_js(&tree), src);
+}
+
+#[test]
+fn lean_nested_block_comments_survive() {
+    let src = "/- outer /- inner -/ still outer -/\ndef x := 1\n";
+    let tree = parse_lean(src);
+    let leaves = tree.leaves();
+    assert!(leaves
+        .iter()
+        .any(|n| matches!(n, CstNode::Trivia { text, .. } if text.starts_with("/- outer"))));
+    assert_eq!(print_lean(&tree), src);
+}
+
+#[test]
+fn rocq_nested_comments_survive() {
+    let src = "(* a (* b *) c *)\nDefinition x := 1.\n";
+    let tree = parse_rocq(src);
+    let leaves = tree.leaves();
+    assert!(leaves
+        .iter()
+        .any(|n| matches!(n, CstNode::Trivia { text, .. } if text == "(* a (* b *) c *)")));
+    assert_eq!(print_rocq(&tree), src);
+}
+
+// -------------------- Repository corpus round-trip --------------------
+
+fn read_if_exists(path: &PathBuf) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+#[test]
+fn round_trips_js_src_cst_mjs() {
+    let p = repo_root().join("js").join("src").join("cst.mjs");
+    if let Some(src) = read_if_exists(&p) {
+        assert_eq!(print_js(&parse_js(&src)), src);
+    }
+}
+
+#[test]
+fn round_trips_rust_src_main_rs() {
+    let p = repo_root().join("rust").join("src").join("main.rs");
+    if let Some(src) = read_if_exists(&p) {
+        assert_eq!(print_rust(&parse_rust(&src)), src);
+    }
+}
+
+#[test]
+fn round_trips_lean_export_basic() {
+    let p = repo_root()
+        .join("examples")
+        .join("lean-export-basic.lean");
+    if let Some(src) = read_if_exists(&p) {
+        assert_eq!(print_lean(&parse_lean(&src)), src);
+    }
+}
+
+#[test]
+fn round_trips_isabelle_typed_fragment_as_rocq_style() {
+    let p = repo_root()
+        .join("examples")
+        .join("isabelle-typed-fragment.thy");
+    if let Some(src) = read_if_exists(&p) {
+        assert_eq!(print_rocq(&parse_rocq(&src)), src);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #138. Adds lossless **CST** converters between `.lino` and four
host languages — **Rust, JavaScript, Lean 4, Rocq** — in both
implementations (JS and Rust). Every byte of host source survives the
round trip, including comments, whitespace, identifiers, raw strings,
template literals, regex literals, and language-specific exotica
(Rust raw idents `r#match`, Lean nested `/- /- -/ -/`, Rocq doubled-quote
strings `""..""`, JS regex-vs-divide disambiguation, etc.).

The case study that designed this work — [`docs/case-studies/issue-138/`](https://github.com/link-foundation/relative-meta-logic/tree/issue-138-559eef049155/docs/case-studies/issue-138) — remains in the PR as the design record. The seven docs explain the data model (`lino-cst.list` / `lino-cst.token` / `lino-cst.trivia`), the dialect-tag convention (`lino-cst.rust.*`, etc.), the surveyed libraries, and the phased roadmap.

The token-stream-level converters in this PR implement the **K** (Rust), **L** (JS), **M** (Lean) and **N** (Rocq) phases of that roadmap end-to-end.

## What's in the implementation

| File | What it does |
|---|---|
| `js/src/cst.mjs`, `rust/src/cst.rs` | Core CST data model: `list` / `token` / `trivia` constructors, `printCst`, `cstToLino` ↔ `linoToCst`, `cloneCst`, `leaves`, `DIALECTS`. |
| `js/src/cst-rust.mjs`, `rust/src/cst_rust.rs` | Rust lexer — shebang, `//`, nested `/* */`, `\"`, `r#\"..\"#`, `b\"..\"`, char & lifetime, raw idents, all numeric forms with suffixes. |
| `js/src/cst-js.mjs`, `rust/src/cst_js.rs` | JS lexer — hashbang, line/block comments, strings, template literals (with nested `${}`), regex literals (context-sensitive), BigInt, Unicode identifiers. |
| `js/src/cst-lean.mjs`, `rust/src/cst_lean.rs` | Lean 4 lexer — `-- line`, nested `/- block -/`, `/-- doc -/`, `/-! mod -/`, raw strings, char literals, dotted hierarchical names, Unicode idents (α, β, →, …). |
| `js/src/cst-rocq.mjs`, `rust/src/cst_rocq.rs` | Rocq lexer — nested `(* *)` comments, doubled-quote string escapes, decimal / hex / oct / bin numbers, ASCII + Unicode idents. |
| `js/src/cst-convert.mjs`, `rust/src/cst_convert.rs` | Dispatch entry point: `parseToCst(src, lang)`, `printFromCst(node, lang)`, `roundTrip(src, lang)`, `SUPPORTED_LANGUAGES`. |

Both implementations honour the same round-trip contract:

```
print(parse(src)) === src   // for every src
```

## What's in the test surface

- **`js/tests/cst.test.mjs`** — 72 tests / 8 suites:
  - data-model unit tests (printCst, cstToLino ↔ linoToCst, cloneCst, leaves, DIALECTS)
  - per-language round-trip samples (14 Rust, 16 JS, 14 Lean, 9 Rocq)
  - cross-converter dispatch (incl. `js` ⇔ `javascript` alias, error on unsupported language)
  - explicit comment/whitespace preservation per language
  - **bootstrap corpus**: round-trips four live files in this repo (`js/src/cst.mjs`, `rust/src/main.rs`, `examples/lean-export-basic.lean`, `examples/isabelle-typed-fragment.thy`)
- **`rust/tests/cst_tests.rs`** — same shape at the Rust integration layer (20 tests), plus 36 inline `#[cfg(test)]` unit tests across the six new modules.

Local test runs: **1031 / 1031** JS tests pass, **684 / 684** Rust tests pass.

## Demos

- `node examples/cst-roundtrip-demo.mjs`
- `cargo run --example cst_roundtrip_demo --manifest-path rust/Cargo.toml`

Both print one OK line per language with a peek at the underlying `.lino` S-expression and the recovered trivia leaves.

## Test plan

- [x] `npm test --prefix js` passes (1031/1031)
- [x] `cargo test --manifest-path rust/Cargo.toml` passes (684/684)
- [x] Demo scripts run cleanly in both implementations
- [x] No source or test files removed; existing CI surface remains intact
- [x] Case-study docs from the planning PR are preserved
- [ ] Reviewer: spot-check the per-language tokeniser corner cases (Rust raw idents, JS regex disambiguation, Lean nested block comments, Rocq doubled-quote escapes)
- [ ] Reviewer: confirm CI parity / bootstrap workflows go green

Fixes #138.