### PR TITLE
Phase 12: links-defined Peano natural numbers (advances #97)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-12T22:03:28.790Z for PR creation at branch issue-163-3a962eb1d8a7 for issue https://github.com/link-foundation/relative-meta-logic/issues/163
 # Updated: 2026-05-12T22:35:53.914Z
 # Updated: 2026-05-12T23:08:32.970Z
-# Updated: 2026-05-17T11:00:16.340Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T22:03:28.790Z for PR creation at branch issue-163-3a962eb1d8a7 for issue https://github.com/link-foundation/relative-meta-logic/issues/163
 # Updated: 2026-05-12T22:35:53.914Z
 # Updated: 2026-05-12T23:08:32.970Z
+# Updated: 2026-05-17T11:00:16.340Z

--- a/docs/FOUNDATIONS.md
+++ b/docs/FOUNDATIONS.md
@@ -346,7 +346,7 @@ env.exit_foundation();
 
 ## 5. Bundled foundations
 
-Three alternative foundations ship in [`lib/self/foundations.lino`](../lib/self/foundations.lino)
+Five alternative foundations ship in [`lib/self/foundations.lino`](../lib/self/foundations.lino)
 and are pre-seeded by the JS and Rust hosts:
 
 - **`boolean-links`** — two-valued Boolean logic over the strict carrier
@@ -364,10 +364,26 @@ and are pre-seeded by the JS and Rust hosts:
   `three-valued` and the numeric domain is the real unit interval; the
   midpoint `0.5` represents `unknown`. These bindings also use host
   aggregators.
+- **`typed-kernel-links`** — links-defined typed-kernel fragment. The
+  four rules `pi-formation`, `lambda-introduction`,
+  `application-elimination`, and `beta-conversion` are recorded as
+  `(root-construct … links-defined …)` and replayed through
+  `(check-proof …)` from
+  [`examples/typed-kernel-links.lino`](../examples/typed-kernel-links.lino).
+- **`nat-links`** — links-defined Peano naturals. The five proof
+  substrate rules `nat-zero-formation`, `nat-succ-formation`,
+  `nat-add-zero`, `nat-add-succ`, and `nat-induction` describe `Nat`,
+  `zero`, `succ`, addition, and induction as proof-substrate data
+  rather than host arithmetic. There is no `succ → +1` shortcut:
+  successor stays a literal constructor and addition is reduced
+  recursively. Replayed end-to-end by
+  [`examples/nat-links.lino`](../examples/nat-links.lino) and pinned in
+  `examples/expected.lino`.
 
 The example [`examples/foundation-boolean-kleene.lino`](../examples/foundation-boolean-kleene.lino)
-exercises both in one file and shows the default semantics being
-restored after each scope. A minimal single-operator showcase lives in
+exercises the Boolean/Kleene foundations in one file and shows the
+default semantics being restored after each scope. A minimal
+single-operator showcase lives in
 [`examples/foundation-with-min.lino`](../examples/foundation-with-min.lino).
 
 ## 6. Carrier enforcement: `(carrier ...)` and `(strict-carrier)`
@@ -563,6 +579,17 @@ and derivations are links data.
   four-abit alphabet and `encodeAnum` / `decodeAnum`; the companion
   theory declares MTC rules and replays a composite proof. It does not
   replace the default RML foundation.
+- **Phase 12 — links-defined Peano naturals.** Implemented as a
+  fifth bundled foundation (§5). `examples/nat-links.lino` declares the
+  five rules `nat-zero-formation`, `nat-succ-formation`,
+  `nat-add-zero`, `nat-add-succ`, and `nat-induction` as proof-substrate
+  data and replays the inhabitants `zero`, `(succ zero)`,
+  `(succ (succ zero))`, the additions `0+0`, `1+0`, `0+1`, `1+1`, and
+  one induction conclusion through `(check-proof …)`. Successor is a
+  literal constructor; there is no `succ → +1` host shortcut. The
+  default host numeric layer is unaffected — this phase adds the
+  inductive substrate the issue's Software Foundations reference uses,
+  not a replacement numeric domain.
 
 Everything in this document is the *backward-compatible* surface. The
 strict modes (`(strict-carrier)`, `(strict-foundation pure-links)`) are

--- a/docs/case-studies/issue-97/README.md
+++ b/docs/case-studies/issue-97/README.md
@@ -35,6 +35,7 @@ fixed the contract:
 | 2026-05-15 (this PR) | Root-construct registry + foundation scope implemented in both engines; JS and Rust unit/integration/e2e tests added; `examples/foundation-boolean-kleene.lino` + `examples/foundation-with-min.lino` added and replayed through both engines; self-evaluator parity test taught to recognise the new forms; `lib/self/foundations.lino` and `lib/self/evaluator.lino` extended; `docs/FOUNDATIONS.md` written; `docs/DIAGNOSTICS.md` extended with `E060`/`E061`/`E062`; this case study compiled. |
 | 2026-05-16 (Phases 2–9) | Phase 2 equality-layer separation, Phase 3 proof-object replay (`E064`), Phase 4 truth-tables, Phase 5 links-defined typed-kernel fragment (`pi-formation`, `lambda-introduction`, `application-elimination`, `beta-conversion` replayed through `(check-proof …)` from `examples/typed-kernel-links.lino`), Phase 6 pure-links strict mode (`E065`), Phase 7 dependency-graph traversal, Phase 8 carrier enforcement (`E063`), and Phase 9 experimental `mtc-anum` profile with `encodeAnum`/`decodeAnum` helpers (`E066`) advanced on PR #175 with parallel JS/Rust tests and parity replay. |
 | 2026-05-17 (PR #176) | Latest issue feedback was incorporated: `semantic-status` / `semanticStatus` separates host-executed lookup and structural matching from links-level data; truth-table implementations report `links-checked`; substitution/freshness/alpha-renaming remain explicit `host-trusted` boundaries; and `examples/proof-checking-relation.lino` adds a nontrivial proof-checking relation represented as links-level data and replayed by both engines. |
+| 2026-05-17 (Phase 12 on PR #177) | Phase 12 adds the inductive data layer the issue originally pointed at: five links-defined Peano rules (`nat-zero-formation`, `nat-succ-formation`, `nat-add-zero`, `nat-add-succ`, `nat-induction`) in `examples/nat-links.lino`, registered as `(foundation nat-links …)`, replayed by both engines, and pinned by `js/tests/nat-links.test.mjs` + `rust/tests/nat_links_tests.rs`. |
 
 Raw data captured in `data/issue-97.json`, `data/issue-97-comments.json`,
 `data/pr-174.json`, `data/pr-175.json`, and `data/pr-176.json`.
@@ -469,6 +470,7 @@ classification requested by the latest issue feedback. Current status:
 | 9 | Experimental `mtc-anum` profile + `encodeAnum`/`decodeAnum` | done as a serialization profile **and** as a links-defined MTC theory fragment | §9.7; `E066`; pre-seeded but opt-in; `(experimental)`, `(root …)`, `(abit …)` clauses; `examples/mtc-anum-theory.lino`; canonicality/injectivity tests in both engines |
 | 10 | Execution-boundary semantic statuses | done | `semantic-status`; `semanticStatus` / `semantic_status`; `bySemanticStatus` / `by_semantic_status`; docs §4.3 |
 | 11 | Links-level proof-checking relation | done | §9.8; `examples/proof-checking-relation.lino`; proof-substrate tests in both engines |
+| 12 | Links-defined Peano naturals (`zero`, `succ`, `add`, induction) | done | §9.9; `examples/nat-links.lino`; `js/tests/nat-links.test.mjs` + `rust/tests/nat_links_tests.rs`; `(foundation nat-links …)` in `lib/self/foundations.lino` |
 
 Every implemented or partially implemented phase has **parallel JS and
 Rust tests** plus the existing self-evaluator parity replay
@@ -631,6 +633,67 @@ implication proof, an antecedent proof, an applied rule tag, and two
 dependency edges. The final `(check-proof mp-rain-checks-wet)` returns
 `1`; both shared-example harnesses pin this in
 `examples/expected.lino`.
+
+### 9.9 Phase 12 — links-defined Peano naturals
+
+The issue's original reference (Software Foundations / `Logic.v`) sits
+on top of Coq's inductive `nat` definition. PR #176 covered the typed
+kernel side (`pi-formation`, `lambda-introduction`,
+`application-elimination`, `beta-conversion`) and PR #176 added a
+proof-checking relation; the obvious missing piece was the **inductive
+data layer itself**: a links-level account of the natural numbers so
+that "Nat", "zero", "succ", "add", and induction are no longer silent
+host primitives but proof-substrate rules consumed by `(check-proof
+…)`.
+
+`examples/nat-links.lino` supplies that fragment with five
+proof-substrate rules:
+
+- `nat-zero-formation` — `(zero has-type Nat)` with no premises.
+- `nat-succ-formation` — `(?n has-type Nat) ⇒ ((succ ?n) has-type Nat)`.
+- `nat-add-zero` — `(?n has-type Nat) ⇒ ((add zero ?n) equals ?n)`.
+- `nat-add-succ` — `((add ?m ?n) equals ?k) ⇒ ((add (succ ?m) ?n)
+  equals (succ ?k))`.
+- `nat-induction` — `(?P at zero)` and `(forall ?n (implies (?P at ?n)
+  (?P at (succ ?n))))` together imply `(forall ?n (?P at ?n))`.
+
+The example then builds `zero`, `(succ zero)`, and `(succ (succ
+zero))` as inhabitants of `Nat`, computes `0+0`, `1+0`, and `1+1`
+through `nat-add-zero` / `nat-add-succ`, and discharges a universal
+claim via `nat-induction`. All eight `(check-proof …)` calls return
+`1` and the engines emit no diagnostics. The matching entry in
+`examples/expected.lino` (`(nat-links.lino: 1 1 1 1 1 1 1 1)`) is
+checked by both the JS and Rust expected-output harnesses, so any
+drift between engines is caught at shared-examples replay time.
+
+The companion `(foundation nat-links …)` registration in
+`lib/self/foundations.lino` records the five rules as `(root-construct
+… links-defined …)` so the trust audit lists them as
+`semantic links-checked` derivations rather than as silent host
+primitives. The host's decimal numeric domain is unaffected — `Nat`
+here is purely structural; the foundation just gives the trust report
+something concrete to point at when a user asks "where do `Nat`,
+`succ`, and addition come from in this proof?".
+
+Each rule is also pinned down individually by
+`js/tests/nat-links.test.mjs` (10 tests) and
+`rust/tests/nat_links_tests.rs` (10 tests), including two negative
+cases (a mistyped `(succ zero)` and an `add-succ` claim that would
+require `(succ ?k)` to unify with `zero`) where `(check-proof …)`
+returns `0` and raises `E064`. The pre-registration test asserts that
+`(foundation-report)` lists `nat-links` with `uses = [nat-add-succ,
+nat-add-zero, nat-induction, nat-succ-formation, nat-zero-formation]`
+and `extends = default-rml`, matching the
+`_registerDefaultFoundation` / `register_default_foundation` seeds in
+both engines.
+
+This phase deliberately does **not** implement `Nat` by host numeric
+conversion: there is no `succ → +1` shortcut. Successor is a literal
+constructor and `equals` is the proof-substrate's structural match, so
+the only host operation involved is the same pattern matcher that
+backs every other Phase 3 proof rule. Substitution, alpha-renaming,
+and freshness remain explicit `host-trusted` boundaries documented in
+the foundation report.
 
 ## 10. Files in this case study
 

--- a/examples/expected.lino
+++ b/examples/expected.lino
@@ -53,6 +53,8 @@
 
 (mtc-anum-theory.lino: 1 1 1)
 
+(nat-links.lino: 1 1 1 1 1 1 1 1)
+
 (proof-checking-relation.lino: 1)
 
 (propositional-logic.lino: 0.3 0.6 0.18 0.72 0.7 0.072 0.8320000000000001)

--- a/examples/nat-links.lino
+++ b/examples/nat-links.lino
@@ -1,0 +1,138 @@
+# Links-defined natural-number foundation (issue #97, Phase 12).
+#
+# Peano arithmetic encoded entirely as proof-substrate rules. The five
+# rules `nat-zero-formation`, `nat-succ-formation`, `nat-add-zero`,
+# `nat-add-succ`, and `nat-induction` make `Nat`, `zero`, `succ`,
+# addition, and structural induction available as links-level constructs
+# whose derivations are checked by the host's structural pattern matcher
+# rather than by the host's decimal numeric domain.
+#
+# `has-type`, `equals`, `at`, `forall`, and `implies` are bare
+# identifiers — the proof substrate treats them as literals while
+# matching the surrounding `?` metavariables. `(zero has-type Nat)`
+# therefore plays the role of `0 : Nat`, and
+# `((add (succ zero) (succ zero)) equals (succ (succ zero)))` plays the
+# role of `1 + 1 = 2`.
+#
+# The derivation below builds `zero`, `(succ zero)`, and
+# `(succ (succ zero))` as inhabitants of `Nat`, computes three small
+# additions by recursion on the left argument, and uses
+# `nat-induction` to derive a trivially-true universally quantified
+# property. Every step is mechanically replayed by `(check-proof ...)`
+# so the host emits no diagnostics and each query returns `1`.
+#
+# This example mirrors the construction laid out in Software
+# Foundations' `Basics.v` / `Induction.v` but runs on the links
+# substrate instead of Coq's typed kernel. The companion foundation
+# entry `(foundation nat-links ...)` in `lib/self/foundations.lino`
+# documents the five rules as an alternative Peano-natural-number
+# foundation; the host's `decimal-12-arithmetic` is unaffected.
+#
+# See: docs/case-studies/issue-97/README.md §9.9.
+
+
+# --- Typing rules: Nat formation ---
+
+(rule nat-zero-formation
+  (conclusion (zero has-type Nat)))
+
+(rule nat-succ-formation
+  (premise (?n has-type Nat))
+  (conclusion ((succ ?n) has-type Nat)))
+
+
+# --- Computation rules: addition by recursion on the left argument ---
+
+(rule nat-add-zero
+  (premise (?n has-type Nat))
+  (conclusion ((add zero ?n) equals ?n)))
+
+(rule nat-add-succ
+  (premise ((add ?m ?n) equals ?k))
+  (conclusion ((add (succ ?m) ?n) equals (succ ?k))))
+
+
+# --- Proof principle: structural induction over Nat ---
+
+(rule nat-induction
+  (premise (?P at zero))
+  (premise (forall ?n (implies (?P at ?n) (?P at (succ ?n)))))
+  (conclusion (forall ?n (?P at ?n))))
+
+
+# --- Building 0, 1, 2 as inhabitants of Nat ---
+
+(proof-object zero-is-nat
+  (applies nat-zero-formation)
+  (conclusion (zero has-type Nat)))
+
+(proof-object one-is-nat
+  (applies nat-succ-formation)
+  (premise-by zero-is-nat)
+  (conclusion ((succ zero) has-type Nat)))
+
+(proof-object two-is-nat
+  (applies nat-succ-formation)
+  (premise-by one-is-nat)
+  (conclusion ((succ (succ zero)) has-type Nat)))
+
+
+# --- Computing small additions step by step ---
+# 0 + 0 = 0 via nat-add-zero applied with n := zero.
+
+(proof-object zero-plus-zero
+  (applies nat-add-zero)
+  (premise-by zero-is-nat)
+  (conclusion ((add zero zero) equals zero)))
+
+# 1 + 0 = 1 via nat-add-succ on top of (0 + 0 = 0).
+
+(proof-object one-plus-zero
+  (applies nat-add-succ)
+  (premise-by zero-plus-zero)
+  (conclusion ((add (succ zero) zero) equals (succ zero))))
+
+# 0 + 1 = 1 via nat-add-zero applied with n := (succ zero).
+
+(proof-object zero-plus-one
+  (applies nat-add-zero)
+  (premise-by one-is-nat)
+  (conclusion ((add zero (succ zero)) equals (succ zero))))
+
+# 1 + 1 = 2 via nat-add-succ on top of (0 + 1 = 1).
+
+(proof-object one-plus-one
+  (applies nat-add-succ)
+  (premise-by zero-plus-one)
+  (conclusion ((add (succ zero) (succ zero)) equals (succ (succ zero)))))
+
+
+# --- Using induction: every Nat satisfies the trivial property `is-nat` ---
+#
+# The base case and the inductive step are taken as axioms here so the
+# example demonstrates the shape of an inductive proof without dragging
+# in the meta-theory needed to derive them. The schematic rule
+# `nat-induction` then folds them into a universally quantified
+# conclusion that `(check-proof ...)` replays structurally.
+
+(axiom is-nat-at-zero
+  (judgement (is-nat at zero)))
+
+(axiom is-nat-step
+  (judgement (forall n (implies (is-nat at n) (is-nat at (succ n))))))
+
+(proof-object every-nat-is-nat
+  (applies nat-induction)
+  (premise-by is-nat-at-zero)
+  (premise-by is-nat-step)
+  (conclusion (forall n (is-nat at n))))
+
+
+(check-proof zero-is-nat)
+(check-proof one-is-nat)
+(check-proof two-is-nat)
+(check-proof zero-plus-zero)
+(check-proof one-plus-zero)
+(check-proof zero-plus-one)
+(check-proof one-plus-one)
+(check-proof every-nat-is-nat)

--- a/js/src/rml-links.mjs
+++ b/js/src/rml-links.mjs
@@ -620,6 +620,35 @@ class Env {
       root: null,
       abits: null,
     });
+    // Pre-seed the links-defined Peano naturals foundation (issue #97,
+    // Phase 12). Selecting it via `(with-foundation nat-links ...)`
+    // records the proof-substrate rules `nat-zero-formation`,
+    // `nat-succ-formation`, `nat-add-zero`, `nat-add-succ`, and
+    // `nat-induction` as the canonical links-defined replacement for
+    // host-numeric Peano arithmetic. The host's decimal numeric domain
+    // is unaffected; the foundation is selected so the trust audit can
+    // list the five rules as the active derivations for `Nat`.
+    this.foundations.set('nat-links', {
+      name: 'nat-links',
+      description: 'links-defined Peano naturals (zero/succ formation, add by recursion, induction)',
+      uses: [
+        'nat-zero-formation',
+        'nat-succ-formation',
+        'nat-add-zero',
+        'nat-add-succ',
+        'nat-induction',
+      ],
+      defines: new Map(),
+      extends: 'default-rml',
+      numericDomain: 'decimal-12',
+      truthDomain: 'default-truth',
+      carrier: null,
+      strictCarrier: false,
+      truthTables: null,
+      experimental: false,
+      root: null,
+      abits: null,
+    });
     seedBuiltinRootConstructs(this);
   }
 

--- a/js/tests/nat-links.test.mjs
+++ b/js/tests/nat-links.test.mjs
@@ -1,0 +1,216 @@
+// Phase 12 — links-defined Peano naturals (issue #97).
+//
+// These tests pin down the behaviour of the five proof-substrate rules
+// (nat-zero-formation, nat-succ-formation, nat-add-zero, nat-add-succ,
+// nat-induction) that are expressed inside the proof substrate by
+// `examples/nat-links.lino`. Each rule is exercised on its own, then
+// composed end-to-end, and finally the corresponding
+// `(foundation nat-links ...)` registration is verified so the data
+// and the runtime stay in sync.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  Env,
+  evaluate,
+  evaluateFile,
+} from '../src/rml-links.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..', '..');
+const examplePath = join(repoRoot, 'examples', 'nat-links.lino');
+const foundationsPath = join(repoRoot, 'lib', 'self', 'foundations.lino');
+
+describe('Phase 12 — links-defined Peano naturals', () => {
+  it('nat-links foundation is pre-registered', () => {
+    const env = new Env();
+    const report = env.foundationReport();
+    const found = report.foundations.find(f => f.name === 'nat-links');
+    assert.ok(found, 'nat-links foundation must be registered');
+    assert.deepStrictEqual(found.uses.slice().sort(), [
+      'nat-add-succ',
+      'nat-add-zero',
+      'nat-induction',
+      'nat-succ-formation',
+      'nat-zero-formation',
+    ]);
+    assert.strictEqual(found.extends, 'default-rml');
+  });
+
+  it('lib/self/foundations.lino documents the nat-links foundation', () => {
+    const source = readFileSync(foundationsPath, 'utf8');
+    assert.match(source, /\(foundation nat-links/);
+    for (const rule of [
+      'nat-zero-formation',
+      'nat-succ-formation',
+      'nat-add-zero',
+      'nat-add-succ',
+      'nat-induction',
+    ]) {
+      assert.match(source, new RegExp(`\\(uses ${rule}\\)`));
+      assert.match(
+        source,
+        new RegExp(`\\(root-construct ${rule}[\\s\\S]*?links-defined`),
+        `${rule} should appear as a root-construct with links-defined status`,
+      );
+    }
+  });
+
+  it('nat-zero-formation derives `zero has-type Nat` without premises', () => {
+    const out = evaluate(`
+(rule nat-zero-formation
+  (conclusion (zero has-type Nat)))
+
+(proof-object zero-is-nat
+  (applies nat-zero-formation)
+  (conclusion (zero has-type Nat)))
+
+(check-proof zero-is-nat)
+`);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('nat-succ-formation lifts a Nat to its successor', () => {
+    const out = evaluate(`
+(rule nat-zero-formation
+  (conclusion (zero has-type Nat)))
+
+(rule nat-succ-formation
+  (premise (?n has-type Nat))
+  (conclusion ((succ ?n) has-type Nat)))
+
+(proof-object zero-is-nat
+  (applies nat-zero-formation)
+  (conclusion (zero has-type Nat)))
+
+(proof-object one-is-nat
+  (applies nat-succ-formation)
+  (premise-by zero-is-nat)
+  (conclusion ((succ zero) has-type Nat)))
+
+(check-proof one-is-nat)
+`);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('nat-add-zero discharges the base case of addition', () => {
+    const out = evaluate(`
+(rule nat-add-zero
+  (premise (?n has-type Nat))
+  (conclusion ((add zero ?n) equals ?n)))
+
+(axiom zero-is-nat
+  (judgement (zero has-type Nat)))
+
+(proof-object zero-plus-zero
+  (applies nat-add-zero)
+  (premise-by zero-is-nat)
+  (conclusion ((add zero zero) equals zero)))
+
+(check-proof zero-plus-zero)
+`);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('nat-add-succ steps addition through the successor', () => {
+    const out = evaluate(`
+(rule nat-add-succ
+  (premise ((add ?m ?n) equals ?k))
+  (conclusion ((add (succ ?m) ?n) equals (succ ?k))))
+
+(axiom zero-plus-zero
+  (judgement ((add zero zero) equals zero)))
+
+(proof-object one-plus-zero
+  (applies nat-add-succ)
+  (premise-by zero-plus-zero)
+  (conclusion ((add (succ zero) zero) equals (succ zero))))
+
+(check-proof one-plus-zero)
+`);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('nat-induction folds a base case and a step into a universal claim', () => {
+    const out = evaluate(`
+(rule nat-induction
+  (premise (?P at zero))
+  (premise (forall ?n (implies (?P at ?n) (?P at (succ ?n)))))
+  (conclusion (forall ?n (?P at ?n))))
+
+(axiom is-nat-at-zero
+  (judgement (is-nat at zero)))
+
+(axiom is-nat-step
+  (judgement (forall n (implies (is-nat at n) (is-nat at (succ n))))))
+
+(proof-object every-nat-is-nat
+  (applies nat-induction)
+  (premise-by is-nat-at-zero)
+  (premise-by is-nat-step)
+  (conclusion (forall n (is-nat at n))))
+
+(check-proof every-nat-is-nat)
+`);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1]);
+  });
+
+  it('rejects a derivation that contradicts nat-succ-formation', () => {
+    // The conclusion of `nat-succ-formation` must keep `Nat` as the
+    // type of `(succ ?n)`; swapping the type to `Bool` therefore
+    // breaks the match and `(check-proof ...)` must return 0 with E064.
+    const out = evaluate(`
+(rule nat-succ-formation
+  (premise (?n has-type Nat))
+  (conclusion ((succ ?n) has-type Nat)))
+
+(axiom zero-is-nat
+  (judgement (zero has-type Nat)))
+
+(proof-object mistyped-succ
+  (applies nat-succ-formation)
+  (premise-by zero-is-nat)
+  (conclusion ((succ zero) has-type Bool)))
+
+(check-proof mistyped-succ)
+`);
+    assert.deepStrictEqual(out.results, [0]);
+    assert.ok(out.diagnostics.some(d => d.code === 'E064'));
+  });
+
+  it('rejects an add-succ derivation that contradicts its arithmetic premise', () => {
+    // Claiming that `(add (succ zero) zero)` equals `zero` would
+    // require `(succ ?k)` to unify with `zero`, which is impossible.
+    const out = evaluate(`
+(rule nat-add-succ
+  (premise ((add ?m ?n) equals ?k))
+  (conclusion ((add (succ ?m) ?n) equals (succ ?k))))
+
+(axiom zero-plus-zero
+  (judgement ((add zero zero) equals zero)))
+
+(proof-object wrong-add
+  (applies nat-add-succ)
+  (premise-by zero-plus-zero)
+  (conclusion ((add (succ zero) zero) equals zero)))
+
+(check-proof wrong-add)
+`);
+    assert.deepStrictEqual(out.results, [0]);
+    assert.ok(out.diagnostics.some(d => d.code === 'E064'));
+  });
+
+  it('runs the full Phase 12 example end-to-end with no diagnostics', () => {
+    const out = evaluateFile(examplePath);
+    assert.deepStrictEqual(out.diagnostics, []);
+    assert.deepStrictEqual(out.results, [1, 1, 1, 1, 1, 1, 1, 1]);
+  });
+});

--- a/lib/self/foundations.lino
+++ b/lib/self/foundations.lino
@@ -282,6 +282,67 @@
   (semantic-status links-checked)
   (depends-on beta-reduction))
 
+# Phase 12 proof-substrate rules that define Peano-style natural
+# numbers entirely from links. Five rules — formation for `zero` and
+# `succ`, two recursive computation rules for `add`, and the induction
+# principle — let the trust report describe `Nat`, `zero`, `succ`,
+# `add`, and structural induction as `links-defined` / `links-checked`
+# constructs without disturbing the host's decimal numeric domain.
+
+(root-construct Nat
+  (kind inductive-type)
+  (status links-defined)
+  (semantic-status links-checked)
+  (links-defined-via nat-zero-formation nat-succ-formation))
+
+(root-construct zero
+  (kind constructor)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat))
+
+(root-construct succ
+  (kind constructor)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat))
+
+(root-construct add
+  (kind derived-operation)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat zero succ))
+
+(root-construct nat-zero-formation
+  (kind typing-rule)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat zero))
+
+(root-construct nat-succ-formation
+  (kind typing-rule)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat succ))
+
+(root-construct nat-add-zero
+  (kind computation-rule)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on add zero))
+
+(root-construct nat-add-succ
+  (kind computation-rule)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on add succ))
+
+(root-construct nat-induction
+  (kind proof-principle)
+  (status links-defined)
+  (semantic-status links-checked)
+  (depends-on Nat))
+
 (root-construct substitution
   (kind meta-operation)
   (status host-primitive)
@@ -507,3 +568,30 @@
   (uses lambda-introduction)
   (uses application-elimination)
   (uses beta-conversion))
+
+# ---------------------------------------------------------------------------
+# Links-defined Peano natural numbers (issue #97, Phase 12). The five
+# proof-substrate rules below — `nat-zero-formation`, `nat-succ-formation`,
+# `nat-add-zero`, `nat-add-succ`, and `nat-induction` — make `Nat`,
+# `zero`, `succ`, addition, and structural induction available as
+# ordinary `(rule ...)` / `(proof-object ...)` data so the trust audit
+# reports them as `links-defined` constructs. The host's
+# `decimal-12-arithmetic` is unaffected; `nat-links` is an alternative
+# semantics for users who want to reason about naturals without relying
+# on the host numeric domain.
+#
+# A concrete Peano derivation lives in `examples/nat-links.lino`, and
+# the JS test in `js/tests/nat-links.test.mjs` plus the Rust mirror in
+# `rust/tests/nat_links_tests.rs` replay it through `(check-proof ...)`.
+# ---------------------------------------------------------------------------
+
+(foundation nat-links
+  (description links-defined-peano-naturals)
+  (numeric-domain decimal-12)
+  (truth-domain default-truth)
+  (extends default-rml)
+  (uses nat-zero-formation)
+  (uses nat-succ-formation)
+  (uses nat-add-zero)
+  (uses nat-add-succ)
+  (uses nat-induction))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1634,6 +1634,40 @@ impl Env {
         };
         self.foundations
             .insert(typed_kernel_links.name.clone(), typed_kernel_links);
+        // Pre-seed the links-defined Peano naturals foundation (issue #97,
+        // Phase 12). Selecting it via `(with-foundation nat-links ...)`
+        // records the proof-substrate rules `nat-zero-formation`,
+        // `nat-succ-formation`, `nat-add-zero`, `nat-add-succ`, and
+        // `nat-induction` as the canonical links-defined replacement for
+        // host-numeric Peano arithmetic. The host's decimal numeric domain
+        // is unaffected; the foundation is selected so the trust audit can
+        // list the five rules as the active derivations for `Nat`.
+        let nat_links = FoundationDescriptor {
+            name: "nat-links".to_string(),
+            description: Some(
+                "links-defined Peano naturals (zero/succ formation, add by recursion, induction)"
+                    .to_string(),
+            ),
+            uses: vec![
+                "nat-zero-formation".to_string(),
+                "nat-succ-formation".to_string(),
+                "nat-add-zero".to_string(),
+                "nat-add-succ".to_string(),
+                "nat-induction".to_string(),
+            ],
+            defines: Vec::new(),
+            extends: Some("default-rml".to_string()),
+            numeric_domain: Some("decimal-12".to_string()),
+            truth_domain: Some("default-truth".to_string()),
+            carrier: Vec::new(),
+            strict_carrier: false,
+            truth_tables: Vec::new(),
+            experimental: false,
+            root: None,
+            abits: Vec::new(),
+        };
+        self.foundations
+            .insert(nat_links.name.clone(), nat_links);
         seed_builtin_root_constructs(self);
     }
 

--- a/rust/tests/nat_links_tests.rs
+++ b/rust/tests/nat_links_tests.rs
@@ -1,0 +1,280 @@
+// Phase 12 — links-defined Peano naturals (issue #97).
+//
+// Parallel to `js/tests/nat-links.test.mjs`. The five proof-substrate
+// rules (nat-zero-formation, nat-succ-formation, nat-add-zero,
+// nat-add-succ, nat-induction) are expressed inside the proof
+// substrate by `examples/nat-links.lino`. The tests below pin each
+// rule down on its own, then run the bundled example end-to-end, and
+// finally verify that the runtime registers the `nat-links`
+// foundation with the expected `uses` list.
+
+use rml::{evaluate, evaluate_file, EvaluateOptions, EvaluateResult, RunResult};
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+}
+
+fn nums(results: &[RunResult]) -> Vec<f64> {
+    results
+        .iter()
+        .filter_map(|r| match r {
+            RunResult::Num(v) => Some(*v),
+            _ => None,
+        })
+        .collect()
+}
+
+fn run(src: &str) -> EvaluateResult {
+    evaluate(src, None, None)
+}
+
+#[test]
+fn nat_links_foundation_is_pre_registered() {
+    let out = evaluate("(foundation-report)", None, None);
+    let foundation = out.results.iter().find_map(|r| match r {
+        RunResult::Foundation(report) => report
+            .foundations
+            .iter()
+            .find(|f| f.name == "nat-links"),
+        _ => None,
+    });
+    let foundation = foundation.expect("nat-links foundation must be registered");
+    let mut uses = foundation.uses.clone();
+    uses.sort();
+    assert_eq!(
+        uses,
+        vec![
+            "nat-add-succ".to_string(),
+            "nat-add-zero".to_string(),
+            "nat-induction".to_string(),
+            "nat-succ-formation".to_string(),
+            "nat-zero-formation".to_string(),
+        ]
+    );
+    assert_eq!(foundation.extends.as_deref(), Some("default-rml"));
+}
+
+#[test]
+fn lib_self_foundations_documents_nat_links() {
+    let path = repo_root().join("lib").join("self").join("foundations.lino");
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("could not read {}: {}", path.display(), e));
+    assert!(
+        source.contains("(foundation nat-links"),
+        "foundations.lino must declare nat-links"
+    );
+    for rule in [
+        "nat-zero-formation",
+        "nat-succ-formation",
+        "nat-add-zero",
+        "nat-add-succ",
+        "nat-induction",
+    ] {
+        assert!(
+            source.contains(&format!("(uses {})", rule)),
+            "nat-links must (uses {})",
+            rule
+        );
+        let marker = format!("(root-construct {}", rule);
+        let idx = source
+            .find(&marker)
+            .unwrap_or_else(|| panic!("missing root-construct entry for {}", rule));
+        let window = &source[idx..(idx + 400).min(source.len())];
+        assert!(
+            window.contains("links-defined"),
+            "{} root-construct must record links-defined status",
+            rule
+        );
+    }
+}
+
+#[test]
+fn nat_zero_formation_derives_zero_has_type_nat() {
+    let src = r#"
+(rule nat-zero-formation
+  (conclusion (zero has-type Nat)))
+
+(proof-object zero-is-nat
+  (applies nat-zero-formation)
+  (conclusion (zero has-type Nat)))
+
+(check-proof zero-is-nat)
+"#;
+    let out = run(src);
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0]);
+}
+
+#[test]
+fn nat_succ_formation_lifts_a_nat_to_its_successor() {
+    let src = r#"
+(rule nat-zero-formation
+  (conclusion (zero has-type Nat)))
+
+(rule nat-succ-formation
+  (premise (?n has-type Nat))
+  (conclusion ((succ ?n) has-type Nat)))
+
+(proof-object zero-is-nat
+  (applies nat-zero-formation)
+  (conclusion (zero has-type Nat)))
+
+(proof-object one-is-nat
+  (applies nat-succ-formation)
+  (premise-by zero-is-nat)
+  (conclusion ((succ zero) has-type Nat)))
+
+(check-proof one-is-nat)
+"#;
+    let out = run(src);
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0]);
+}
+
+#[test]
+fn nat_add_zero_discharges_the_base_case_of_addition() {
+    let src = r#"
+(rule nat-add-zero
+  (premise (?n has-type Nat))
+  (conclusion ((add zero ?n) equals ?n)))
+
+(axiom zero-is-nat
+  (judgement (zero has-type Nat)))
+
+(proof-object zero-plus-zero
+  (applies nat-add-zero)
+  (premise-by zero-is-nat)
+  (conclusion ((add zero zero) equals zero)))
+
+(check-proof zero-plus-zero)
+"#;
+    let out = run(src);
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0]);
+}
+
+#[test]
+fn nat_add_succ_steps_addition_through_the_successor() {
+    let src = r#"
+(rule nat-add-succ
+  (premise ((add ?m ?n) equals ?k))
+  (conclusion ((add (succ ?m) ?n) equals (succ ?k))))
+
+(axiom zero-plus-zero
+  (judgement ((add zero zero) equals zero)))
+
+(proof-object one-plus-zero
+  (applies nat-add-succ)
+  (premise-by zero-plus-zero)
+  (conclusion ((add (succ zero) zero) equals (succ zero))))
+
+(check-proof one-plus-zero)
+"#;
+    let out = run(src);
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0]);
+}
+
+#[test]
+fn nat_induction_folds_a_base_case_and_a_step_into_a_universal_claim() {
+    let src = r#"
+(rule nat-induction
+  (premise (?P at zero))
+  (premise (forall ?n (implies (?P at ?n) (?P at (succ ?n)))))
+  (conclusion (forall ?n (?P at ?n))))
+
+(axiom is-nat-at-zero
+  (judgement (is-nat at zero)))
+
+(axiom is-nat-step
+  (judgement (forall n (implies (is-nat at n) (is-nat at (succ n))))))
+
+(proof-object every-nat-is-nat
+  (applies nat-induction)
+  (premise-by is-nat-at-zero)
+  (premise-by is-nat-step)
+  (conclusion (forall n (is-nat at n))))
+
+(check-proof every-nat-is-nat)
+"#;
+    let out = run(src);
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0]);
+}
+
+#[test]
+fn rejects_a_derivation_that_contradicts_nat_succ_formation() {
+    let src = r#"
+(rule nat-succ-formation
+  (premise (?n has-type Nat))
+  (conclusion ((succ ?n) has-type Nat)))
+
+(axiom zero-is-nat
+  (judgement (zero has-type Nat)))
+
+(proof-object mistyped-succ
+  (applies nat-succ-formation)
+  (premise-by zero-is-nat)
+  (conclusion ((succ zero) has-type Bool)))
+
+(check-proof mistyped-succ)
+"#;
+    let out = run(src);
+    assert_eq!(nums(&out.results), vec![0.0]);
+    assert!(out.diagnostics.iter().any(|d| d.code == "E064"));
+}
+
+#[test]
+fn rejects_an_add_succ_derivation_that_contradicts_its_arithmetic_premise() {
+    let src = r#"
+(rule nat-add-succ
+  (premise ((add ?m ?n) equals ?k))
+  (conclusion ((add (succ ?m) ?n) equals (succ ?k))))
+
+(axiom zero-plus-zero
+  (judgement ((add zero zero) equals zero)))
+
+(proof-object wrong-add
+  (applies nat-add-succ)
+  (premise-by zero-plus-zero)
+  (conclusion ((add (succ zero) zero) equals zero)))
+
+(check-proof wrong-add)
+"#;
+    let out = run(src);
+    assert_eq!(nums(&out.results), vec![0.0]);
+    assert!(out.diagnostics.iter().any(|d| d.code == "E064"));
+}
+
+#[test]
+fn runs_the_full_phase_12_example_end_to_end_with_no_diagnostics() {
+    let path = repo_root().join("examples").join("nat-links.lino");
+    let out = evaluate_file(path.to_str().unwrap(), EvaluateOptions::default());
+    assert!(
+        out.diagnostics.is_empty(),
+        "diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(nums(&out.results), vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
+}


### PR DESCRIPTION
## Summary

Advances #97 by adding the inductive data layer the issue's
Software Foundations reference (`Logic.v`, `Basics.v`, `Induction.v`)
starts from: **`Nat`, `zero`, `succ`, addition, and induction
expressed entirely as links-level proof-substrate rules.**

Successor stays a literal constructor; there is no `succ → +1` host
shortcut. The host's decimal numeric domain is unaffected — this PR
adds an inductive substrate, not a replacement numeric backend. The
default foundation `default-rml` continues to be active on every fresh
`Env`, so every `.lino` file that ran before this PR runs identically
afterwards.

Builds on the merged foundation + trust-report scaffolding from PR
#175 and the semantic-status / proof-checking-relation layer from PR
#176. Follows the acceptance criteria from
[issue #97 follow-up comment](https://github.com/link-foundation/relative-meta-logic/issues/97#issuecomment-4469640002).

## What's in this PR

- **`examples/nat-links.lino`** — declares the five
  proof-substrate rules `nat-zero-formation`, `nat-succ-formation`,
  `nat-add-zero`, `nat-add-succ`, `nat-induction`; builds `zero`,
  `(succ zero)`, `(succ (succ zero))` as inhabitants of `Nat`;
  computes `0+0`, `1+0`, `0+1`, `1+1` step by step; and discharges a
  universal claim via induction. All 8 `(check-proof …)` calls return
  `1` with no diagnostics.
- **`lib/self/foundations.lino`** — adds 9 `(root-construct …)`
  entries (`Nat`, `zero`, `succ`, `add`, `nat-zero-formation`,
  `nat-succ-formation`, `nat-add-zero`, `nat-add-succ`,
  `nat-induction`) with `status: links-defined` and
  `semantic-status: links-checked`, plus the
  `(foundation nat-links …)` declaration that bundles the five rules.
- **JS + Rust host seeds** —
  `_registerDefaultFoundation` (`js/src/rml-links.mjs`) and
  `register_default_foundation` (`rust/src/lib.rs`) pre-seed the
  `nat-links` foundation with `extends default-rml` so a fresh `Env`
  lists it in `foundation-report` without changing legacy semantics.
- **`examples/expected.lino`** — `(nat-links.lino: 1 1 1 1 1 1 1 1)`
  pins the byte-identical replay between engines.
- **Tests** — `js/tests/nat-links.test.mjs` and
  `rust/tests/nat_links_tests.rs` each add 10 tests covering
  foundation pre-registration, `foundations.lino` documentation,
  every individual rule, two negative cases that raise `E064`, and
  the end-to-end example replay.
- **Docs** — `docs/FOUNDATIONS.md` lists `nat-links` as a bundled
  foundation in §5 and adds Phase 12 to §10; the issue-97 case study
  (`docs/case-studies/issue-97/README.md`) gains a timeline row, a
  phase-table row, and a new §9.9 explaining the construction.

## Acceptance-criteria coverage (issue #97 comment §7)

1. Adds a `nat-links` foundation — ✅ `(foundation nat-links …)`
   pre-registered in both engines.
2. `Nat`, `zero`, `succ` as explicit root constructs — ✅
   `lib/self/foundations.lino`.
3. Proves `zero : Nat`, `succ zero : Nat`, `succ (succ zero) : Nat` —
   ✅ proof-objects `zero-is-nat`, `one-is-nat`, `two-is-nat`.
4. Addition rules `add zero n = n` and `add (succ m) n = succ (add m n)`
   — ✅ rules `nat-add-zero`, `nat-add-succ`.
5. Replays at least two addition proof objects — ✅ four:
   `zero-plus-zero`, `one-plus-zero`, `zero-plus-one`, `one-plus-one`.
6. Separates `nat-equality` from host numeric equality — ✅ `equals`
   is a literal identifier consumed by the proof substrate's
   structural matcher; the host numeric `=` operator is never invoked
   for Nat reasoning.
7. Keeps all host boundaries visible in `foundation-report` — ✅ the
   rules are `links-defined` with `links-checked` semantics;
   pattern-matching/structural substitution remain explicit
   `host-trusted` boundaries unchanged.
8. JS and Rust parity tests — ✅ 10 + 10 mirrored tests; full
   `npm test` (1237 pass) and `cargo test` (all targets pass) green.
9. Examples + expected outputs — ✅ `nat-links.lino` +
   `expected.lino` entry.
10. Docs + case study updated — ✅ `docs/FOUNDATIONS.md` and
    `docs/case-studies/issue-97/README.md`.
11. No `Fixes #97` — ✅ uses "Advances #97".

Stretch goal — symbolic Nat induction rule + one proof object using it
— ✅ `nat-induction` rule + `every-nat-is-nat` proof object.

## Test plan

- [x] `cd js && npm test` — 1237 / 1237 pass (including 10 new
  `nat-links` tests).
- [x] `cd rust && cargo test` — all binaries pass (including 10 new
  `nat_links_tests`).
- [x] `examples/expected.lino` entry `(nat-links.lino: 1 1 1 1 1 1 1 1)`
  pins the shared-examples replay between engines.
- [x] Negative cases verify `E064` fires when a derivation violates a
  rule (mistyped successor, contradictory `add-succ`).
- [x] `(foundation-report)` lists `nat-links` with sorted `uses`
  `[nat-add-succ, nat-add-zero, nat-induction, nat-succ-formation,
  nat-zero-formation]` and `extends default-rml` in both engines.

## Backward compatibility

Additive only. `default-rml` is still active on every fresh `Env`; no
existing operator, query result, or diagnostic shape changes.