### PR TITLE
Document probabilistic logic in valence overview

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T22:03:28.790Z for PR creation at branch issue-163-3a962eb1d8a7 for issue https://github.com/link-foundation/relative-meta-logic/issues/163
-# Updated: 2026-05-12T22:35:53.914Z
-# Updated: 2026-05-12T23:08:32.970Z
-# Updated: 2026-06-04T22:12:59.940Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-12T22:03:28.790Z for PR creation at branch issue-163-3a962eb1d8a7 for issue https://github.com/link-foundation/relative-meta-logic/issues/163
 # Updated: 2026-05-12T22:35:53.914Z
 # Updated: 2026-05-12T23:08:32.970Z
+# Updated: 2026-06-04T22:12:59.940Z

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ RML (Relative Meta-Logic, formerly Associative-Dependent Logic / ADL) is a minim
 | 1 | Unary (trivial) | `{any}` (no quantization) | `{any}` (no quantization) | [Many-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic) |
 | 2 | Binary / [Boolean](https://en.wikipedia.org/wiki/Boolean_algebra) | `{0, 1}` (false, true) | `{-1, 1}` (false, true) | [Classical logic](https://en.wikipedia.org/wiki/Classical_logic) |
 | 3 | Ternary / [Three-valued](https://en.wikipedia.org/wiki/Three-valued_logic) | `{0, 0.5, 1}` (false, unknown, true) | `{-1, 0, 1}` (false, unknown, true) | [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics), [Łukasiewicz logic](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic), [Balanced ternary](https://en.wikipedia.org/wiki/Balanced_ternary) |
-| 4 | Quaternary | `{0, ⅓, ⅔, 1}` | `{-1, -⅓, ⅓, 1}` | [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic) |
+| 4 | Quaternary / [Four-valued](https://en.wikipedia.org/wiki/Four-valued_logic) | `{0, ⅓, ⅔, 1}` | `{-1, -⅓, ⅓, 1}` | [Belnap's four-valued logic](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap) |
 | 5 | Quinary | `{0, 0.25, 0.5, 0.75, 1}` | `{-1, -0.5, 0, 0.5, 1}` | [Many-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic) |
-| N | N-valued | N evenly-spaced levels | N evenly-spaced levels | [Many-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic) |
-| 0/∞ | Continuous / [Fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic) | Any value in `[0, 1]` | Any value in `[-1, 1]` | [Fuzzy logic](https://en.wikipedia.org/wiki/Fuzzy_logic), [Łukasiewicz ∞-valued](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic) |
+| N | [Finite-valued](https://en.wikipedia.org/wiki/Finite-valued_logic) / N-valued | N evenly-spaced levels | N evenly-spaced levels | [Many-valued logic](https://en.wikipedia.org/wiki/Many-valued_logic), [Finite-valued logic](https://en.wikipedia.org/wiki/Finite-valued_logic) |
+| 0/∞ | Continuous / [Probabilistic](https://en.wikipedia.org/wiki/Probabilistic_logic) / [Fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic) | Any value in `[0, 1]` | Any value in `[-1, 1]` | [Probabilistic logic](https://en.wikipedia.org/wiki/Probabilistic_logic) (probability logic), [Fuzzy logic](https://en.wikipedia.org/wiki/Fuzzy_logic), [Infinite-valued logic](https://en.wikipedia.org/wiki/Infinite-valued_logic), [Łukasiewicz ∞-valued](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic) |
 
 ## Quick Start
 
@@ -1101,7 +1101,10 @@ with this file so any new violation fails the build.
 - [Boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra) — classical 2-valued logic
 - [Three-valued logic](https://en.wikipedia.org/wiki/Three-valued_logic) — ternary logics (Kleene, Łukasiewicz, Bochvar)
 - [Łukasiewicz logic](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic) — N-valued and infinite-valued extensions
+- [Finite-valued logic](https://en.wikipedia.org/wiki/Finite-valued_logic) — discrete many-valued logic with finitely many truth values
+- [Infinite-valued logic](https://en.wikipedia.org/wiki/Infinite-valued_logic) — continuous-valued many-valued logic families
 - [Fuzzy logic](https://en.wikipedia.org/wiki/Fuzzy_logic) — continuous-valued logic with degrees of truth
+- [Probabilistic logic](https://en.wikipedia.org/wiki/Probabilistic_logic) — probability and logic for reasoning under uncertainty
 - [Balanced ternary](https://en.wikipedia.org/wiki/Balanced_ternary) — ternary system using {-1, 0, 1}
 - [Four-valued logic (Belnap)](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap) — extends classical logic with "both" (contradiction) and "neither" (gap)
 - [Liar paradox](https://en.wikipedia.org/wiki/Liar_paradox) — "this statement is false" and its resolution in many-valued logics

--- a/docs/CONFIGURABILITY.md
+++ b/docs/CONFIGURABILITY.md
@@ -40,7 +40,8 @@ RML reverses this priority. Its design goals demand:
 1. **Many-valued by default.** RML supports unary, Boolean, ternary
    ([Kleene](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics)),
    N-valued, [Belnap four-valued](https://en.wikipedia.org/wiki/Four-valued_logic#Belnap),
-   and continuous [fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic) /
+   and continuous [probabilistic](https://en.wikipedia.org/wiki/Probabilistic_logic),
+   [fuzzy](https://en.wikipedia.org/wiki/Fuzzy_logic), and
    [Łukasiewicz ∞-valued](https://en.wikipedia.org/wiki/%C5%81ukasiewicz_logic) logics.
    No single fixed `and`/`or` works across all of these; min, max, average,
    product, and probabilistic-sum are all the right answer somewhere.

--- a/scripts/docs.test.mjs
+++ b/scripts/docs.test.mjs
@@ -140,6 +140,55 @@ describe('compatibility and release documentation', () => {
   });
 });
 
+describe('supported logic type overview documentation', () => {
+  function readmeTableRow(prefix) {
+    const readme = read('README.md');
+    return readme.split('\n').find(line => line.startsWith(prefix));
+  }
+
+  it('mentions probabilistic logic in the continuous valence row', () => {
+    const row = readmeTableRow('| 0/∞ |');
+
+    assert.ok(row, 'README must include the continuous valence row');
+    for (const expected of [
+      '[Probabilistic](https://en.wikipedia.org/wiki/Probabilistic_logic)',
+      '[Probabilistic logic](https://en.wikipedia.org/wiki/Probabilistic_logic)',
+      'probability logic',
+      '[Infinite-valued logic](https://en.wikipedia.org/wiki/Infinite-valued_logic)',
+    ]) {
+      assert.ok(row.includes(expected), `continuous row missing ${expected}`);
+    }
+  });
+
+  it('uses specific Wikipedia references for finite and four-valued logic rows', () => {
+    const quaternary = readmeTableRow('| 4 |');
+    const nValued = readmeTableRow('| N |');
+
+    assert.ok(quaternary, 'README must include the quaternary valence row');
+    assert.ok(nValued, 'README must include the N-valued valence row');
+    assert.ok(
+      quaternary.includes('https://en.wikipedia.org/wiki/Four-valued_logic'),
+      'quaternary row must link four-valued logic',
+    );
+    assert.ok(
+      nValued.includes('https://en.wikipedia.org/wiki/Finite-valued_logic'),
+      'N-valued row must link finite-valued logic',
+    );
+  });
+
+  it('keeps the expanded logic references in the README bibliography', () => {
+    const readme = read('README.md');
+
+    for (const expected of [
+      '[Probabilistic logic](https://en.wikipedia.org/wiki/Probabilistic_logic)',
+      '[Finite-valued logic](https://en.wikipedia.org/wiki/Finite-valued_logic)',
+      '[Infinite-valued logic](https://en.wikipedia.org/wiki/Infinite-valued_logic)',
+    ]) {
+      assert.ok(readme.includes(expected), `README references missing ${expected}`);
+    }
+  });
+});
+
 describe('self-bootstrap tutorial documentation', () => {
   it('is linked from the README', () => {
     const readme = read('README.md');


### PR DESCRIPTION
Fixes #179.

## Summary
- Add probabilistic logic to the README supported-logic-types table for the continuous `0/∞` valence row.
- Tighten related table references for four-valued, finite-valued, and infinite-valued logic pages.
- Mirror the probabilistic mention in `docs/CONFIGURABILITY.md`.
- Add a docs regression test that fails when the README omits the probabilistic/finite/infinite/four-valued references.
- Remove the placeholder `.gitkeep` from the prepared branch.

## Reproduction
Before the README update, the new `supported logic type overview documentation` tests failed with missing probabilistic logic, four-valued logic, finite-valued logic, and bibliography references.

## Verification
- `node --test scripts/docs.test.mjs`
- `npm ci`
- `npm test`
- `cargo test --all-targets`
- `npm run test:bootstrap`
- `npm run build:playground`
- `npm run test:playground`
- `npm run docs -- --destination /tmp/rml-jsdocs`
- `cargo doc --manifest-path rust/Cargo.toml --no-deps --target-dir /tmp/rml-rustdoc`
- `node --test scripts/check-corpus-parity.test.mjs`
- `cargo build --manifest-path rust/Cargo.toml --bin rml`
- `node scripts/check-corpus-parity.mjs`
- `node scripts/lint-english.mjs --allowlist scripts/lint-english.allowlist.json examples/*.lino lib/*/*.lino`

Docker workflow was not reproduced locally because Docker is not installed in this environment (`docker: command not found`).

## References Checked
- https://en.wikipedia.org/wiki/Probabilistic_logic
- https://en.wikipedia.org/wiki/Finite-valued_logic
- https://en.wikipedia.org/wiki/Infinite-valued_logic
- https://en.wikipedia.org/wiki/Four-valued_logic
